### PR TITLE
Unify associated files display with reusable macros

### DIFF
--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1,31 +1,5 @@
 /* PlexCache-D Web UI Custom Styles */
 
-/* Status indicators */
-.status-ok {
-    color: var(--plex-success);
-}
-
-.status-warn {
-    color: var(--plex-warning);
-}
-
-.status-error {
-    color: var(--plex-error);
-}
-
-.status-running {
-    color: var(--plex-orange);
-}
-
-/* Priority score colors */
-.priority-score {
-    display: inline-block;
-    padding: 0.1rem 0.4rem;
-    border-radius: 4px;
-    font-weight: bold;
-    font-size: 0.9em;
-}
-
 /* Log viewer - single scroll context for both axes */
 .log-viewer {
     height: 500px;
@@ -158,15 +132,6 @@ article nav ul li a[aria-current="page"] {
     margin-bottom: -1px;
 }
 
-/* Operation status cards */
-.status-success {
-    border-left: 4px solid #2ecc71;
-}
-
-.status-error {
-    border-left: 4px solid #e74c3c;
-}
-
 /* Footer styling */
 footer {
     margin-top: 2rem;
@@ -224,6 +189,101 @@ footer {
     top: 0;
     background: var(--plex-bg-card);
     z-index: 1;
+}
+
+/* Activity table column tweaks */
+.activity-file-col {
+    word-break: break-word;
+    white-space: normal;
+    min-width: 0;
+}
+.recent-activity-scroll table td:first-child {
+    white-space: nowrap;
+}
+
+/* Associated files badge + expandable sub-rows */
+.af-parent {
+    cursor: pointer;
+}
+.associated-files-badge {
+    margin-left: 0.375rem;
+    cursor: pointer;
+    user-select: none;
+    transition: opacity 0.15s ease;
+}
+.af-expanded .associated-files-badge {
+    opacity: 0.5;
+}
+.associated-sub-row {
+    display: none;
+}
+.associated-sub-row.af-visible {
+    display: table-row;
+}
+.associated-sub-row td {
+    padding-top: 0.1rem !important;
+    padding-bottom: 0.1rem !important;
+    border-bottom: none !important;
+}
+.associated-sub-row:hover td {
+    background: transparent !important;
+}
+.associated-sub-file {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.8rem;
+    color: var(--plex-text-muted, #8e8e93);
+    padding-left: 1.5rem !important;
+}
+.associated-sub-arrow {
+    color: var(--plex-text-muted, #8e8e93);
+    opacity: 0.5;
+    margin-right: 0.25rem;
+}
+.associated-sub-size {
+    font-size: 0.8rem;
+    color: var(--plex-text-muted, #8e8e93);
+}
+
+/* Associated files hover popup (compact tables) */
+.associated-files-hover {
+    position: relative;
+    display: inline-block;
+    cursor: default;
+}
+.associated-files-popup {
+    display: none;
+    position: fixed;
+    background: var(--plex-surface-elevated, #1f1f1f);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: var(--plex-radius-sm, 8px);
+    padding: 0.5rem 0.75rem;
+    min-width: 280px;
+    width: max-content;
+    z-index: 1000;
+    box-shadow: var(--plex-shadow-elevated, 0 4px 12px rgba(0, 0, 0, 0.4));
+    white-space: nowrap;
+    pointer-events: none;
+}
+.associated-files-popup .af-popup-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.125rem 0;
+    font-size: 0.78rem;
+    color: var(--plex-text-muted, #8e8e93);
+}
+.associated-files-popup .af-popup-name {
+    flex: 1;
+    min-width: 0;
+}
+.associated-files-popup .af-popup-name .associated-sub-arrow {
+    opacity: 0.4;
+}
+.associated-files-popup .af-popup-size {
+    flex-shrink: 0;
+    text-align: right;
 }
 
 /* Date group headers in activity feed */
@@ -825,6 +885,10 @@ footer {
     background: rgba(255,149,0,0.12);
     color: #FF9500;
 }
+.di-action-tag--error {
+    background: rgba(255,59,48,0.12);
+    color: #FF3B30;
+}
 .di-file-row__name {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -836,6 +900,21 @@ footer {
     color: rgba(255,255,255,0.25);
     flex-shrink: 0;
     margin-left: auto;
+}
+.di-file-row__assoc-badge {
+    font-size: 0.6rem;
+    color: rgba(255,255,255,0.3);
+    flex-shrink: 0;
+}
+.di-file-row--sub {
+    padding-left: 1.25rem;
+    font-size: 0.65rem;
+    opacity: 0.55;
+}
+.di-sub-arrow {
+    color: rgba(255,255,255,0.25);
+    flex-shrink: 0;
+    font-size: 0.7rem;
 }
 
 /* ── Buttons ─────────────────────────────────────────── */
@@ -880,14 +959,6 @@ footer {
     line-height: 1;
 }
 .di-dismiss:hover { background: rgba(255,255,255,0.12); color: #fff; }
-
-/* Ghost button (legacy compat) */
-.btn-ghost {
-    background: transparent;
-    border: none;
-    color: #fff;
-    cursor: pointer;
-}
 
 /* ── Warning row (reused from old banner) ────────────── */
 .di-warning {

--- a/web/templates/cache/list.html
+++ b/web/templates/cache/list.html
@@ -134,107 +134,9 @@
                    hx-get="/api/cache/files"
                    hx-trigger="load, refresh, every 30s"
                    hx-include=".cache-filter">
-                {% if files %}
-                    {% for file in files %}
-                    <tr>
-                        <td>
-                            <input type="checkbox" class="file-checkbox" value="{{ file.path }}" onchange="updateBulkActions()">
-                        </td>
-                        <td title="{{ file.path }}">
-                            {{ file.filename }}
-                            {% if file.subtitle_count > 0 %}
-                            <span class="subtitle-indicator" title="{{ file.subtitle_count }} subtitle{{ 's' if file.subtitle_count > 1 else '' }}">
-                                <i data-lucide="subtitles" style="width: 14px; height: 14px; vertical-align: middle; margin-left: 0.25rem; opacity: 0.6;"></i>
-                                <span style="font-size: 0.75rem; opacity: 0.6;">{{ file.subtitle_count }}</span>
-                            </span>
-                            {% endif %}
-                        </td>
-                        <td class="text-muted">{{ file.size_display }}</td>
-                        {% if eviction_enabled %}
-                        <td>
-                            <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
-                                {{ file.priority_score }}
-                            </span>
-                        </td>
-                        {% endif %}
-                        <td class="source-badges">
-                            {% if file.is_ondeck %}
-                            <span class="badge badge-info">OnDeck</span>
-                            {% endif %}
-                            {% if file.is_watchlist %}
-                            <span class="badge badge-muted">Watchlist</span>
-                            {% endif %}
-                            {% if not file.is_ondeck and not file.is_watchlist %}
-                                {% if file.source == 'ondeck' %}
-                                <span class="badge badge-warning">Stale OnDeck</span>
-                                {% elif file.source == 'watchlist' %}
-                                <span class="badge badge-warning">Stale Watchlist</span>
-                                {% else %}
-                                <span class="badge badge-warning">Other</span>
-                                {% endif %}
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if file.users %}
-                                {% for user in file.users %}
-                                <span class="badge badge-success" style="margin-right: 0.25rem;">{{ user }}</span>
-                                {% endfor %}
-                            {% else %}
-                            <span class="text-muted">-</span>
-                            {% endif %}
-                        </td>
-                        <td class="text-muted">{{ file.cache_age_hours|round(1) }}h</td>
-                        <td>
-                            <button class="btn btn-sm btn-secondary"
-                                    onclick="showEvictConfirm('{{ file.path|replace("'", "\\'") }}', '{{ file.filename|replace("'", "\\'") }}', '{{ file.size_display }}')"
-                                    title="Evict from cache">
-                                <i data-lucide="x"></i>
-                            </button>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                {% else %}
-                    <tr>
-                        <td colspan="8" class="text-muted" style="text-align: center; padding: 2rem;">
-                            <i data-lucide="inbox" style="width: 32px; height: 32px; display: block; margin: 0 auto 0.5rem;"></i>
-                            No cached files
-                        </td>
-                    </tr>
-                {% endif %}
+                {% include "cache/partials/file_table.html" %}
             </tbody>
             <tfoot id="cache-table-footer">
-                {% if files %}
-                <tr class="totals-row">
-                    <td colspan="8">
-                        <div class="totals-summary">
-                            <span class="totals-item">
-                                <i data-lucide="files"></i>
-                                <strong>{{ totals.total_files }}</strong> files
-                            </span>
-                            <span class="totals-divider"></span>
-                            <span class="totals-item">
-                                <i data-lucide="hard-drive"></i>
-                                <strong>{{ totals.total_size_display }}</strong> total
-                            </span>
-                            <span class="totals-divider"></span>
-                            <span class="totals-item">
-                                <span class="badge badge-info">OnDeck</span>
-                                <strong>{{ totals.ondeck_count }}</strong>
-                            </span>
-                            <span class="totals-item">
-                                <span class="badge badge-muted">Watchlist</span>
-                                <strong>{{ totals.watchlist_count }}</strong>
-                            </span>
-                            {% if totals.other_count > 0 %}
-                            <span class="totals-item">
-                                <span class="badge badge-warning">Other</span>
-                                <strong>{{ totals.other_count }}</strong>
-                            </span>
-                            {% endif %}
-                        </div>
-                    </td>
-                </tr>
-                {% endif %}
             </tfoot>
         </table>
     </div>
@@ -496,7 +398,7 @@ function executeEvict() {
 
     // Always use maintenance runner endpoint (handles single + bulk)
     const formData = new FormData();
-    pendingEvictPaths.forEach(path => formData.append('paths', path));
+    formData.append('paths_json', JSON.stringify(pendingEvictPaths));
 
     fetch('/maintenance/evict-files', {
         method: 'POST',

--- a/web/templates/cache/partials/file_table.html
+++ b/web/templates/cache/partials/file_table.html
@@ -1,20 +1,17 @@
 <!-- Cache files table body - HTMX partial -->
+{% from "macros/associated_files.html" import af_popup, af_popup_init %}
 {% if files %}
     {% for file in files %}
+    {% set assoc_count = file.subtitle_count + file.sidecar_count %}
     <tr>
         <td>
             <input type="checkbox" class="file-checkbox" value="{{ file.path }}" onchange="updateBulkActions()">
         </td>
-        <td title="{{ file.path }}">
-            {{ file.filename }}
-            {% if file.subtitle_count > 0 %}
-            <span class="subtitle-indicator" title="{{ file.subtitle_count }} subtitle{{ 's' if file.subtitle_count > 1 else '' }}">
-                <i data-lucide="subtitles" style="width: 14px; height: 14px; vertical-align: middle; margin-left: 0.25rem; opacity: 0.6;"></i>
-                <span style="font-size: 0.75rem; opacity: 0.6;">{{ file.subtitle_count }}</span>
-            </span>
-            {% endif %}
+        <td title="{{ file.path }}">{{ file.filename }}</td>
+        <td class="text-muted">
+            {{ file.size_display }}
+            {{ af_popup(file.associated_files or [], assoc_count) }}
         </td>
-        <td class="text-muted">{{ file.size_display }}</td>
         {% if eviction_enabled %}
         <td>
             <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
@@ -62,7 +59,7 @@
     <tr>
         <td colspan="{{ 8 if eviction_enabled else 7 }}" class="text-muted" style="text-align: center; padding: 2rem;">
             <i data-lucide="inbox" style="width: 32px; height: 32px; display: block; margin: 0 auto 0.5rem;"></i>
-            No cached files{% if source_filter != 'all' or search %} matching filters{% endif %}
+            No cached items{% if source_filter != 'all' or search %} matching filters{% endif %}
         </td>
     </tr>
 {% endif %}
@@ -75,7 +72,7 @@
             <div class="totals-summary">
                 <span class="totals-item">
                     <i data-lucide="files"></i>
-                    <strong>{{ totals.total_files }}</strong> files
+                    <strong>{{ totals.total_files }}</strong> items
                 </span>
                 <span class="totals-divider"></span>
                 <span class="totals-item">
@@ -102,3 +99,5 @@
     </tr>
     {% endif %}
 </tfoot>
+<script>lucide.createIcons();</script>
+{{ af_popup_init('cache-table-body') }}

--- a/web/templates/cache/partials/priorities_content.html
+++ b/web/templates/cache/partials/priorities_content.html
@@ -1,3 +1,4 @@
+{% from "macros/associated_files.html" import af_badge %}
 <!-- Priority Report Content - loaded via HTMX -->
 
 {% if data.files %}
@@ -6,7 +7,7 @@
     <div class="stat-card">
         <div class="stat-card-header">
             <i data-lucide="files"></i>
-            Total Files
+            Total Items
         </div>
         <div class="stat-value orange">{{ data.summary.total }}</div>
         <div class="stat-label">{{ data.summary.total_size_display }} cached</div>
@@ -17,7 +18,7 @@
             OnDeck
         </div>
         <div class="stat-value" style="color: var(--plex-info);">{{ data.summary.ondeck_count }}</div>
-        <div class="stat-label">files</div>
+        <div class="stat-label">items</div>
     </a>
     <a href="/cache?source=watchlist" class="stat-card stat-card-link">
         <div class="stat-card-header">
@@ -25,7 +26,7 @@
             Watchlist
         </div>
         <div class="stat-value text-muted">{{ data.summary.watchlist_count }}</div>
-        <div class="stat-label">files</div>
+        <div class="stat-label">items</div>
     </a>
     {% if data.summary.other_count > 0 %}
     <a href="/cache?source=other" class="stat-card stat-card-link">
@@ -34,7 +35,7 @@
             Other
         </div>
         <div class="stat-value text-warning">{{ data.summary.other_count }}</div>
-        <div class="stat-label">files</div>
+        <div class="stat-label">items</div>
     </a>
     {% endif %}
 </div>
@@ -54,7 +55,7 @@
                 </div>
                 <div class="tier-range">90 - 100</div>
                 <div class="tier-value">{{ data.tiers.high.count }}</div>
-                <div class="tier-label">files ({{ data.tiers.high.percent }}%)</div>
+                <div class="tier-label">items ({{ data.tiers.high.percent }}%)</div>
                 <div class="tier-size">{{ data.tiers.high.size_display }}</div>
                 <div class="tier-bar">
                     <div class="tier-fill" style="width: {{ data.tiers.high.percent }}%"></div>
@@ -67,7 +68,7 @@
                 </div>
                 <div class="tier-range">70 - 89</div>
                 <div class="tier-value">{{ data.tiers.medium.count }}</div>
-                <div class="tier-label">files ({{ data.tiers.medium.percent }}%)</div>
+                <div class="tier-label">items ({{ data.tiers.medium.percent }}%)</div>
                 <div class="tier-size">{{ data.tiers.medium.size_display }}</div>
                 <div class="tier-bar">
                     <div class="tier-fill" style="width: {{ data.tiers.medium.percent }}%"></div>
@@ -80,7 +81,7 @@
                 </div>
                 <div class="tier-range">0 - 69</div>
                 <div class="tier-value">{{ data.tiers.low.count }}</div>
-                <div class="tier-label">files ({{ data.tiers.low.percent }}%)</div>
+                <div class="tier-label">items ({{ data.tiers.low.percent }}%)</div>
                 <div class="tier-size">{{ data.tiers.low.size_display }}</div>
                 <div class="tier-bar">
                     <div class="tier-fill" style="width: {{ data.tiers.low.percent }}%"></div>
@@ -97,7 +98,7 @@
 <div class="card mb-2">
     <div class="card-header">
         <i data-lucide="file-text"></i>
-        <h2>File Priority Details</h2>
+        <h2>Item Priority Details</h2>
         <span class="text-muted" style="margin-left: auto; font-size: 0.85rem;">Click row to see score breakdown</span>
     </div>
     <div class="card-body" style="padding: 0;">
@@ -169,7 +170,11 @@
                         </span>
                     </td>
                     <td title="{{ file.path }}">{{ file.filename }}</td>
-                    <td class="text-muted">{{ file.size_display }}</td>
+                    <td class="text-muted">
+                        {{ file.size_display }}
+                        {% set assoc_count = (file.subtitle_count or 0) + (file.sidecar_count or 0) %}
+                        {{ af_badge(assoc_count, (file.subtitle_count or 0) ~ ' subtitle' ~ ('s' if (file.subtitle_count or 0) != 1 else '') ~ ', ' ~ (file.sidecar_count or 0) ~ ' asset' ~ ('s' if (file.sidecar_count or 0) != 1 else '')) }}
+                    </td>
                     <td class="source-badges">
                         {% if file.is_ondeck %}
                         <span class="badge badge-info">OnDeck</span>
@@ -201,32 +206,47 @@
                 <!-- Expandable breakdown row -->
                 <tr id="breakdown-{{ loop.index }}" class="priority-breakdown-row" style="display: none;">
                     <td colspan="7">
-                        <div class="breakdown-details">
-                            <div class="breakdown-title">Score Breakdown</div>
-                            <div class="breakdown-table">
-                                <div class="breakdown-line">
-                                    <span>Base Score:</span>
-                                    <span>{{ file.priority_breakdown.base }}</span>
-                                </div>
-                                {% for factor in file.priority_breakdown.factors %}
-                                <div class="breakdown-line">
-                                    <span>{{ factor.label }}:</span>
-                                    <span class="{{ 'text-success' if factor.value > 0 else 'text-error' if factor.value < 0 else '' }}">
-                                        {{ '+' if factor.value > 0 else '' }}{{ factor.value }}
-                                    </span>
-                                </div>
-                                {% endfor %}
-                                {% if not file.priority_breakdown.factors %}
-                                <div class="breakdown-line text-muted">
-                                    <span>No bonuses applied</span>
-                                    <span></span>
-                                </div>
-                                {% endif %}
-                                <div class="breakdown-line breakdown-total">
-                                    <span>Final Score:</span>
-                                    <span><strong>{{ file.priority_score }}</strong></span>
+                        <div class="breakdown-details" style="display: flex; gap: 3rem; align-items: flex-start;">
+                            <div>
+                                <div class="breakdown-title">Score Breakdown</div>
+                                <div class="breakdown-table">
+                                    <div class="breakdown-line">
+                                        <span>Base Score:</span>
+                                        <span>{{ file.priority_breakdown.base }}</span>
+                                    </div>
+                                    {% for factor in file.priority_breakdown.factors %}
+                                    <div class="breakdown-line">
+                                        <span>{{ factor.label }}:</span>
+                                        <span class="{{ 'text-success' if factor.value > 0 else 'text-error' if factor.value < 0 else '' }}">
+                                            {{ '+' if factor.value > 0 else '' }}{{ factor.value }}
+                                        </span>
+                                    </div>
+                                    {% endfor %}
+                                    {% if not file.priority_breakdown.factors %}
+                                    <div class="breakdown-line text-muted">
+                                        <span>No bonuses applied</span>
+                                        <span></span>
+                                    </div>
+                                    {% endif %}
+                                    <div class="breakdown-line breakdown-total">
+                                        <span>Final Score:</span>
+                                        <span><strong>{{ file.priority_score }}</strong></span>
+                                    </div>
                                 </div>
                             </div>
+                            {% if file.associated_files %}
+                            <div style="flex: 1; min-width: 0;">
+                                <div class="breakdown-title">Associated Files</div>
+                                <div class="breakdown-table" style="max-width: none;">
+                                    {% for af in file.associated_files %}
+                                    <div class="breakdown-line" style="gap: 1rem;">
+                                        <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1; color: var(--plex-text-muted);"><span class="associated-sub-arrow">&#8627;</span> {{ af.filename }}</span>
+                                        <span class="associated-sub-size" style="flex-shrink: 0;">{{ af.size }}</span>
+                                    </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                            {% endif %}
                         </div>
                     </td>
                 </tr>
@@ -238,7 +258,7 @@
                         <div class="totals-summary">
                             <span class="totals-item">
                                 <i data-lucide="files"></i>
-                                <strong>{{ data.summary.total }}</strong> files
+                                <strong>{{ data.summary.total }}</strong> items
                             </span>
                             <span class="totals-divider"></span>
                             <span class="totals-item">

--- a/web/templates/cache/partials/storage_stats.html
+++ b/web/templates/cache/partials/storage_stats.html
@@ -1,3 +1,4 @@
+{% from "macros/associated_files.html" import af_popup, af_popup_init %}
 <!-- ZFS Warning (only shown when ZFS detected without manual override) -->
 {% if data.storage.is_zfs and not data.storage.has_manual_drive_size %}
 <div class="alert alert-warning mb-2" style="display: flex; align-items: flex-start; gap: 0.75rem; padding: 0.75rem 1rem;">
@@ -43,7 +44,7 @@
     <div class="stat-card">
         <div class="stat-card-header">
             <i data-lucide="files"></i>
-            Cached Files
+            Cached Items
         </div>
         <div class="stat-value orange">{{ data.storage.file_count }}</div>
         <div class="stat-label">{{ data.storage.cached_size_display }} total</div>
@@ -249,7 +250,7 @@
                 </div>
                 <div class="breakdown-stats">
                     <div class="breakdown-value">{{ data.breakdown.ondeck.count }}</div>
-                    <div class="breakdown-label">files</div>
+                    <div class="breakdown-label">items</div>
                 </div>
                 <div class="breakdown-size">{{ data.breakdown.ondeck.size_display }}</div>
                 <div class="breakdown-bar">
@@ -264,7 +265,7 @@
                 </div>
                 <div class="breakdown-stats">
                     <div class="breakdown-value">{{ data.breakdown.watchlist.count }}</div>
-                    <div class="breakdown-label">files</div>
+                    <div class="breakdown-label">items</div>
                 </div>
                 <div class="breakdown-size">{{ data.breakdown.watchlist.size_display }}</div>
                 <div class="breakdown-bar">
@@ -280,7 +281,7 @@
                 </div>
                 <div class="breakdown-stats">
                     <div class="breakdown-value">{{ data.breakdown.other.count }}</div>
-                    <div class="breakdown-label">files</div>
+                    <div class="breakdown-label">items</div>
                 </div>
                 <div class="breakdown-size">{{ data.breakdown.other.size_display }}</div>
                 <div class="breakdown-bar">
@@ -299,7 +300,7 @@
     <div class="card">
         <div class="card-header">
             <i data-lucide="arrow-up-wide-narrow"></i>
-            <h2>Largest Files</h2>
+            <h2>Largest Items</h2>
         </div>
         <div class="card-body card-body-scrollable" style="padding: 0;">
             <table class="compact-table">
@@ -317,7 +318,10 @@
                         {% for file in data.largest_files %}
                         <tr>
                             <td title="{{ file.path }}">{{ file.filename|truncate(35) }}</td>
-                            <td class="text-muted">{{ file.size_display }}</td>
+                            <td class="text-muted">
+                                {{ file.size_display }}
+                                {{ af_popup(file.associated_files or [], file.subtitle_count + file.sidecar_count) }}
+                            </td>
                             {% if data.config.eviction_enabled %}
                             <td>
                                 <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
@@ -349,7 +353,7 @@
                         {% endfor %}
                     {% else %}
                         <tr>
-                            <td colspan="5" class="text-muted text-center">No files in cache</td>
+                            <td colspan="5" class="text-muted text-center">No items in cache</td>
                         </tr>
                     {% endif %}
                 </tbody>
@@ -361,7 +365,7 @@
     <div class="card">
         <div class="card-header">
             <i data-lucide="clock"></i>
-            <h2>Oldest Cached Files</h2>
+            <h2>Oldest Cached Items</h2>
         </div>
         <div class="card-body card-body-scrollable" style="padding: 0;">
             <table class="compact-table">
@@ -380,7 +384,10 @@
                         {% for file in data.oldest_files %}
                         <tr>
                             <td title="{{ file.path }}">{{ file.filename|truncate(30) }}</td>
-                            <td class="text-muted">{{ file.size_display }}</td>
+                            <td class="text-muted">
+                                {{ file.size_display }}
+                                {{ af_popup(file.associated_files or [], file.subtitle_count + file.sidecar_count) }}
+                            </td>
                             {% if data.config.eviction_enabled %}
                             <td>
                                 <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
@@ -419,7 +426,7 @@
                         {% endfor %}
                     {% else %}
                         <tr>
-                            <td colspan="6" class="text-muted text-center">No files in cache</td>
+                            <td colspan="6" class="text-muted text-center">No items in cache</td>
                         </tr>
                     {% endif %}
                 </tbody>
@@ -453,7 +460,10 @@
                         {% for file in data.activity.recently_cached %}
                         <tr>
                             <td title="{{ file.path }}">{{ file.filename|truncate(30) }}</td>
-                            <td class="text-muted">{{ file.size_display }}</td>
+                            <td class="text-muted">
+                                {{ file.size_display }}
+                                {{ af_popup(file.associated_files or [], file.subtitle_count + file.sidecar_count) }}
+                            </td>
                             {% if data.config.eviction_enabled %}
                             <td>
                                 <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
@@ -486,7 +496,7 @@
                         {% endfor %}
                     {% else %}
                         <tr>
-                            <td colspan="6" class="text-muted text-center">No recently cached files</td>
+                            <td colspan="6" class="text-muted text-center">No recently cached items</td>
                         </tr>
                     {% endif %}
                 </tbody>
@@ -529,7 +539,10 @@
                         {% for item in data.expiring_soon %}
                         <tr>
                             <td title="{{ item.file.path }}">{{ item.file.filename|truncate(30) }}</td>
-                            <td class="text-muted">{{ item.file.size_display }}</td>
+                            <td class="text-muted">
+                                {{ item.file.size_display }}
+                                {{ af_popup(item.file.associated_files or [], item.file.subtitle_count + item.file.sidecar_count) }}
+                            </td>
                             {% if data.config.eviction_enabled %}
                             <td>
                                 <span class="priority-badge {{ 'high' if item.file.priority_score >= 70 else 'medium' if item.file.priority_score >= 40 else 'low' }}">
@@ -568,7 +581,7 @@
                         {% endfor %}
                     {% else %}
                         <tr>
-                            <td colspan="6" class="text-muted text-center">No files expiring within {{ data.expiring_within_days }} days</td>
+                            <td colspan="6" class="text-muted text-center">No items expiring within {{ data.expiring_within_days }} days</td>
                         </tr>
                     {% endif %}
                 </tbody>
@@ -577,3 +590,4 @@
     </div>
 </div>
 <script>lucide.createIcons();</script>
+{{ af_popup_init('storage-content') }}

--- a/web/templates/components/global_operation_banner.html
+++ b/web/templates/components/global_operation_banner.html
@@ -755,7 +755,17 @@ function dismissMaintCompletionBanner() {
                 <span class="di-action-tag {{ 'di-action-tag--cached' if f.action == 'Cached' else 'di-action-tag--restored' }}">{{ f.action|upper }}</span>
                 <span class="di-file-row__name">{{ f.filename|truncate(55, True, '...') }}</span>
                 {% if f.size and f.size != '-' %}<span class="di-file-row__size">{{ f.size }}</span>{% endif %}
+                {% if f.associated_files is defined and f.associated_files %}<span class="di-file-row__assoc-badge">+{{ f.associated_files|length }}</span>{% endif %}
             </div>
+            {%- if f.associated_files is defined and f.associated_files %}
+            {%- for af in f.associated_files %}
+            <div class="di-file-row di-file-row--sub">
+                <span class="di-sub-arrow">&#8627;</span>
+                <span class="di-file-row__name">{{ af.filename|truncate(55, True, '...') }}</span>
+                {% if af.size %}<span class="di-file-row__size">{{ af.size }}</span>{% endif %}
+            </div>
+            {%- endfor %}
+            {%- endif %}
             {%- endfor %}
             {%- endif %}
             <div class="di-divider"></div>
@@ -879,25 +889,54 @@ function dismissMaintCompletionBanner() {
     // File detail rows
     var recentFiles = [
         {% for f in status.recent_files|default([]) %}
-        { action: '{{ f.action }}', filename: '{{ f.filename|truncate(45, True, "...")|e }}', size: '{{ f.size }}' },
+        { action: '{{ f.action }}', filename: '{{ f.filename|truncate(45, True, "...")|e }}', size: '{{ f.size }}', associatedFiles: [
+            {%- if f.associated_files is defined and f.associated_files %}{% for af in f.associated_files %}{ filename: '{{ af.filename|truncate(45, True, "...")|e }}', size: '{{ af.size }}' },{% endfor %}{% endif -%}
+        ] },
+        {% endfor %}
+    ];
+    var errorMessages = [
+        {% for msg in status.error_messages|default([]) %}
+        '{{ msg|truncate(80, True, "...")|e }}',
         {% endfor %}
     ];
     var detailHtml = '';
     var hintHtml = '';
-    if (recentFiles.length > 0) {
+    var hasDetails = recentFiles.length > 0 || errorMessages.length > 0;
+    if (hasDetails) {
         hintHtml = '<div class="di-expand-hint"><span>Click for details</span><i data-lucide="chevron-down" style="width: 12px; height: 12px;"></i></div>';
         detailHtml = '<div class="di-pill__detail"><div class="di-divider"></div>';
         recentFiles.forEach(function(f) {
             var tagClass = f.action === 'Cached' ? 'di-action-tag--cached' : 'di-action-tag--restored';
+            var assocBadge = f.associatedFiles.length > 0 ? '<span class="di-file-row__assoc-badge">+' + f.associatedFiles.length + '</span>' : '';
             detailHtml += '<div class="di-file-row">' +
                 '<span class="di-action-tag ' + tagClass + '">' + f.action.toUpperCase() + '</span>' +
                 '<span class="di-file-row__name">' + f.filename + '</span>' +
                 (f.size !== '-' ? '<span class="di-file-row__size">' + f.size + '</span>' : '') +
+                assocBadge +
                 '</div>';
+            f.associatedFiles.forEach(function(af) {
+                detailHtml += '<div class="di-file-row di-file-row--sub">' +
+                    '<span class="di-sub-arrow">&#8627;</span>' +
+                    '<span class="di-file-row__name">' + af.filename + '</span>' +
+                    (af.size ? '<span class="di-file-row__size">' + af.size + '</span>' : '') +
+                    '</div>';
+            });
         });
         var totalFiles = filesCached + filesRestored;
         if (totalFiles > recentFiles.length) {
             detailHtml += '<div class="di-more-files">+ ' + (totalFiles - recentFiles.length) + ' more files</div>';
+        }
+        if (errorMessages.length > 0) {
+            if (recentFiles.length > 0) detailHtml += '<div class="di-divider"></div>';
+            errorMessages.forEach(function(msg) {
+                detailHtml += '<div class="di-file-row">' +
+                    '<span class="di-action-tag di-action-tag--error">ERROR</span>' +
+                    '<span class="di-file-row__name" style="color: var(--plex-error, #e5a00d);">' + msg + '</span>' +
+                    '</div>';
+            });
+            if (errorCount > errorMessages.length) {
+                detailHtml += '<div class="di-more-files">+ ' + (errorCount - errorMessages.length) + ' more errors</div>';
+            }
         }
         detailHtml += '</div>';
     }

--- a/web/templates/components/recent_activity.html
+++ b/web/templates/components/recent_activity.html
@@ -1,4 +1,5 @@
 <!-- Recent Activity component - HTMX partial (grouped by date) -->
+{% from "macros/associated_files.html" import af_expand_badge, af_expand_rows, af_expand_onclick %}
 {% if activity %}
 {% for group in activity|groupby('date_key')|reverse %}
 <tr class="date-group-header" data-date-group="{{ group.grouper }}">
@@ -14,7 +15,7 @@
     </td>
 </tr>
 {% for item in group.list %}
-<tr data-action="{{ item.action }}" data-date-group="{{ item.date_key }}">
+<tr data-action="{{ item.action }}" data-date-group="{{ item.date_key }}"{% if item.associated_files %} class="af-parent" {{ af_expand_onclick() }}{% endif %}>
     <td>{{ item.time_display }}</td>
     <td>
         {% if item.action in ('Cached', 'Protected', 'Fixed') %}
@@ -27,7 +28,7 @@
         <span class="badge badge-muted">{{ item.action }}</span>
         {% endif %}
     </td>
-    <td class="text-muted" style="max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="{{ item.filename }}">{{ item.filename }}</td>
+    <td class="text-muted activity-file-col" title="{{ item.filename }}">{{ item.filename }}</td>
     <td class="user-badges">
         {% if item.users and item.users|length > 0 %}
             {% for user in item.users[:3] %}
@@ -40,8 +41,12 @@
         <span class="text-muted">-</span>
         {% endif %}
     </td>
-    <td>{{ item.size }}</td>
+    <td>
+        {{ item.size }}
+        {{ af_expand_badge(item.associated_files) }}
+    </td>
 </tr>
+{{ af_expand_rows(item.associated_files, {"data-action": item.action, "data-date-group": item.date_key}) }}
 {% endfor %}
 {% endfor %}
 {% else %}

--- a/web/templates/macros/associated_files.html
+++ b/web/templates/macros/associated_files.html
@@ -1,0 +1,125 @@
+{#
+    Associated Files Macros
+    =======================
+    Reusable components for displaying grouped asset files (subtitles, artwork, .nfo, etc.)
+    under primary media files. Two display variants:
+
+    1. Click-to-expand (Dashboard/Activity) — inline table sub-rows
+       - af_expand_badge(files)       → +N badge in the parent row
+       - af_expand_rows(files, attrs) → hidden <tr> sub-rows that toggle on click
+
+    2. Hover popup (Cache list, Maintenance, etc.) — fixed-position popup
+       - af_popup(files, count)       → badge + popup container
+
+    Data contract: `files` is List[Dict] with {"filename": str, "size": str}
+
+    CSS: All styles live in custom.css (lines 239-322), no additional CSS needed.
+    JS:  Expand uses inline onclick on the parent <tr>.
+         Popup uses af_popup_init(containerId) — call after HTMX swap.
+#}
+
+
+{# ── Click-to-Expand variant ── #}
+
+{# Badge showing +N count, placed inside the parent <tr> cell.
+   `title` = optional tooltip text for the badge.
+#}
+{% macro af_expand_badge(files, title='') %}
+{% if files %}
+<span class="badge badge-muted badge-sm associated-files-badge"{% if title %} title="{{ title }}"{% endif %}>+{{ files|length }}</span>
+{% endif %}
+{% endmacro %}
+
+{# Standalone badge (no expand, no popup) — just the +N count with optional tooltip.
+   Useful when the page has its own layout for showing associated files (e.g. priorities breakdown).
+#}
+{% macro af_badge(count, title='') %}
+{% if count > 0 %}
+<span class="badge badge-muted badge-sm associated-files-badge"{% if title %} title="{{ title }}"{% endif %}>+{{ count }}</span>
+{% endif %}
+{% endmacro %}
+
+{# Hidden sub-rows revealed by clicking the parent row.
+   `files` = list of {filename, size} dicts
+   `attrs` = dict of extra data-* attributes to copy onto each sub-row (e.g. {"data-action": "Cached", "data-date-group": "2026-03-06"})
+   `empty_cols_before` = number of empty <td>s before the filename column (default 2)
+   `empty_cols_after` = number of empty <td>s between filename and size (default 1)
+#}
+{% macro af_expand_rows(files, attrs={}, empty_cols_before=2, empty_cols_after=1) %}
+{% if files %}
+{% for af in files %}
+<tr class="associated-sub-row"{% for k, v in attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
+    {% for _ in range(empty_cols_before) %}<td></td>{% endfor %}
+    <td class="associated-sub-file" title="{{ af.filename }}"><span class="associated-sub-arrow">&#8627;</span> {{ af.filename }}</td>
+    {% for _ in range(empty_cols_after) %}<td></td>{% endfor %}
+    <td class="associated-sub-size">{{ af.size if af.size else '-' }}</td>
+</tr>
+{% endfor %}
+{% endif %}
+{% endmacro %}
+
+{# Inline onclick attribute for the parent <tr> — toggles expand/collapse of sub-rows #}
+{% macro af_expand_onclick() %}onclick="this.classList.toggle('af-expanded'); var s=this.nextElementSibling; while(s && s.classList.contains('associated-sub-row')){s.classList.toggle('af-visible'); s=s.nextElementSibling;}"{% endmacro %}
+
+
+{# ── Hover Popup variant ── #}
+
+{# Badge + popup container for hover display.
+   `files` = list of {filename, size} dicts
+   `count` = total associated file count (may differ from files|length if list is truncated)
+#}
+{% macro af_popup(files, count=none) %}
+{% set file_list = files if files else [] %}
+{% set display_count = count if count is not none else file_list|length %}
+{% if display_count > 0 %}
+<span class="associated-files-hover">
+    <span class="badge badge-muted badge-sm associated-files-badge">+{{ display_count }}</span>
+    {% if file_list|length > 0 %}
+    <span class="associated-files-popup">
+        {% for af in file_list %}
+        <span class="af-popup-row">
+            <span class="af-popup-name"><span class="associated-sub-arrow">&#8627;</span> {{ af.filename }}</span>
+            <span class="af-popup-size">{{ af.size }}</span>
+        </span>
+        {% endfor %}
+    </span>
+    {% endif %}
+</span>
+{% endif %}
+{% endmacro %}
+
+
+{# ── Popup positioning JS ── #}
+
+{# Call this once per page/partial that uses af_popup, passing the container element ID.
+   Uses event delegation so it works with HTMX-swapped content.
+#}
+{% macro af_popup_init(container_id) %}
+<script>
+(function() {
+    var container = document.getElementById('{{ container_id }}');
+    if (!container) return;
+    container.addEventListener('mouseenter', function(e) {
+        var hover = e.target.closest('.associated-files-hover');
+        if (!hover) return;
+        var popup = hover.querySelector('.associated-files-popup');
+        if (!popup) return;
+        var rect = hover.getBoundingClientRect();
+        var vw = window.innerWidth;
+        popup.style.top = (rect.bottom + 4) + 'px';
+        popup.style.display = 'block';
+        var pw = popup.offsetWidth;
+        var left = rect.left;
+        if (left + pw > vw - 16) left = vw - pw - 16;
+        if (left < 8) left = 8;
+        popup.style.left = left + 'px';
+    }, true);
+    container.addEventListener('mouseleave', function(e) {
+        var hover = e.target.closest('.associated-files-hover');
+        if (!hover) return;
+        var popup = hover.querySelector('.associated-files-popup');
+        if (popup) popup.style.display = 'none';
+    }, true);
+})();
+</script>
+{% endmacro %}

--- a/web/templates/maintenance/partials/audit_results.html
+++ b/web/templates/maintenance/partials/audit_results.html
@@ -37,6 +37,12 @@
         <div class="stat-value" style="color: var(--success);">OK</div>
         <div class="stat-label">no issues</div>
         {% endif %}
+        {% if dup_summary is defined and dup_summary.duplicate_count > 0 %}
+        <a href="javascript:void(0)" onclick="showDuplicateSection()" class="stat-detail" style="margin-top: 0.35rem; font-size: 0.75rem; color: var(--warning); text-decoration: none; display: block; cursor: pointer;">
+            <i data-lucide="copy" style="width: 12px; height: 12px; vertical-align: middle;"></i>
+            {{ dup_summary.duplicate_count }} duplicate{{ 's' if dup_summary.duplicate_count != 1 }}{% if dup_summary.orphan_count > 0 %} &middot; {{ dup_summary.orphan_count }} orphan{{ 's' if dup_summary.orphan_count != 1 }}{% if dup_summary.orphan_bytes_display %} ({{ dup_summary.orphan_bytes_display }}){% endif %}{% endif %}
+        </a>
+        {% endif %}
     </div>
 
     <div class="stat-card {% if results.unprotected_files|length == 0 %}stat-card-success{% endif %}">
@@ -100,7 +106,7 @@
 <div class="card mb-2">
     <div class="card-header">
         <i data-lucide="eye"></i>
-        <h2>Untracked Files ({{ results.unprotected_files|length }})</h2>
+        <h2>Untracked Files ({{ results.unprotected_files|length }}{% if results.grouped_unprotected|length != results.unprotected_files|length %} in {{ results.grouped_unprotected|length }} groups{% endif %})</h2>
     </div>
     <div class="card-body" style="padding: 0.75rem;">
         <p class="text-muted" style="margin: 0 0 0.75rem 0;">
@@ -138,15 +144,23 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for file in results.unprotected_files %}
-                    <tr data-filename="{{ file.filename|lower }}" data-size="{{ file.size }}" data-age="{{ file.age_days }}" data-has-backup="{{ file.has_plexcached_backup|lower }}" data-has-dup="{{ file.has_array_duplicate|lower }}">
+                    {% for group in results.grouped_unprotected %}
+                    {% set file = group.primary %}
+                    {% set children = group.children %}
+                    {% set group_size = file.size + children|sum(attribute='size') if children else file.size %}
+                    <tr data-filename="{{ file.filename|lower }}" data-size="{{ group_size }}" data-age="{{ file.age_days }}" data-has-backup="{{ file.has_plexcached_backup|lower }}" data-has-dup="{{ file.has_array_duplicate|lower }}"{% if children %} class="untracked-group-row" onclick="toggleUntrackedGroup(this, event)" style="cursor: pointer;"{% endif %}>
                         <td>
-                            <input type="checkbox" class="untracked-checkbox" value="{{ file.cache_path }}" onchange="toggleUntrackedFile(this)" data-has-backup="{{ file.has_plexcached_backup|lower }}" data-has-dup="{{ file.has_array_duplicate|lower }}">
+                            <input type="checkbox" class="untracked-checkbox" value="{{ file.cache_path }}" onchange="toggleUntrackedFile(this){% if children %}; toggleGroupCheckbox(this){% endif %}" data-has-backup="{{ file.has_plexcached_backup|lower }}" data-has-dup="{{ file.has_array_duplicate|lower }}">
                         </td>
                         <td title="{{ file.cache_path }}" style="max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
                             {{ file.filename }}
                         </td>
-                        <td class="text-muted">{{ file.size_display }}</td>
+                        <td class="text-muted" style="white-space: nowrap;">
+                            {% if children %}{{ group.total_size_display }}{% else %}{{ file.size_display }}{% endif %}
+                            {% if children %}
+                            <span class="badge badge-muted badge-sm associated-files-badge">+{{ children|length }}</span>
+                            {% endif %}
+                        </td>
                         <td class="text-muted">
                             {% if file.has_invalid_timestamp %}
                             <span class="badge badge-warning">Bad date</span>
@@ -166,6 +180,35 @@
                             {% endif %}
                         </td>
                     </tr>
+                    {% for child in children %}
+                    <tr class="untracked-child-row" style="display: none;" data-filename="{{ child.filename|lower }}" data-size="{{ child.size }}" data-age="{{ child.age_days }}">
+                        <td>
+                            <input type="checkbox" class="untracked-checkbox untracked-child-cb" value="{{ child.cache_path }}" onchange="toggleUntrackedFile(this)" data-has-backup="{{ child.has_plexcached_backup|lower }}" data-has-dup="{{ child.has_array_duplicate|lower }}">
+                        </td>
+                        <td title="{{ child.cache_path }}" style="max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding-left: 2rem;">
+                            <span style="color: rgba(255,255,255,0.35); margin-right: 4px;">&#8627;</span>{{ child.filename }}
+                        </td>
+                        <td class="text-muted">{{ child.size_display }}</td>
+                        <td class="text-muted">
+                            {% if child.has_invalid_timestamp %}
+                            <span class="badge badge-warning">Bad date</span>
+                            {% elif child.age_days >= 999 %}
+                            Unknown
+                            {% else %}
+                            {{ "%.1f"|format(child.age_days) }}d
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if child.has_plexcached_backup %}
+                            <span class="badge badge-success" title="A .plexcached backup exists on the array">Has backup</span>
+                            {% elif child.has_array_duplicate %}
+                            <span class="badge badge-info" title="This file also exists on the array">Has copy</span>
+                            {% else %}
+                            <span class="badge badge-warning" title="No copy exists on the array - only on cache">Cache only</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
                     {% endfor %}
                 </tbody>
             </table>
@@ -597,6 +640,20 @@ th.sortable .sort-icon i {
     width: 14px;
     height: 14px;
 }
+
+/* Untracked file grouping */
+.untracked-child-row {
+    background: rgba(255,255,255,0.02);
+}
+
+.untracked-group-row:hover {
+    background: var(--plex-bg-hover);
+}
+
+.untracked-group-expanded + .untracked-child-row,
+.untracked-child-row + .untracked-child-row {
+    border-top: 1px solid rgba(255,255,255,0.04);
+}
 </style>
 
 <script>
@@ -606,13 +663,41 @@ var sortState = sortState || {
     orphaned: { column: 'filename', direction: 'asc' }
 };
 
+function toggleUntrackedGroup(row, event) {
+    if (event && (event.target.tagName === 'INPUT' || event.target.closest('input'))) return;
+    var expanded = row.classList.toggle('untracked-group-expanded');
+    var next = row.nextElementSibling;
+    while (next && next.classList.contains('untracked-child-row')) {
+        next.style.display = expanded ? '' : 'none';
+        next = next.nextElementSibling;
+    }
+}
+
+function toggleGroupCheckbox(checkbox) {
+    var row = checkbox.closest('tr');
+    var next = row.nextElementSibling;
+    while (next && next.classList.contains('untracked-child-row')) {
+        var cb = next.querySelector('.untracked-child-cb');
+        if (cb) {
+            cb.checked = checkbox.checked;
+            if (checkbox.checked) {
+                selectedUntrackedFiles.add(cb.value);
+            } else {
+                selectedUntrackedFiles.delete(cb.value);
+            }
+        }
+        next = next.nextElementSibling;
+    }
+    updateUntrackedActions();
+}
+
 function sortTable(tableId, column) {
     const state = sortState[tableId];
     const table = document.getElementById(tableId + '-table');
     if (!table) return;
 
     const tbody = table.querySelector('tbody');
-    const rows = Array.from(tbody.querySelectorAll('tr'));
+    const allRows = Array.from(tbody.querySelectorAll('tr'));
 
     // Toggle direction if same column
     if (state.column === column) {
@@ -622,21 +707,31 @@ function sortTable(tableId, column) {
         state.direction = column === 'filename' ? 'asc' : 'desc';
     }
 
-    // Sort rows
-    rows.sort((a, b) => {
-        let aVal, bVal;
-
-        if (column === 'filename') {
-            aVal = a.dataset.filename || '';
-            bVal = b.dataset.filename || '';
-        } else if (column === 'size') {
-            aVal = parseFloat(a.dataset.size) || 0;
-            bVal = parseFloat(b.dataset.size) || 0;
-        } else if (column === 'age') {
-            aVal = parseFloat(a.dataset.age) || 0;
-            bVal = parseFloat(b.dataset.age) || 0;
+    // Build groups: each primary row with its child rows
+    var groups = [];
+    var currentGroup = null;
+    allRows.forEach(function(row) {
+        if (row.classList.contains('untracked-child-row')) {
+            if (currentGroup) currentGroup.children.push(row);
+        } else {
+            currentGroup = { primary: row, children: [] };
+            groups.push(currentGroup);
         }
+    });
 
+    // Sort groups by primary row data
+    groups.sort(function(a, b) {
+        var aVal, bVal;
+        if (column === 'filename') {
+            aVal = a.primary.dataset.filename || '';
+            bVal = b.primary.dataset.filename || '';
+        } else if (column === 'size') {
+            aVal = parseFloat(a.primary.dataset.size) || 0;
+            bVal = parseFloat(b.primary.dataset.size) || 0;
+        } else if (column === 'age') {
+            aVal = parseFloat(a.primary.dataset.age) || 0;
+            bVal = parseFloat(b.primary.dataset.age) || 0;
+        }
         if (typeof aVal === 'string') {
             return state.direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
         } else {
@@ -644,8 +739,11 @@ function sortTable(tableId, column) {
         }
     });
 
-    // Re-append sorted rows
-    rows.forEach(row => tbody.appendChild(row));
+    // Re-append sorted groups (primary + children stay together)
+    groups.forEach(function(g) {
+        tbody.appendChild(g.primary);
+        g.children.forEach(function(c) { tbody.appendChild(c); });
+    });
 
     // Update header icons
     updateSortIcons(tableId, column, state.direction);
@@ -675,7 +773,7 @@ function keepOnCacheSelected() {
 
     const count = selectedUntrackedFiles.size;
     const formData = new FormData();
-    selectedUntrackedFiles.forEach(path => formData.append('paths', path));
+    appendPathsToForm(formData, selectedUntrackedFiles);
 
     // Build file list for display
     const fileList = Array.from(selectedUntrackedFiles).slice(0, 5).map(path =>
@@ -732,7 +830,7 @@ function moveToArraySelected() {
     });
 
     const formData = new FormData();
-    selectedUntrackedFiles.forEach(path => formData.append('paths', path));
+    appendPathsToForm(formData, selectedUntrackedFiles);
 
     // Build file list for display
     const fileList = Array.from(selectedUntrackedFiles).slice(0, 5).map(path =>


### PR DESCRIPTION
## Summary

- Extract associated files display (subtitle/sidecar badges, expand rows, hover popups) into shared Jinja2 macros in `web/templates/macros/associated_files.html`
- Two variants: click-to-expand (Dashboard) and hover popup (Cache list, Storage, Priorities)
- Dynamic popup positioning with viewport-aware JS using `getBoundingClientRect()`
- Remove duplicated table markup from `cache/list.html` in favor of shared `file_table.html` partial
- Fix associated files failing to restore when no `.plexcached` backup exists
- Consolidate CSS for associated files display

## Test plan

- [x] All existing tests pass
- [x] Click-to-expand rows work on Dashboard
- [x] Hover popups render correctly and stay within viewport bounds
- [x] Audit results show associated files with proper grouping
- [x] Banner pill shows file extensions for associated files