### PR TITLE
Improve maintenance UI with bulk actions and directory grouping

### DIFF
--- a/web/routers/maintenance.py
+++ b/web/routers/maintenance.py
@@ -1,10 +1,12 @@
 """Maintenance routes - cache audit and fix actions"""
 
+import json
 import logging
 from datetime import datetime
 from typing import List, Optional
-from fastapi import APIRouter, Request, Form, Query
+from fastapi import APIRouter, Depends, Request, Form, Query
 from fastapi.responses import HTMLResponse, JSONResponse
+from starlette.datastructures import ImmutableMultiDict
 
 from web.config import templates, get_time_format
 from web.services.maintenance_service import get_maintenance_service
@@ -14,12 +16,30 @@ from web.services.maintenance_runner import (
 )
 from web.services.duplicate_service import get_duplicate_service
 from core.system_utils import format_duration, format_cache_age
+from web.dependencies import parse_form
 from web.services.operation_runner import get_operation_runner
 from web.services.web_cache import get_web_cache_service, CACHE_KEY_MAINTENANCE_AUDIT, CACHE_KEY_MAINTENANCE_HEALTH, CACHE_KEY_DASHBOARD_STATS
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _get_paths(paths: List[str], paths_json: Optional[str] = None) -> List[str]:
+    """Extract paths from either JSON-encoded single field or individual form fields.
+
+    Frontend sends paths_json (single field with JSON array) to avoid
+    Starlette's 1000 multipart field limit on large selections.
+    Falls back to individual paths fields for backward compatibility.
+    """
+    if paths_json:
+        try:
+            decoded = json.loads(paths_json)
+            if isinstance(decoded, list) and decoded:
+                return decoded
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return paths
 
 
 # In-memory cache for full audit results (not JSON-serializable)
