### PR TITLE
Fix summary notification appearing when unraid_level is 'warning'

### DIFF
--- a/plexcache_app.py
+++ b/plexcache_app.py
@@ -14,7 +14,7 @@ from typing import List, Set, Optional, Tuple
 import os
 
 from config import ConfigManager
-from logging_config import LoggingManager
+from logging_config import LoggingManager, reset_warning_error_flag
 from system_utils import SystemDetector, FileUtils, SingleInstanceLock
 from plex_api import PlexManager, OnDeckItem
 from file_operations import MultiPathModifier, SubtitleFinder, FileFilter, FileMover, CacheCleanup, PlexcachedRestorer, CacheTimestampTracker, WatchlistTracker, OnDeckTracker, CachePriorityManager, PlexcachedMigration
@@ -63,6 +63,8 @@ class PlexCacheApp:
         try:
             # Setup logging first before any log messages
             self._setup_logging()
+            # Reset warning/error tracking for conditional summary notifications
+            reset_warning_error_flag()
             if self.dry_run:
                 logging.warning("DRY-RUN MODE - No files will be moved")
             if self.verbose:


### PR DESCRIPTION
## Summary
Fixes #61 - Summary popup appears when `unraid_level` is set to "warning" even when there are no warnings/errors

## Problem
When notification level is "warning", users expect to only be notified when there are actual warnings/errors. Currently, the SUMMARY notification appears on every run because `SUMMARY` level (31) is above `WARNING` level (30), so it passes through the level filter.

From the setup text:
> "warning - Only notify on warnings and errors"

Users expect no notification on successful runs.

## Solution
Added conditional summary logic that tracks whether warnings/errors occurred during the run:

| Level | Summary Shows When |
|-------|-------------------|
| `summary` | Every run (current behavior) |
| `warning` | Only if warnings/errors occurred |
| `error` | Only if errors occurred |

When a warning/error does occur, the summary is included to provide context.

## Changes

**logging_config.py:**
- Added `_had_warnings_or_errors` flag to track if warnings/errors occurred
- Added helper functions: `reset_warning_error_flag()`, `mark_warning_or_error()`, `had_warnings_or_errors()`
- Modified `UnraidHandler.emit()` to track warnings/errors and conditionally emit summary
- Modified `WebhookHandler.emit()` with the same logic

**plexcache_app.py:**
- Import and call `reset_warning_error_flag()` at the start of each run