### PR TITLE
Fix stale audit entries for .m2ts and consolidate media extensions

### DIFF
--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -27,8 +27,20 @@ PLEXCACHED_EXTENSION = ".plexcached"
 # Minimum free space (in bytes) required for metadata operations during rename
 MINIMUM_SPACE_FOR_RENAME = 100 * 1024 * 1024  # 100 MB
 
-# Subtitle file extensions (excluded from cross-type upgrade detection)
-SUBTITLE_EXTENSIONS = {'.srt', '.sub', '.ass', '.ssa', '.vtt', '.idx', '.sbv'}
+# --- Canonical media extension definitions (single source of truth) ---
+# All other modules should import these instead of defining their own.
+
+# Video file extensions
+VIDEO_EXTENSIONS = {
+    '.mkv', '.mp4', '.avi', '.m4v', '.mov', '.wmv', '.flv', '.ts', '.m2ts',
+    '.mpg', '.mpeg', '.webm', '.ogv', '.3gp', '.divx', '.vob',
+}
+
+# Subtitle file extensions
+SUBTITLE_EXTENSIONS = {'.srt', '.sub', '.ass', '.ssa', '.vtt', '.idx', '.sbv', '.sup', '.smi'}
+
+# Combined media extensions (video + subtitle)
+MEDIA_EXTENSIONS = VIDEO_EXTENSIONS | SUBTITLE_EXTENSIONS
 
 
 def save_json_atomically(filepath: str, data, label: str = "data") -> None:
@@ -825,8 +837,7 @@ class CacheTimestampTracker:
             filename = filename[:match.start()]
 
         # Try common video extensions
-        video_extensions = ['.mkv', '.mp4', '.avi', '.m4v', '.wmv', '.flv', '.mov', '.ts']
-        for vext in video_extensions:
+        for vext in VIDEO_EXTENSIONS:
             candidate = os.path.join(directory, filename + vext)
             if os.path.exists(candidate):
                 return candidate
@@ -2594,7 +2605,7 @@ class SubtitleFinder:
     
     def __init__(self, subtitle_extensions: Optional[List[str]] = None):
         if subtitle_extensions is None:
-            subtitle_extensions = [".srt", ".vtt", ".sbv", ".sub", ".idx"]
+            subtitle_extensions = sorted(SUBTITLE_EXTENSIONS)
         self.subtitle_extensions = subtitle_extensions
     
     def get_media_subtitles_grouped(self, media_files: List[str], files_to_skip: Optional[Set[str]] = None) -> Dict[str, List[str]]:
@@ -3407,8 +3418,7 @@ class FileFilter:
             name, ext = os.path.splitext(filename)
 
             # Handle subtitle files - strip language code suffixes (e.g., ".en", ".eng", ".en.hi", ".forced")
-            subtitle_extensions = {'.srt', '.sub', '.ass', '.ssa', '.vtt', '.idx'}
-            if ext.lower() in subtitle_extensions:
+            if ext.lower() in SUBTITLE_EXTENSIONS:
                 # Strip common language code patterns from the end (loop for multiple suffixes like ".en.hi")
                 pattern = r'\.(en|eng|es|spa|fr|fra|de|deu|ger|it|ita|pt|por|ja|jpn|ko|kor|zh|chi|forced|sdh|cc|hi)$'
                 prev_name = None

--- a/tools/audit_cache.py
+++ b/tools/audit_cache.py
@@ -18,6 +18,7 @@ if PROJECT_ROOT_INIT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT_INIT)
 
 from core.system_utils import get_array_direct_path
+from core.file_operations import VIDEO_EXTENSIONS, SUBTITLE_EXTENSIONS, MEDIA_EXTENSIONS
 
 # Get script directory and resolve project root
 # If we're in tools/, go up one level to project root
@@ -135,11 +136,7 @@ load_settings()
 def get_cache_files():
     """Get all media files currently on cache."""
     cache_files = set()
