### PR TITLE
Fix Docker template URLs pointing to removed v3.0 branch

### DIFF
--- a/docker/UNRAID_SETUP.md
+++ b/docker/UNRAID_SETUP.md
@@ -27,7 +27,7 @@ PlexCache-D automatically caches your frequently-accessed Plex media (OnDeck and
 
 ### Option 2: Docker Template (Quick Install)
 
-1. Download [plexcache-d.xml](https://raw.githubusercontent.com/StudioNirin/PlexCache-D/v3.0/docker/plexcache-d.xml) (will move to StudioNirin repo after upstream merge)
+1. Download [plexcache-d.xml](https://raw.githubusercontent.com/StudioNirin/PlexCache-D/main/docker/plexcache-d.xml)
 2. Place it in `/boot/config/plugins/dockerMan/templates-user/` on your Unraid server
 3. Go to **Docker** → **Add Container** → Select "plexcache-d" from the template dropdown
 4. Adjust paths for your setup and click **Apply**

--- a/docker/plexcache-d.xml
+++ b/docker/plexcache-d.xml
@@ -26,8 +26,8 @@ If using CA Mover Tuning plugin, set the exclude file path to:
     </Overview>
     <Category>MediaServer:Other Tools:</Category>
     <WebUI>http://[IP]:[PORT:5757]</WebUI>
-    <TemplateURL>https://raw.githubusercontent.com/StudioNirin/PlexCache-D/v3.0/docker/plexcache-d.xml</TemplateURL>
-    <Icon>https://raw.githubusercontent.com/StudioNirin/PlexCache-D/v3.0/docker/icon.png</Icon>
+    <TemplateURL>https://raw.githubusercontent.com/StudioNirin/PlexCache-D/main/docker/plexcache-d.xml</TemplateURL>
+    <Icon>https://raw.githubusercontent.com/StudioNirin/PlexCache-D/main/docker/icon.png</Icon>
     <ExtraParams/>
     <PostArgs/>
     <CPUset/>


### PR DESCRIPTION
## Summary
- Update `TemplateURL` and `Icon` in `plexcache-d.xml` from `v3.0` to `main` branch
- Update download link in `UNRAID_SETUP.md` from `v3.0` to `main`

Refs #93