### PR TITLE
Fix movies and shows not being removed from cache

### DIFF
--- a/file_operations.py
+++ b/file_operations.py
@@ -262,9 +262,7 @@ class FileFilter:
             filename = os.path.basename(file_path)
             name, _ext = os.path.splitext(filename)
 
-            # Remove trailing parentheses blocks like:
-            # (Bluray-1080p x265), (WEBDL-2160p), (whatever)
-            # but keep parentheses that are part of the real title (e.g. "Babe (1995)")
+            # Remove trailing parentheses blocks
             cleaned = re.sub(r'\s*\([^)]*\)$', '', name).strip()
 
             return cleaned


### PR DESCRIPTION
Same as your PR - 

Fixes #21 - Movies were not being removed from cache when removed from watchlist.
ADDITIONAL - Fixes tv shows not being removed from cache when removed from watchlist.

**Root Cause: (for movies)** The `_extract_show_name()` function only worked for TV shows (it looks for `Season X`, `Series X`, or `Specials` folders). For movies, there's no such folder, so the function returned `None` and the movie was silently skipped in the "move back to array" logic.

**Root Cause: (for TV)** The watchlist logic was looking for the main title of the tv show from the folder name, but the cache file lists individual episodes, so I guess it wasn't enough to find a match (or it equally matched multiple files as it was too generic a search) and so didn't function. 

**The Fix: (for movies)**
- Rename `_extract_show_name()` to `_extract_media_name()`
- Add fallback logic for movies: if no Season/Series/Specials folder is found, return the parent folder of the file (e.g., `Argo (2012)`)
- Update variable names from `show` to `media` for clarity
- Add warning log when media name cannot be extracted

ADDITIONAL - For TV
- Simplified the logic to just grab the file name, with some cleaning and normalisation, so it more closesly and consistently matches what's written in the exclude file. 


## Test plan

- [x] Add a movie to watchlist, run script, verify movie is cached
- [x] Remove movie from watchlist, run script, verify movie is moved back to array
- [x] Verify TV shows still work correctly by doing the same thing