### PR TITLE
Improve plex_api.py error logging and debug output

### DIFF
--- a/plex_api.py
+++ b/plex_api.py
@@ -385,6 +385,10 @@ class PlexManager:
 
                 for section_key in available_sections:
                     section = plex_instance.library.sectionByID(section_key)
+                    # Skip non-video sections (music, photos) - they don't support 'unwatched' filter
+                    if section.type not in ('movie', 'show'):
+                        logging.debug(f"Skipping non-video section '{section.title}' (type: {section.type})")
+                        continue
                     for video in section.search(unwatched=False):
                         if last_updated and video.lastViewedAt and video.lastViewedAt < datetime.fromtimestamp(last_updated):
                             continue


### PR DESCRIPTION
## Summary
- Handle None values in episode index comparisons (prevents "'>' not supported between instances of 'NoneType' and 'int'" errors)
- Skip non-video library sections when fetching watched media (prevents errors with music/photo libraries)
- Add exception details to warning logs for better debugging
- Add debug logging when items are skipped due to section filtering or missing metadata

## Changes

### None-safe episode index handling
Some episodes (e.g., specials or incorrectly tagged media) may have `None` for `parentIndex` or `index`. This caused comparison errors when fetching next episodes. Now:
- `_process_episode_ondeck` skips next episode fetch if current video has missing index data (logs a warning)
- `_get_next_episodes` skips episodes with missing index data instead of crashing (logs debug message)

### Skip non-video library sections
Music and photo libraries don't support the `unwatched` filter, causing errors like:
```
ERROR - Error fetching watched media for Brandon: Unknown filter field "unwatched" for libtype "artist"
```
Now skips sections that aren't 'movie' or 'show' type.

### Improved exception logging
Generic `except Exception` blocks now capture and log the actual exception, making it easier to debug issues with token retrieval and user switching.

### Debug logging for filtered items
When items are skipped (wrong section, missing metadata), debug logs show why.

## Test plan
- [x] Run with `--debug` flag to verify new debug logs appear when items are filtered
- [x] Check logs show exception details when token/user errors occur
- [x] Test with shows that may have specials or episodes with missing metadata
- [x] Verify no errors occur when music libraries are present