### PR TITLE
Fix hardcoded config path to use script location

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
 from dataclasses import dataclass
 
+# Get the directory where config.py is located
+_SCRIPT_DIR = Path(os.path.dirname(os.path.abspath(__file__)))
+
 
 @dataclass
 class NotificationConfig:
@@ -28,8 +31,8 @@ class NotificationConfig:
 @dataclass
 class PathConfig:
     """Configuration for file paths and directories."""
-    script_folder: str = "/mnt/user/appdata/plexcache/"
-    logs_folder: str = "/mnt/user/appdata/plexcache/logs"
+    script_folder: str = str(_SCRIPT_DIR)
+    logs_folder: str = str(_SCRIPT_DIR / "logs")
     plex_source: str = ""
     real_source: str = ""
     cache_dir: str = ""

--- a/plexcache_app.py
+++ b/plexcache_app.py
@@ -562,11 +562,9 @@ def main():
     skip_cache = "--skip-cache" in sys.argv
     debug = "--debug" in sys.argv
 
-    # Use the script_folder from the config system
-    temp_cfg = ConfigManager("dummy")   # ConfigManager constructs PathConfig internally
-
-    # Build the correct path using the internally defined script_folder
-    config_file = str(Path(temp_cfg.paths.script_folder) / "plexcache_settings.json")
+    # Derive config path from the script's actual location (matches plexcache_setup.py behavior)
+    script_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    config_file = str(script_dir / "plexcache_settings.json")
 
     app = PlexCacheApp(config_file, skip_cache, debug)
     app.run()


### PR DESCRIPTION
## Summary

- Fixes the hardcoded default config path (`/mnt/user/appdata/plexcache/`) that ignores custom install locations
- Updates `PathConfig` defaults in `config.py` to derive paths from the script's actual location using `__file__`
- Simplifies `main()` in `plexcache_app.py` to derive the config path directly from the script location, matching `plexcache_setup.py` behavior

## Problem

When installing PlexCache-R to a custom directory, the application fails to find the settings file because the config path was hardcoded in `config.py` rather than derived from the script's location.

Running `plexcache_setup.py` creates the settings file correctly in the install directory, but `plexcache_app.py` looks for it at the hardcoded path `/mnt/user/appdata/plexcache/plexcache_settings.json`.

## Test plan

- [ ] Install PlexCache-R to a custom path (e.g., `/mnt/cache_appdata/apps/PlexCache-R/`)
- [ ] Run `python3 plexcache_setup.py` to generate config
- [ ] Run `python3 plexcache_app.py` and verify it finds the settings file in the same directory