### PR TITLE
Fix dashboard 500 error from shadowed re import

### DIFF
--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -707,7 +707,6 @@ class CacheService:
                         percent_val = int(limit_str.rstrip("%"))
                         cache_limit_bytes = int(disk_total * percent_val / 100)
                     else:
-                        import re
                         match = re.match(r'^([\d.]+)\s*(T|TB|G|GB|M|MB)?$', limit_str, re.IGNORECASE)
                         if match:
                             value = float(match.group(1))
@@ -745,8 +744,7 @@ class CacheService:
                     percent_val = int(limit_str.rstrip('%'))
                     min_free_bytes = int(disk_total * percent_val / 100)
                 else:
-                    import re as _re
-                    match = _re.match(r'^([\d.]+)\s*(T|TB|G|GB|M|MB)?$', limit_str, _re.IGNORECASE)
+                    match = re.match(r'^([\d.]+)\s*(T|TB|G|GB|M|MB)?$', limit_str, re.IGNORECASE)
                     if match:
                         value = float(match.group(1))
                         unit = (match.group(2) or "GB").upper()
@@ -1337,7 +1335,6 @@ class CacheService:
         Returns dict with files that would be evicted and space freed.
         """
         import shutil
-        import re
 
         settings = self._load_settings()
         cache_dir = self._get_cache_dir(settings)


### PR DESCRIPTION
## Summary
- Conditional `import re` inside `get_cache_stats()` caused Python to treat `re` as a local variable for the entire function scope
- When `cache_limit` was unset (or percentage-based) but `plexcache_quota` was configured with an absolute value, the local import never executed — producing `UnboundLocalError: cannot access local variable 're'`
- Removed redundant local imports; the module-level `import re` already covers all usage

## Root Cause
Python determines variable scope at **compile time**. Any `import re` inside a function makes `re` local to the entire function, shadowing the module-level import. If the branch containing the import doesn't execute at runtime, the local `re` is never bound.

## Test plan
- [ ] Verify dashboard loads with `plexcache_quota` set to an absolute value (e.g. `500GB`) and `cache_limit` empty
- [x] Verify dashboard loads with both settings empty
- [x] Verify dashboard loads with both settings configured

Fixes #102