### PR TITLE
Fix missing parse_form dependency (#119)

### DIFF
--- a/web/dependencies.py
+++ b/web/dependencies.py
@@ -5,12 +5,24 @@ from pathlib import Path
 from functools import lru_cache
 from typing import Optional
 
+from fastapi import Request
+from starlette.datastructures import ImmutableMultiDict
+
 # Add project root to path for core imports
 PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from web.config import SETTINGS_FILE, DATA_DIR, LOGS_DIR
+
+
+async def parse_form(request: Request) -> ImmutableMultiDict:
+    """Parse form data from request for use in sync route handlers.
+
+    Use as Depends(parse_form) to receive pre-parsed form data in def handlers,
+    avoiding the need for async def just to call await request.form().
+    """
+    return await request.form()
 
 
 @lru_cache()


### PR DESCRIPTION
## Summary
- Adds `parse_form` async dependency to `web/dependencies.py`
- This function was referenced by `web/routers/maintenance.py` (merged in PR #112) but the dependency definition was missing from the module
- Fixes #119: `ImportError: cannot import name 'parse_form' from 'web.dependencies'`

## Root cause
PR #112 (maintenance bulk actions) cherry-picked the router code that uses `Depends(parse_form)`, but the `parse_form` function itself was part of a broader refactor on the dev branch that wasn't included in that PR.

## Test plan
- [ ] Verify web UI loads without import errors
- [ ] Verify maintenance evict files action works