### PR TITLE
Fix dashboard watchlist and OnDeck cached counts

### DIFF
--- a/web/routers/api.py
+++ b/web/routers/api.py
@@ -53,6 +53,7 @@ def _get_dashboard_stats_data(use_cache: bool = True) -> tuple[dict, str | None]
         "usage_percent": cache_stats["usage_percent"],
         "cached_files_size": cache_stats.get("cached_files_size"),
         "ondeck_count": cache_stats["ondeck_count"],
+        "ondeck_tracked_count": cache_stats.get("ondeck_tracked_count", 0),
         "watchlist_count": cache_stats["watchlist_count"],
         "watchlist_tracked_count": cache_stats.get("watchlist_tracked_count", 0),
         "eviction_over_threshold": cache_stats.get("eviction_over_threshold", False),

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -681,8 +681,9 @@ class CacheService:
             except (OSError, AttributeError) as e:
                 logging.warning(f"Could not get disk usage for {cache_dir}: {e}")
 
-        # Count ondeck and watchlist items
-        ondeck_count = len(ondeck)
+        # Count ondeck and watchlist items (cached = on disk, tracked = in tracker)
+        ondeck_cached_count = sum(1 for f in all_files if f.is_ondeck)
+        ondeck_tracked_count = len(ondeck)
         watchlist_cached_count = sum(1 for f in all_files if f.is_watchlist)
         watchlist_tracked_count = len(watchlist)
 
@@ -793,7 +794,8 @@ class CacheService:
             "usage_percent": usage_percent,
             "cached_files_size": format_bytes(cached_files_size),  # PlexCache files only
             "cached_files_size_bytes": cached_files_size,
-            "ondeck_count": ondeck_count,
+            "ondeck_count": ondeck_cached_count,
+            "ondeck_tracked_count": ondeck_tracked_count,
             "watchlist_count": watchlist_cached_count,
             "watchlist_tracked_count": watchlist_tracked_count,
             "eviction_over_threshold": eviction_over_threshold,

--- a/web/services/web_cache.py
+++ b/web/services/web_cache.py
@@ -291,6 +291,7 @@ def init_web_cache():
             "cache_limit": cache_stats["cache_limit"],
             "usage_percent": cache_stats["usage_percent"],
             "ondeck_count": cache_stats["ondeck_count"],
+            "ondeck_tracked_count": cache_stats.get("ondeck_tracked_count", 0),
             "watchlist_count": cache_stats["watchlist_count"],
             "watchlist_tracked_count": cache_stats.get("watchlist_tracked_count", 0),
             "last_run": last_run,

--- a/web/templates/partials/dashboard_stats.html
+++ b/web/templates/partials/dashboard_stats.html
@@ -39,7 +39,10 @@
         OnDeck
     </div>
     <div class="stat-value">{{ stats.ondeck_count }}</div>
-    <div class="stat-label">items ready</div>
+    <div class="stat-label">items cached</div>
+    {% if stats.ondeck_tracked_count and stats.ondeck_tracked_count > stats.ondeck_count %}
+    <div class="stat-detail">of {{ stats.ondeck_tracked_count }} on deck</div>
+    {% endif %}
 </a>
 
 <a href="/cache?source=watchlist" class="stat-card stat-card-link">


### PR DESCRIPTION
## Summary

- Dashboard Watchlist card showed total tracked items instead of actually-cached count — now shows cached items with a subtitle showing total tracked
- Dashboard OnDeck card had the same issue — applied the same fix
- Dual-source items (appearing in both OnDeck and Watchlist) are now correctly included in cached counts

## Test plan

- [x] All existing tests pass
- [x] Dashboard headline numbers now match click-through destinations
- [x] Dual-source items counted correctly