### PR TITLE
Fix summary notification level conditional logic

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -161,13 +161,13 @@ class UnraidHandler(logging.Handler):
                 # - Level is WARNING (30): Show summary if warnings OR errors occurred
                 # - Level is ERROR (40): Show summary ONLY if errors occurred
                 should_send = False
-                if self.level <= SUMMARY:
-                    # Handler level is "summary" - always send
+                if self.level == SUMMARY:
+                    # Handler level is exactly "summary" - always send
                     should_send = True
-                elif self.level <= logging.WARNING:
+                elif self.level == logging.WARNING:
                     # Handler level is "warning" - send if any warnings or errors
                     should_send = had_warnings_or_errors()
-                elif self.level <= logging.ERROR:
+                elif self.level == logging.ERROR:
                     # Handler level is "error" - only send if actual errors occurred
                     should_send = had_errors()
 
@@ -222,13 +222,13 @@ class WebhookHandler(logging.Handler):
             # - Level is WARNING (30): Show summary if warnings OR errors occurred
             # - Level is ERROR (40): Show summary ONLY if errors occurred
             should_send = False
-            if self.level <= SUMMARY:
-                # Handler level is "summary" - always send
+            if self.level == SUMMARY:
+                # Handler level is exactly "summary" - always send
                 should_send = True
-            elif self.level <= logging.WARNING:
+            elif self.level == logging.WARNING:
                 # Handler level is "warning" - send if any warnings or errors
                 should_send = had_warnings_or_errors()
-            elif self.level <= logging.ERROR:
+            elif self.level == logging.ERROR:
                 # Handler level is "error" - only send if actual errors occurred
                 should_send = had_errors()
 


### PR DESCRIPTION
## Summary
- Fix notification level comparison using `==` instead of `<=` to properly respect user's notification level setting
- When `unraid_level` or `webhook_level` is set to "warning", summaries are now only sent when warnings or errors actually occur
- When set to "error", summaries are only sent when errors occur
- When set to "summary", summaries are always sent (existing behavior)

## Problem
The previous code used `<=` for level comparison:
```python
if self.level <= SUMMARY:  # 30 <= 31 = TRUE for WARNING level!
    should_send = True
```

This meant that when the level was set to "warning" (30), the check `30 <= 31` was always TRUE, causing summaries to be sent regardless of whether any warnings/errors occurred.

## Fix
Changed to exact equality matching:
```python
if self.level == SUMMARY:
    should_send = True
elif self.level == logging.WARNING:
    should_send = had_warnings_or_errors()
elif self.level == logging.ERROR:
    should_send = had_errors()
```

## Testing
Tested by user with `unraid_level: "warning"`:
- Clean run with no warnings/errors → No summary notification sent
- Run with connection error → Summary notification sent

Fixes the conditional notification behavior for both UnraidHandler and WebhookHandler.