### PR TITLE
Fix migration path conversion for multi-path mode

### DIFF
--- a/plexcache_app.py
+++ b/plexcache_app.py
@@ -323,7 +323,8 @@ class PlexCacheApp:
             cache_dir=self.config_manager.paths.cache_dir,
             real_source=self.config_manager.paths.real_source,
             script_folder=self.config_manager.paths.script_folder,
-            is_unraid=self.system_detector.is_unraid
+            is_unraid=self.system_detector.is_unraid,
+            path_modifier=self.file_path_modifier
         )
         if migration.needs_migration():
             logging.info("Running one-time migration for .plexcached backups...")


### PR DESCRIPTION
## Summary
- Migration now uses path_mappings via `MultiPathModifier.convert_cache_to_real()` for accurate cache→array path conversion
- Fixes issue where `real_source` was empty in multi-path mode, causing path conversion to fail and migration to attempt unnecessary file copies (600GB+ in my case)
- Falls back to legacy `cache_dir`/`real_source` for non-multi-path setups
- Correctly detects existing `.plexcached` backups on Unraid via `/mnt/user0/`

## Problem
In multi-path mode, the migration was using the legacy `real_source` field which is empty. This caused:
- Path conversion to fail silently
- Migration to not find existing `.plexcached` backups
- Unnecessary attempts to copy hundreds of GB of files that already had backups

## Test plan
- [x] Tested on Unraid with multi-path configuration
- [x] Verified migration correctly detects all 196 existing `.plexcached` backups
- [x] Migration completes instantly with "All files already have backups, no migration needed"