-    # Video extensions
-    video_ext = ('.mkv', '.mp4', '.avi', '.m4v', '.mov', '.wmv', '.ts')
-    # Subtitle extensions
-    subtitle_ext = ('.srt', '.sub', '.idx', '.ass', '.ssa', '.vtt', '.smi')
-    extensions = video_ext + subtitle_ext
+    extensions = tuple(MEDIA_EXTENSIONS)
 
     for cache_dir in CACHE_DIRS:
         if os.path.exists(cache_dir):
@@ -803,12 +800,7 @@ def find_malformed_plexcached():
     """
     # Settings already loaded on module import
 
-    # Valid media extensions (video + subtitle)
-    MEDIA_EXTENSIONS = {
-        '.mkv', '.mp4', '.avi', '.m4v', '.mov', '.wmv', '.ts', '.m2ts',
-        '.webm', '.flv', '.mpg', '.mpeg', '.divx', '.xvid', '.3gp', '.ogv',
-        '.srt', '.sub', '.ass', '.ssa', '.vtt', '.idx'
-    }
+    # MEDIA_EXTENSIONS imported from core.file_operations
 
     print("\n" + "=" * 80)
     print("SCANNING FOR MALFORMED .plexcached FILES")

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -12,11 +12,7 @@ from dataclasses import dataclass
 
 from web.config import PROJECT_ROOT, DATA_DIR, CONFIG_DIR, SETTINGS_FILE
 from core.system_utils import get_disk_usage, detect_zfs, get_array_direct_path, parse_size_bytes, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file
-from core.file_operations import get_media_identity, find_matching_plexcached, save_json_atomically
-
-
-# Subtitle file extensions (case-insensitive)
-SUBTITLE_EXTENSIONS = {'.srt', '.ass', '.sub', '.idx', '.vtt', '.ssa', '.sup', '.smi'}
+from core.file_operations import get_media_identity, find_matching_plexcached, save_json_atomically, SUBTITLE_EXTENSIONS
 
 
 @dataclass

--- a/web/services/maintenance_service.py
+++ b/web/services/maintenance_service.py
@@ -14,13 +14,7 @@ from typing import Callable, Dict, List, Optional, Set, Any, Tuple
 
 from web.config import PROJECT_ROOT, DATA_DIR, CONFIG_DIR, SETTINGS_FILE
 from core.system_utils import get_array_direct_path, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file
-from core.file_operations import PLEXCACHED_EXTENSION
-
-# Common media extensions for validation
-_MEDIA_EXTENSIONS = {
-    '.mkv', '.mp4', '.avi', '.mov', '.wmv', '.flv', '.m4v', '.ts',
-    '.mpg', '.mpeg', '.webm', '.ogv', '.3gp', '.divx', '.vob',
-}
+from core.file_operations import PLEXCACHED_EXTENSION, VIDEO_EXTENSIONS, SUBTITLE_EXTENSIONS, MEDIA_EXTENSIONS
 
 
 def _strip_plexcached(path: str) -> str:
@@ -34,7 +28,7 @@ def _strip_plexcached(path: str) -> str:
         raise ValueError(f"Not a .plexcached file: {path}")
     original = path[:-len(PLEXCACHED_EXTENSION)]
     _, ext = os.path.splitext(original)
-    if ext.lower() not in _MEDIA_EXTENSIONS:
+    if ext.lower() not in VIDEO_EXTENSIONS:
         raise ValueError(
             f"Malformed .plexcached file (no media extension): {os.path.basename(path)}"
         )
@@ -184,10 +178,6 @@ class _ByteProgressAggregator:
 class MaintenanceService:
     """Service for cache auditing and maintenance actions"""
 
-    # Video extensions
-    VIDEO_EXTENSIONS = ('.mkv', '.mp4', '.avi', '.m4v', '.mov', '.wmv', '.ts')
-    # Subtitle extensions
-    SUBTITLE_EXTENSIONS = ('.srt', '.sub', '.idx', '.ass', '.ssa', '.vtt', '.smi')
     # Chunk size for copy progress reporting (4 MB)
     _COPY_CHUNK_SIZE = 4 * 1024 * 1024
 
@@ -413,7 +403,7 @@ class MaintenanceService:
         """Get all media files currently on cache"""
         cache_dirs, _ = self._get_paths()
         cache_files = set()
-        extensions = self.VIDEO_EXTENSIONS + self.SUBTITLE_EXTENSIONS
+        extensions = tuple(MEDIA_EXTENSIONS)
 
         def _walk_error(err):
             logging.warning(f"Permission error scanning directory: {err}")
@@ -654,7 +644,7 @@ class MaintenanceService:
                             # lives on cache while the malformed .plexcached is on the array.
                             stem = f[:-len(PLEXCACHED_EXTENSION)]  # strip .plexcached
                             repair_ext = None
-                            for ext in _MEDIA_EXTENSIONS:
+                            for ext in VIDEO_EXTENSIONS:
                                 # Check array sibling first
                                 if (stem + ext) in file_set:
                                     repair_ext = ext
@@ -768,8 +758,8 @@ class MaintenanceService:
                         # Check for extensionless files with matching media siblings
                         # (created by malformed .plexcached restores that stripped the extension)
                         _, ext = os.path.splitext(f)
-                        if ext.lower() not in _MEDIA_EXTENSIONS:
-                            for media_ext in _MEDIA_EXTENSIONS:
+                        if ext.lower() not in VIDEO_EXTENSIONS:
+                            for media_ext in VIDEO_EXTENSIONS:
                                 sibling_name = f + media_ext
                                 if sibling_name in file_set:
                                     file_path = os.path.join(root, f)
@@ -1163,13 +1153,13 @@ class MaintenanceService:
             _, ext = os.path.splitext(filename)
 
             # Safety check 1: Must not have a media extension
-            if ext.lower() in _MEDIA_EXTENSIONS:
+            if ext.lower() in VIDEO_EXTENSIONS:
                 errors.append(f"{filename}: Has media extension, refusing to delete")
                 continue
 
             # Safety check 2: Must have a matching media sibling
             has_sibling = False
-            for media_ext in _MEDIA_EXTENSIONS:
+            for media_ext in VIDEO_EXTENSIONS:
                 if os.path.exists(file_path + media_ext):
                     has_sibling = True
                     break


### PR DESCRIPTION
## Summary
- Consolidates `VIDEO_EXTENSIONS`, `SUBTITLE_EXTENSIONS`, and `MEDIA_EXTENSIONS` into a single source of truth in `core/file_operations.py`
- Adds `.m2ts` (Blu-ray) and other missing video formats (`.mpg`, `.mpeg`, `.webm`, `.ogv`, `.3gp`, `.divx`, `.vob`)
- Removes ~10 duplicate extension definitions across 4 files

## Problem
Reported in [Discussion #50](https://github.com/StudioNirin/PlexCache-D/discussions/50#discussioncomment-15978653): `.m2ts` files (Blu-ray rips) appear as perpetually "stale" in the Maintenance audit. The main caching engine recognizes and caches `.m2ts` files correctly, but the maintenance audit scanner had a separate `VIDEO_EXTENSIONS` list that was missing `.m2ts`. This caused a cycle: cache engine adds file → audit doesn't recognize it → shows as stale → user clears → next run adds it back.

## Fix
Rather than just adding `.m2ts` to yet another extension list, all extension definitions are consolidated into `core/file_operations.py` as the single source of truth. Every other module now imports from there, eliminating the class of bugs where formats are recognized in one place but not another.

## Files changed
- `core/file_operations.py` — canonical extension sets + replaced 3 local duplicates
- `web/services/maintenance_service.py` — removed local `VIDEO_EXTENSIONS`/`SUBTITLE_EXTENSIONS`/`_MEDIA_EXTENSIONS`, imports from core
- `web/services/cache_service.py` — removed local `SUBTITLE_EXTENSIONS`, imports from core
- `tools/audit_cache.py` — removed local `video_ext`/`subtitle_ext`/`MEDIA_EXTENSIONS`, imports from core

## Test plan
- [x] Verify `.m2ts` files no longer appear as stale in Maintenance audit
- [x] Verify caching/eviction still works for all media formats
- [x] Run existing test suite (654 tests pass)