### PR TITLE
Improve plexcache_setup.py error handling and validation

### DIFF
--- a/plexcache_setup.py
+++ b/plexcache_setup.py
@@ -447,7 +447,7 @@ def setup():
 
     # ---------------- Cache / Array Paths ----------------
     if 'cache_dir' not in settings_data:
-        cache_dir = input('\nInsert the path of your cache drive: (default: "/mnt/cache/media") ').replace('"', '').replace("'", '') or '/mnt/cache/media'
+        cache_dir = input('\nInsert the path of your cache drive: (default: "/mnt/cache") ').replace('"', '').replace("'", '') or '/mnt/cache'
         while True:
             test_path = input('\nDo you want to test the given path? [y/N]  ') or 'no'
             if test_path.lower() in ['y', 'yes']:
@@ -458,7 +458,7 @@ def setup():
                     print('The path appears to be invalid.')
                     edit_path = input('\nDo you want to edit the path? [y/N]  ') or 'no'
                     if edit_path.lower() in ['y', 'yes']:
-                        cache_dir = input('\nInsert the path of your cache drive: (default: "/mnt/cache/media") ').replace('"', '').replace("'", '') or '/mnt/cache/media'
+                        cache_dir = input('\nInsert the path of your cache drive: (default: "/mnt/cache") ').replace('"', '').replace("'", '') or '/mnt/cache'
                     elif edit_path.lower() in ['n', 'no']:
                         break
                     else:
@@ -473,7 +473,7 @@ def setup():
         settings_data['cache_dir'] = cache_dir
 
     if 'real_source' not in settings_data:
-        real_source = input('\nInsert the path where your media folders are located?: (default: "/mnt/user/media") ').replace('"', '').replace("'", '') or '/mnt/user/media'
+        real_source = input('\nInsert the path where your media folders are located?: (default: "/mnt/user") ').replace('"', '').replace("'", '') or '/mnt/user'
         while True:
             test_path = input('\nDo you want to test the given path? [y/N]  ') or 'no'
             if test_path.lower() in ['y', 'yes']:
@@ -484,7 +484,7 @@ def setup():
                     print('The path appears to be invalid.')
                     edit_path = input('\nDo you want to edit the path? [y/N]  ') or 'no'
                     if edit_path.lower() in ['y', 'yes']:
-                        real_source = input('\nInsert the path where your media folders are located?: (default: "/mnt/user/media") ').replace('"', '').replace("'", '') or '/mnt/user/media'
+                        real_source = input('\nInsert the path where your media folders are located?: (default: "/mnt/user") ').replace('"', '').replace("'", '') or '/mnt/user'
                     elif edit_path.lower() in ['n', 'no']:
                         break
                     else:


### PR DESCRIPTION
## Summary

Improves error handling, input validation, and user feedback in the setup script.

## Changes

| Issue | Fix |
|-------|-----|
| Relative script path | Use `os.path.dirname(os.path.abspath(__file__))` instead of `"."` |
| File read/write errors | Add try/except with error messages and UTF-8 encoding |
| Number validation | Use try/except with ValueError instead of `isdigit()`, reject negative numbers |
| Duplicate section IDs | Check if `library.key` already in list before appending |
| Silent exceptions | Add `as e` and include error details in all exception handlers |
| Token errors | Wrap `user.get_token()` in try/except to handle failures gracefully |
| Misleading JSON error | Change "initialized successfully" to "corrupted, re-initializing" |
| Invalid file creation choice | Loop until valid input instead of printing and exiting |
| Misleading "file created" message | Changed to "Starting setup..." since file isn't written until end |
| **plex_source set to "/" (Issue #12)** | Compute plex_source from only selected libraries, not all libraries. Add warning and manual override if plex_source resolves to "/" |
| **Auto-detect Plex token (Unraid)** | On Unraid, offer to auto-detect token from Plex's Preferences.xml. Uses optimized search (~3-6 seconds) |

## Test plan

- [x] Run setup from a different working directory to verify absolute path works
- [x] Enter invalid numbers (negative, text) to verify improved validation
- [x] Corrupt settings JSON and re-run to verify new error message
- [x] Enter invalid choice for file creation prompt to verify it loops
- [x] Test with Plex libraries that have different base paths (e.g., /data and /music) to verify plex_source is computed correctly from selected libraries only
- [x] If plex_source still resolves to "/", verify warning is shown and manual override works
- [x] On Unraid: test auto-detect token feature (should find Preferences.xml and extract token)
- [x] On Unraid: decline auto-detect and verify manual entry still works
- [x] On non-Unraid: verify auto-detect prompt doesn't appear