@@ -214,12 +234,24 @@ def run_audit(request: Request, refresh: bool = Query(default=False, description
     # Calculate cache age display
     cache_age = format_cache_age(updated_at)
 
+    # Load cached duplicate scan data for health card (zero API overhead)
+    dup_summary = {"duplicate_count": 0, "orphan_count": 0, "orphan_bytes_display": None}
+    try:
+        dup_results = get_duplicate_service().load_scan_results()
+        if dup_results is not None:
+            dup_summary["duplicate_count"] = dup_results.duplicate_count
+            dup_summary["orphan_count"] = dup_results.orphan_count
+            dup_summary["orphan_bytes_display"] = dup_results.orphan_bytes_display
+    except Exception:
+        pass
+
     response = templates.TemplateResponse(
         "maintenance/partials/audit_results.html",
         {
             "request": request,
             "results": results,
             "cache_age": cache_age or "just now",
+            "dup_summary": dup_summary,
         }
     )
     # Prevent browser caching so refresh button always fetches fresh data
@@ -343,11 +375,13 @@ def action_history(
 def restore_plexcached(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     restore_all: bool = Form(default=False),
     orphaned_only: bool = Form(default=False),
     dry_run: bool = Form(default=True)
 ):
     """Restore orphaned .plexcached backups"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
 
     if dry_run:
@@ -390,10 +424,12 @@ def restore_plexcached(
 def delete_plexcached(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     delete_all: bool = Form(default=False),
     dry_run: bool = Form(default=True)
 ):
     """Delete orphaned .plexcached backups (when no longer needed)"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
 
     if dry_run:
@@ -433,10 +469,12 @@ def delete_plexcached(
 def repair_plexcached(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     repair_all: bool = Form(default=False),
     dry_run: bool = Form(default=True)
 ):
     """Repair malformed .plexcached backups by adding missing media extension"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
 
     if dry_run:
@@ -476,10 +514,12 @@ def repair_plexcached(
 def delete_extensionless(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     delete_all: bool = Form(default=False),
     dry_run: bool = Form(default=True)
 ):
     """Delete extensionless duplicate files (from malformed .plexcached restores)"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
 
     if dry_run:
@@ -519,9 +559,11 @@ def delete_extensionless(
 def fix_with_backup(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     dry_run: bool = Form(default=True)
 ):
     """Fix files that have .plexcached backup"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
 
     if dry_run:
@@ -548,9 +590,11 @@ def fix_with_backup(
 def sync_to_array(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     dry_run: bool = Form(default=True)
 ):
     """Move files to array - restores backups if they exist, copies if not"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
 
     if dry_run:
@@ -574,10 +618,10 @@ def sync_to_array(
 
 
 @router.post("/evict-files", response_class=HTMLResponse)
-async def evict_files(request: Request):
+def evict_files(request: Request, form_data: ImmutableMultiDict = Depends(parse_form)):
     """Evict file(s) from cache — runs in background via maintenance runner."""
-    form = await request.form()
-    paths = form.getlist("paths")
+    paths_json = form_data.get("paths_json")
+    paths = _get_paths(form_data.getlist("paths"), paths_json)
 
     if not paths:
         return HTMLResponse(
@@ -602,9 +646,11 @@ async def evict_files(request: Request):
 def protect_with_backup(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     dry_run: bool = Form(default=True)
 ):
     """Protect files by creating .plexcached backup on array and adding to exclude list"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
 
     if dry_run:
@@ -633,9 +679,11 @@ def protect_with_backup(
 def add_to_exclude(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     dry_run: bool = Form(default=True)
 ):
     """Add files to exclude list"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
     started_at = datetime.now()
     result = service.add_to_exclude(paths, dry_run=dry_run)
@@ -715,9 +763,11 @@ def clean_timestamps(
 def fix_timestamps(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     dry_run: bool = Form(default=True)
 ):
     """Fix invalid file timestamps"""
+    paths = _get_paths(paths, paths_json)
     service = get_maintenance_service()
     started_at = datetime.now()
     result = service.fix_file_timestamps(paths, dry_run=dry_run)
@@ -861,10 +911,12 @@ def get_duplicates(request: Request):
 def delete_duplicates(
     request: Request,
     paths: List[str] = Form(default=[]),
+    paths_json: Optional[str] = Form(default=None),
     all_orphans: bool = Form(default=False),
     dry_run: bool = Form(default=True),
 ):
     """Delete selected duplicate files or all orphans"""
+    paths = _get_paths(paths, paths_json)
     service = get_duplicate_service()
 
     if dry_run:

--- a/web/templates/maintenance/index.html
+++ b/web/templates/maintenance/index.html
@@ -82,6 +82,43 @@
 
 {% block scripts %}
 <script>
+// Shift+Click range selection for checkbox groups
+// Delegated listener — works with HTMX-swapped content, no template changes needed.
+// Each group: { selector, toggleFn, lastChecked }
+var _shiftClickGroups = [];
+function enableShiftClick(selector, toggleFn) {
+    _shiftClickGroups.push({ selector: selector, toggleFn: toggleFn, lastChecked: null });
+}
+document.addEventListener('click', function(e) {
+    var cb = e.target;
+    if (cb.tagName !== 'INPUT' || cb.type !== 'checkbox') return;
+    for (var i = 0; i < _shiftClickGroups.length; i++) {
+        var g = _shiftClickGroups[i];
+        if (!cb.matches(g.selector)) continue;
+        if (e.shiftKey && g.lastChecked && g.lastChecked !== cb) {
+            var all = Array.from(document.querySelectorAll(g.selector));
+            var start = all.indexOf(g.lastChecked);
+            var end = all.indexOf(cb);
+            if (start > -1 && end > -1) {
+                var lo = Math.min(start, end);
+                var hi = Math.max(start, end);
+                for (var j = lo; j <= hi; j++) {
+                    all[j].checked = cb.checked;
+                    g.toggleFn(all[j]);
+                }
+            }
+        }
+        g.lastChecked = cb;
+        break;
+    }
+});
+
+// Encode paths as a single JSON field to avoid Starlette's max_fields limit.
+// The backend reads paths_json first, falls back to individual paths fields.
+function appendPathsToForm(formData, paths) {
+    formData.append('paths_json', JSON.stringify(Array.from(paths)));
+}
+
 // Selected items tracking
 let selectedUntrackedFiles = new Set();
 let selectedOrphanedBackups = new Set();
@@ -177,7 +214,20 @@ function showConfirmModal(title, message, action, formData, isDryRun = false) {
     const actionBtn = document.getElementById('confirm-modal-action');
 
     modalTitle.textContent = title;
-    modalBody.innerHTML = message;
+
+    // Warn on very large selections
+    var pathsJson = formData.get('paths_json');
+    var pathCount = 0;
+    if (pathsJson) {
+        try { pathCount = JSON.parse(pathsJson).length; } catch(e) {}
+    }
+    var largeWarning = '';
+    if (pathCount > 5000) {
+        largeWarning = '<div class="alert alert-warning" style="margin-bottom: 1rem; display: flex; align-items: flex-start; gap: 0.5rem; font-size: 0.85rem;">' +
+            '<i data-lucide="alert-triangle" style="flex-shrink: 0; margin-top: 2px;"></i>' +
+            '<span>Large selection (' + pathCount.toLocaleString() + ' files). This operation may take a while.</span></div>';
+    }
+    modalBody.innerHTML = largeWarning + message;
 
     // Determine button style and text based on action type
     let btnClass = 'btn btn-primary';
@@ -372,7 +422,7 @@ function restoreOrphanedSelected(isDryRun = false) {
 
     const count = orphanedPaths.length;
     const formData = new FormData();
-    orphanedPaths.forEach(path => formData.append('paths', path));
+    appendPathsToForm(formData, orphanedPaths);
 
     const action = isDryRun ? 'Preview' : 'Restore';
     const message = `
@@ -409,7 +459,7 @@ function deleteOrphanedSelected(isDryRun = false) {
 
     const count = selectedOrphanedBackups.size;
     const formData = new FormData();
-    selectedOrphanedBackups.forEach(path => formData.append('paths', path));
+    appendPathsToForm(formData, selectedOrphanedBackups);
 
     const action = isDryRun ? 'Preview' : 'Delete';
     const message = `
@@ -523,6 +573,12 @@ document.addEventListener('htmx:afterSwap', function(e) {
         selectedOrphanedBackups.clear();
         updateUntrackedActions();
         updateOrphanedActions();
+
+        // Auto-expand duplicate section if navigated with #duplicates hash
+        if (window.location.hash === '#duplicates') {
+            showDuplicateSection();
+            history.replaceState(null, '', window.location.pathname);
+        }
     }
 });
 
@@ -550,7 +606,30 @@ function toggleDuplicateSection() {
     if (typeof lucide !== 'undefined') lucide.createIcons();
 }
 
-function toggleDuplicateExpand(row) {
+function showDuplicateSection() {
+    const content = document.getElementById('dup-section-content');
+    const chevron = document.getElementById('dup-section-chevron');
+    const header = content && content.closest('.card');
+    if (!content) return;
+
+    // Expand if collapsed
+    if (content.style.display === 'none') {
+        content.style.display = 'block';
+        if (chevron) chevron.style.transform = 'rotate(180deg)';
+        if (typeof htmx !== 'undefined') {
+            htmx.process(content);
+        }
+        if (typeof lucide !== 'undefined') lucide.createIcons();
+    }
+
+    // Scroll the card into view
+    if (header) {
+        header.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+function toggleDuplicateExpand(row, event) {
+    if (event && (event.target.tagName === 'INPUT' || event.target.closest('input'))) return;
     const key = row.dataset.ratingKey;
     const detailRow = document.querySelector(`.dup-detail-row[data-parent="${key}"]`);
     const icon = row.querySelector('.dup-expand-icon');
@@ -630,7 +709,7 @@ function deleteSelectedDuplicates(isDryRun) {
 
     const count = selectedDuplicateFiles.size;
     const formData = new FormData();
-    selectedDuplicateFiles.forEach(function(path) { formData.append('paths', path); });
+    appendPathsToForm(formData, selectedDuplicateFiles);
 
     const fileList = Array.from(selectedDuplicateFiles).slice(0, 5).map(function(path) {
         return '<li style="font-size: 0.9em; color: var(--text-muted);">' + path.split('/').pop() + '</li>';
@@ -691,5 +770,10 @@ document.addEventListener('keydown', function(e) {
         closeConfirmModal();
     }
 });
+
+// Register shift+click range selection for all checkbox groups
+enableShiftClick('.untracked-checkbox', toggleUntrackedFile);
+enableShiftClick('.orphaned-checkbox', toggleOrphanedFile);
+enableShiftClick('.dup-file-checkbox', toggleDuplicateFile);
 </script>
 {% endblock %}

--- a/web/templates/maintenance/partials/action_history.html
+++ b/web/templates/maintenance/partials/action_history.html
@@ -100,7 +100,7 @@
                     </div>
                     {% endif %}
                     {% if not entry.affected_files and not entry.errors %}
-                    <span class="text-muted" style="font-size: 0.85rem;">No additional details.</span>
+                    <span class="text-muted" style="font-size: 0.85rem;">{{ entry.message if entry.message else 'No additional details.' }}</span>
                     {% endif %}
                 </td>
             </tr>


### PR DESCRIPTION
## Summary

- Add shift+click range selection for audit result checkboxes
- Send bulk paths as JSON to avoid multipart form field limits
- Group untracked files by directory in audit results for easier scanning
- Show error messages in banner pill detail view
- Raise max request part size to 20MB for large bulk operations

## Test plan

- [x] All existing tests pass
- [x] Shift+click selects range of checkboxes
- [x] Bulk remove/add works with large file lists
- [x] Directory grouping renders correctly in audit results