### PR TITLE
Fix skip_watchlist not working for remote users (RSS)

### DIFF
--- a/plex_api.py
+++ b/plex_api.py
@@ -972,7 +972,7 @@ class PlexManager:
 
         # --- RSS feed processing ---
         if rss_url:
-            yield from self._process_rss_watchlist(rss_url, current_username, filtered_sections, watchlist_episodes)
+            yield from self._process_rss_watchlist(rss_url, current_username, filtered_sections, watchlist_episodes, skip_watchlist)
             return
 
         # --- Local Plex watchlist processing ---
@@ -1005,8 +1005,13 @@ class PlexManager:
             self.mark_watchlist_incomplete()
 
     def _process_rss_watchlist(self, rss_url: str, current_username: str,
-                                filtered_sections: List[int], watchlist_episodes: int) -> Generator[Tuple[str, str, Optional[datetime]], None, None]:
-        """Process RSS feed items and yield matching media files."""
+                                filtered_sections: List[int], watchlist_episodes: int,
+                                skip_watchlist: List[str] = None) -> Generator[Tuple[str, str, Optional[datetime]], None, None]:
+        """Process RSS feed items and yield matching media files.
+
+        Args:
+            skip_watchlist: List of usernames to skip (filters RSS items by who added them)
+        """
         rss_items = self._fetch_rss_titles(rss_url)
         logging.debug(f"RSS feed contains {len(rss_items)} items")
         unknown_user_ids = set()
@@ -1025,6 +1030,11 @@ class PlexManager:
                     unknown_user_ids.add(author_id)
             else:
                 rss_username = "Friends (RSS)"
+
+            # Skip items from users in the skip list (fixes issue #51)
+            if skip_watchlist and rss_username in skip_watchlist:
+                logging.debug(f"RSS: Skipping '{title}' — added by {rss_username} (in skip list)")
+                continue
 
             cleaned_title = self.clean_rss_title(title)
             file = self.search_plex(cleaned_title, guid=guid, expected_type=category,


### PR DESCRIPTION
## Summary
- Adds `skip_watchlist` parameter to `_process_rss_watchlist()` method
- Passes `skip_watchlist` from caller to RSS processing
- Filters out RSS items from users in the skip list

Previously, `skip_watchlist` was only checked for local users but not applied to RSS feed processing for remote users. This fix ensures the setting works consistently for both local and remote users.

## Test plan
- [x] Configure a remote user with `"skip_watchlist": true` in settings
- [x] Run with `--verbose --dry-run` and verify RSS items from that user are skipped
- [x] Confirm local user skip_watchlist still works as before

Fixes #51