### PR TITLE
Fix multi-user eviction retaining gap episodes (#107)

### DIFF
--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -3101,21 +3101,26 @@ class FileFilter:
         return cache_path, cache_file_name
 
     def _build_needed_media_sets(self, current_ondeck_items: Set[str],
-                                  current_watchlist_items: Set[str]) -> Tuple[Dict[str, Dict[int, int]], Set[str]]:
+                                  current_watchlist_items: Set[str]) -> Tuple[Dict[str, Dict[int, Set[int]]], Set[str]]:
         """Build tracking sets of media that should be kept in cache.
 
         Uses Plex API metadata when available (from OnDeckTracker, media_info_map, or
         CacheTimestampTracker), falling back to regex path parsing for legacy entries.
+
+        Tracks the exact set of needed episodes per show/season rather than a minimum
+        episode number. This correctly handles multiple users at different watch positions
+        (e.g., User 1 at E20, User 2 at E01) by keeping only the episodes each user
+        actually needs, not the entire range between them.
 
         Args:
             current_ondeck_items: Set of OnDeck file paths.
             current_watchlist_items: Set of watchlist file paths.
 
         Returns:
-            Tuple of (tv_show_min_episodes dict, needed_movies set).
-            tv_show_min_episodes maps show_name -> {season: min_episode_to_keep}
+            Tuple of (tv_show_needed_episodes dict, needed_movies set).
+            tv_show_needed_episodes maps show_name -> {season: set of episode numbers}
         """
-        tv_show_min_episodes: Dict[str, Dict[int, int]] = {}
+        tv_show_needed_episodes: Dict[str, Dict[int, Set[int]]] = {}
         needed_movies: Set[str] = set()
 
         for item in current_ondeck_items | current_watchlist_items:
@@ -3128,14 +3133,11 @@ class FileFilter:
                     season_num = ep_info.get("season")
                     episode_num = ep_info.get("episode")
                     if show_name and season_num is not None and episode_num is not None:
-                        if show_name not in tv_show_min_episodes:
-                            tv_show_min_episodes[show_name] = {}
-                        if season_num not in tv_show_min_episodes[show_name]:
-                            tv_show_min_episodes[show_name][season_num] = episode_num
-                        else:
-                            tv_show_min_episodes[show_name][season_num] = min(
-                                tv_show_min_episodes[show_name][season_num], episode_num
-                            )
+                        if show_name not in tv_show_needed_episodes:
+                            tv_show_needed_episodes[show_name] = {}
+                        if season_num not in tv_show_needed_episodes[show_name]:
+                            tv_show_needed_episodes[show_name][season_num] = set()
+                        tv_show_needed_episodes[show_name][season_num].add(episode_num)
                         continue
                 if media_type == "movie":
                     media_name = self._extract_media_name(item)
@@ -3147,58 +3149,51 @@ class FileFilter:
             tv_info = self._extract_tv_info(item)
             if tv_info:
                 show_name, season_num, episode_num = tv_info
-                if show_name not in tv_show_min_episodes:
-                    tv_show_min_episodes[show_name] = {}
-                if season_num not in tv_show_min_episodes[show_name]:
-                    tv_show_min_episodes[show_name][season_num] = episode_num
-                else:
-                    tv_show_min_episodes[show_name][season_num] = min(
-                        tv_show_min_episodes[show_name][season_num], episode_num
-                    )
+                if show_name not in tv_show_needed_episodes:
+                    tv_show_needed_episodes[show_name] = {}
+                if season_num not in tv_show_needed_episodes[show_name]:
+                    tv_show_needed_episodes[show_name][season_num] = set()
+                tv_show_needed_episodes[show_name][season_num].add(episode_num)
             else:
                 media_name = self._extract_media_name(item)
                 if media_name:
                     needed_movies.add(media_name)
 
-        logging.debug(f"TV shows on deck/watchlist: {list(tv_show_min_episodes.keys())}")
+        logging.debug(f"TV shows on deck/watchlist: {list(tv_show_needed_episodes.keys())}")
         logging.debug(f"Movies on deck/watchlist: {len(needed_movies)}")
-        return tv_show_min_episodes, needed_movies
+        return tv_show_needed_episodes, needed_movies
 
     def _is_tv_episode_still_needed(self, show_name: str, season_num: int, episode_num: int,
-                                     tv_show_min_episodes: Dict[str, Dict[int, int]]) -> bool:
-        """Check if a TV episode should be kept in cache based on OnDeck position.
+                                     tv_show_needed_episodes: Dict[str, Dict[int, Set[int]]]) -> bool:
+        """Check if a TV episode should be kept in cache based on OnDeck/watchlist sets.
+
+        An episode is kept only if it appears in the exact set of needed episodes
+        (built from all users' OnDeck + prefetch windows). This correctly handles
+        multiple users at different watch positions without retaining the gap between them.
 
         Args:
             show_name: Name of the TV show.
             season_num: Season number of the episode.
             episode_num: Episode number.
-            tv_show_min_episodes: Dict of show -> {season: min_episode}.
+            tv_show_needed_episodes: Dict of show -> {season: set of episode numbers}.
 
         Returns:
             True if episode should be kept, False if it can be moved back.
         """
-        if show_name not in tv_show_min_episodes:
+        if show_name not in tv_show_needed_episodes:
             return False  # Show not on deck/watchlist
 
-        min_ondeck_season = min(tv_show_min_episodes[show_name].keys())
-
-        if season_num < min_ondeck_season:
-            # Previous season - user has moved past this
-            logging.debug(f"TV episode in previous season (S{season_num:02d} < S{min_ondeck_season:02d}): {show_name}")
+        if season_num not in tv_show_needed_episodes[show_name]:
+            logging.debug(f"TV episode in unneeded season (S{season_num:02d}): {show_name}")
             return False
-        elif season_num > min_ondeck_season:
-            # Future season - keep (user may have pre-cached ahead)
-            logging.debug(f"TV episode in future season, keeping: {show_name} S{season_num:02d}E{episode_num:02d}")
+
+        needed_episodes = tv_show_needed_episodes[show_name][season_num]
+        if episode_num in needed_episodes:
+            logging.debug(f"TV episode still needed (S{season_num:02d}E{episode_num:02d}): {show_name}")
             return True
         else:
-            # Same season - check episode number
-            min_episode = tv_show_min_episodes[show_name][season_num]
-            if episode_num >= min_episode:
-                logging.debug(f"TV episode still needed (E{episode_num:02d} >= E{min_episode:02d}): {show_name}")
-                return True
-            else:
-                logging.debug(f"TV episode watched (E{episode_num:02d} < E{min_episode:02d}): {show_name}")
-                return False
+            logging.debug(f"TV episode not needed (S{season_num:02d}E{episode_num:02d}): {show_name}")
+            return False
 
     def get_files_to_move_back_to_array(self, current_ondeck_items: Set[str],
                                        current_watchlist_items: Set[str],
@@ -3241,7 +3236,7 @@ class FileFilter:
             logging.debug(f"Found {len(cache_files)} files in exclude list")
 
             # Build tracking sets for needed media
-            tv_show_min_episodes, needed_movies = self._build_needed_media_sets(
+            tv_show_needed_episodes, needed_movies = self._build_needed_media_sets(
                 current_ondeck_items, current_watchlist_items
             )
 
@@ -3273,7 +3268,7 @@ class FileFilter:
                 # Determine if file should be kept
                 if tv_info:
                     show_name, season_num, episode_num = tv_info
-                    if self._is_tv_episode_still_needed(show_name, season_num, episode_num, tv_show_min_episodes):
+                    if self._is_tv_episode_still_needed(show_name, season_num, episode_num, tv_show_needed_episodes):
                         continue
                     media_name = show_name
                 else:

--- a/tests/test_media_type_classification.py
+++ b/tests/test_media_type_classification.py
@@ -330,6 +330,74 @@ class TestBuildNeededMediaSetsWithMetadata:
         tv_eps, movies = file_filter._build_needed_media_sets(set(), watchlist)
         assert len(movies) > 0
 
+    def test_multi_user_disjoint_ranges(self, file_filter):
+        """Issue #107: Two users at different watch positions should not retain gap episodes.
+
+        User 1 at E20 (prefetch E21-E25), User 2 at E01 (prefetch E02-E06).
+        Only E01-E06 and E20-E25 should be needed, NOT E07-E19.
+        """
+        base = "/mnt/user/TV/TestShow/Season 01"
+        ondeck = set()
+
+        # User 2's window: E01-E06
+        for ep in range(1, 7):
+            path = f"{base}/S01E{ep:02d}.mkv"
+            file_filter.ondeck_tracker.update_entry(
+                path, "user2",
+                episode_info={"show": "TestShow", "season": 1, "episode": ep},
+                is_current_ondeck=(ep == 1)
+            )
+            ondeck.add(path)
+
+        # User 1's window: E20-E25
+        for ep in range(20, 26):
+            path = f"{base}/S01E{ep:02d}.mkv"
+            file_filter.ondeck_tracker.update_entry(
+                path, "user1",
+                episode_info={"show": "TestShow", "season": 1, "episode": ep},
+                is_current_ondeck=(ep == 20)
+            )
+            ondeck.add(path)
+
+        tv_eps, _ = file_filter._build_needed_media_sets(ondeck, set())
+
+        assert "TestShow" in tv_eps
+        needed = tv_eps["TestShow"][1]
+
+        # Should contain exactly E01-E06 and E20-E25
+        expected = set(range(1, 7)) | set(range(20, 26))
+        assert needed == expected
+
+        # Gap episodes (E07-E19) should NOT be needed
+        for ep in range(7, 20):
+            assert ep not in needed, f"E{ep:02d} should not be retained (gap episode)"
+
+    def test_multi_user_is_tv_episode_still_needed(self, file_filter):
+        """Issue #107: _is_tv_episode_still_needed correctly rejects gap episodes."""
+        # Simulate needed episodes: E01-E06 and E20-E25
+        tv_show_needed = {
+            "TestShow": {
+                1: set(range(1, 7)) | set(range(20, 26))
+            }
+        }
+
+        # Needed episodes should be kept
+        assert file_filter._is_tv_episode_still_needed("TestShow", 1, 1, tv_show_needed)
+        assert file_filter._is_tv_episode_still_needed("TestShow", 1, 6, tv_show_needed)
+        assert file_filter._is_tv_episode_still_needed("TestShow", 1, 20, tv_show_needed)
+        assert file_filter._is_tv_episode_still_needed("TestShow", 1, 25, tv_show_needed)
+
+        # Gap episodes should NOT be kept
+        assert not file_filter._is_tv_episode_still_needed("TestShow", 1, 7, tv_show_needed)
+        assert not file_filter._is_tv_episode_still_needed("TestShow", 1, 10, tv_show_needed)
+        assert not file_filter._is_tv_episode_still_needed("TestShow", 1, 19, tv_show_needed)
+
+        # Unknown show should not be kept
+        assert not file_filter._is_tv_episode_still_needed("Unknown", 1, 1, tv_show_needed)
+
+        # Unknown season should not be kept
+        assert not file_filter._is_tv_episode_still_needed("TestShow", 2, 1, tv_show_needed)
+
 
 # ============================================================================
 # FileFilter.get_files_to_move_back_to_array with metadata


### PR DESCRIPTION
## Summary

- Fixes #107: When multiple users have the same show on their OnDeck at different watch positions, the eviction logic incorrectly retained all episodes between the two positions
- Root cause: `_build_needed_media_sets()` tracked a single global minimum episode number per show/season across all users, then `_is_tv_episode_still_needed()` kept everything `>= min_episode`
- Fix: Changed from `Dict[str, Dict[int, int]]` (min episode) to `Dict[str, Dict[int, Set[int]]]` (set of needed episode numbers), so only episodes explicitly in a user's OnDeck + prefetch window are retained

### Example (from issue)
25-episode show, User 1 at E20, User 2 at E01, `episodes_to_fetch=6`:
- **Before:** min_episode=1, keeps E01–E25 (all 25 episodes)
- **After:** keeps {E01–E06} ∪ {E20–E25} (12 episodes, evicts 13 gap episodes)

## Test plan

- [x] Added `test_multi_user_disjoint_ranges` — validates two users with disjoint episode windows only retain their respective episodes
- [x] Added `test_multi_user_is_tv_episode_still_needed` — directly tests eviction check against disjoint episode set
- [x] All existing tests pass (615 passed, 1 pre-existing Windows-only skip)
- [x] Validated against production log with real multi-user scenarios (Stranger Things S04/S05, ONE PIECE S01/S02, Law & Order SVU, Invincible, ted)