### PR TITLE
Fix #136: audit fan-out + legacy migration subdir + cache_path warnings

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -251,6 +251,53 @@ class LoggingConfig:
     keep_error_logs_days: int = 7
 
 
+def _derive_migrated_cache_path(real_source: str, cache_dir: str) -> str:
+    """Derive a specific cache_path from legacy real_source + cache_dir.
+
+    The legacy settings stored cache_dir as the cache drive root (e.g.
+    "/mnt/cache/") rather than the media subdirectory. When real_source was
+    deeper than that root (e.g. "/mnt/user/Media/"), the old migration copied
+    cache_dir verbatim, leaving the audit to walk the entire cache drive.
+    This helper mirrors the real_source subpath into cache_dir.
+
+    Examples:
+        real_source="/mnt/user/Media/", cache_dir="/mnt/cache/"
+            -> "/mnt/cache/Media/"
+        real_source="/mnt/user/Movies/", cache_dir="/mnt/cache/Movies/"
+            -> "/mnt/cache/Movies/"  (user already specific, unchanged)
+        real_source="/custom/path/", cache_dir="/other/"
+            -> "/other/"  (non-/mnt/user/ real_source, preserve legacy value)
+
+    Args:
+        real_source: Legacy real_source value.
+        cache_dir: Legacy cache_dir value.
+
+    Returns:
+        The derived cache_path string. Falls back to cache_dir unchanged when
+        no safe transformation applies.
+    """
+    if not real_source or not cache_dir:
+        return cache_dir
+
+    real = real_source.rstrip("/\\")
+    cache = cache_dir.rstrip("/\\")
+
+    if not real.startswith("/mnt/user/"):
+        return cache_dir
+
+    # Mirror the subpath under /mnt/cache/
+    translated = real.replace("/mnt/user/", "/mnt/cache/", 1)
+
+    # Only override when cache_dir is the bare cache drive root. If the user
+    # already specified a deeper cache_dir that matches or extends the
+    # translated path, leave it alone.
+    if cache in ("/mnt/cache", "/mnt/cache/"):
+        # Preserve trailing slash convention from the original cache_dir
+        return translated + "/" if cache_dir.endswith("/") else translated
+
+    return cache_dir
+
+
 def migrate_path_settings(settings: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
     """Migrate legacy single-path settings to multi-path format.
 
@@ -280,12 +327,17 @@ def migrate_path_settings(settings: Dict[str, Any]) -> Tuple[Dict[str, Any], boo
 
     logging.info("Migrating legacy path settings to multi-path format...")
 
-    # Create single mapping from legacy settings
+    # Derive a specific cache_path by mirroring the real_source subdir.
+    # See issue #136 — the previous migration copied cache_dir verbatim, which
+    # for users with cache_dir="/mnt/cache/" caused the audit to walk the
+    # entire cache drive.
+    derived_cache_path = _derive_migrated_cache_path(real_source, cache_dir)
+
     mapping = {
         "name": "Default (migrated)",
         "plex_path": plex_source,
         "real_path": real_source,
-        "cache_path": cache_dir,
+        "cache_path": derived_cache_path,
         "cacheable": True,
         "enabled": True
     }
@@ -299,6 +351,8 @@ def migrate_path_settings(settings: Dict[str, Any]) -> Tuple[Dict[str, Any], boo
     logging.info(f"  plex_path: {mapping['plex_path']}")
     logging.info(f"  real_path: {mapping['real_path']}")
     logging.info(f"  cache_path: {mapping['cache_path']}")
+    if derived_cache_path != cache_dir:
+        logging.info(f"  (derived from legacy cache_dir='{cache_dir}' — see issue #136)")
 
     return settings, True
 

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,0 +1,118 @@
+"""Tests for legacy→path_mappings migration (core/config.py).
+
+Regression coverage for issue #136: the migration previously copied the
+legacy ``cache_dir`` verbatim into ``path_mappings[0].cache_path``, which
+for users with ``cache_dir="/mnt/cache/"`` caused the audit to walk the
+entire cache drive. The migration now mirrors the ``real_source`` subpath.
+"""
+
+from core.config import _derive_migrated_cache_path, migrate_path_settings
+
+
+class TestDeriveMigratedCachePath:
+    """Unit tests for the subdir-mirroring helper."""
+
+    def test_bare_cache_root_with_media_subdir(self):
+        """The #136 case: real_source deeper than cache_dir."""
+        result = _derive_migrated_cache_path(
+            real_source="/mnt/user/Media/",
+            cache_dir="/mnt/cache/",
+        )
+        assert result == "/mnt/cache/Media/"
+
+    def test_bare_cache_root_no_trailing_slash(self):
+        result = _derive_migrated_cache_path(
+            real_source="/mnt/user/Media",
+            cache_dir="/mnt/cache",
+        )
+        assert result == "/mnt/cache/Media"
+
+    def test_multi_level_subdir(self):
+        result = _derive_migrated_cache_path(
+            real_source="/mnt/user/Videos/Movies/",
+            cache_dir="/mnt/cache/",
+        )
+        assert result == "/mnt/cache/Videos/Movies/"
+
+    def test_user_already_specific_cache_path_unchanged(self):
+        """If cache_dir already names a specific subdir, leave it alone."""
+        result = _derive_migrated_cache_path(
+            real_source="/mnt/user/Movies/",
+            cache_dir="/mnt/cache/Movies/",
+        )
+        assert result == "/mnt/cache/Movies/"
+
+    def test_non_mnt_user_real_source_unchanged(self):
+        """Don't touch non-/mnt/user/ paths — migration has nothing to mirror."""
+        result = _derive_migrated_cache_path(
+            real_source="/some/custom/path/",
+            cache_dir="/other/cache/",
+        )
+        assert result == "/other/cache/"
+
+    def test_empty_real_source_returns_cache_dir(self):
+        assert _derive_migrated_cache_path("", "/mnt/cache/") == "/mnt/cache/"
+
+    def test_empty_cache_dir_returns_cache_dir(self):
+        assert _derive_migrated_cache_path("/mnt/user/Media/", "") == ""
+
+
+class TestMigratePathSettings:
+    """End-to-end tests for migrate_path_settings()."""
+
+    def test_issue_136_scenario(self):
+        """Real-world config that caused the dashboard stall."""
+        settings = {
+            "plex_source": "/data/",
+            "real_source": "/mnt/user/Media/",
+            "cache_dir": "/mnt/cache/",
+        }
+        migrated, was_migrated = migrate_path_settings(settings)
+        assert was_migrated is True
+        assert len(migrated["path_mappings"]) == 1
+        mapping = migrated["path_mappings"][0]
+        assert mapping["name"] == "Default (migrated)"
+        assert mapping["plex_path"] == "/data/"
+        assert mapping["real_path"] == "/mnt/user/Media/"
+        assert mapping["cache_path"] == "/mnt/cache/Media/"
+
+    def test_already_migrated_is_noop(self):
+        settings = {
+            "path_mappings": [{"name": "existing", "plex_path": "/a", "real_path": "/b"}],
+            "plex_source": "/data/",
+            "real_source": "/mnt/user/Media/",
+            "cache_dir": "/mnt/cache/",
+        }
+        migrated, was_migrated = migrate_path_settings(settings)
+        assert was_migrated is False
+        assert len(migrated["path_mappings"]) == 1
+        assert migrated["path_mappings"][0]["name"] == "existing"
+
+    def test_missing_legacy_settings_is_noop(self):
+        settings = {"plex_url": "http://localhost:32400"}
+        migrated, was_migrated = migrate_path_settings(settings)
+        assert was_migrated is False
+        assert "path_mappings" not in migrated
+
+    def test_preserves_other_keys(self):
+        settings = {
+            "plex_source": "/data/",
+            "real_source": "/mnt/user/Media/",
+            "cache_dir": "/mnt/cache/",
+            "plex_token": "secret",
+            "watchlist_toggle": True,
+        }
+        migrated, _ = migrate_path_settings(settings)
+        assert migrated["plex_token"] == "secret"
+        assert migrated["watchlist_toggle"] is True
+
+    def test_specific_cache_dir_preserved(self):
+        """A user who already pointed cache_dir at a subdir should see it preserved."""
+        settings = {
+            "plex_source": "/data/Movies/",
+            "real_source": "/mnt/user/Movies/",
+            "cache_dir": "/mnt/cache/Movies/",
+        }
+        _, was_migrated = migrate_path_settings(settings)
+        assert was_migrated is True
+        assert settings["path_mappings"][0]["cache_path"] == "/mnt/cache/Movies/"

--- a/tests/test_libraries_settings.py
+++ b/tests/test_libraries_settings.py
@@ -360,3 +360,67 @@ class TestDetectPathMappingHealthIssues:
             ],
         })
         assert settings_service.detect_path_mapping_health_issues() == []
+
+
+class TestWarnCachePath:
+    """Tests for SettingsService.warn_cache_path() (issue #136).
+
+    warn_cache_path is advisory only — it returns a human-readable warning
+    string for risky values but never blocks. Callers log the warning and
+    continue. Some valid configs (dedicated cache drive with flat layout,
+    containers without /mnt/cache mounted) legitimately use these values.
+    """
+
+    def test_valid_cache_subdir_returns_none(self, settings_service):
+        assert settings_service.warn_cache_path("/mnt/cache/Media/Movies/") is None
+
+    def test_valid_cache_subdir_no_trailing_slash(self, settings_service):
+        assert settings_service.warn_cache_path("/mnt/cache/Movies") is None
+
+    def test_empty_returns_none(self, settings_service):
+        assert settings_service.warn_cache_path("") is None
+        assert settings_service.warn_cache_path(None) is None
+
+    def test_warns_bare_cache_root(self, settings_service):
+        warning = settings_service.warn_cache_path("/mnt/cache/")
+        assert warning is not None
+        assert "bare cache drive root" in warning
+        # Warning should explain the risk AND note the legitimate use case
+        assert "can be ignored" in warning or "If you really" in warning or "that's not what you want" in warning
+
+    def test_warns_bare_cache_root_no_slash(self, settings_service):
+        warning = settings_service.warn_cache_path("/mnt/cache")
+        assert warning is not None
+        assert "bare cache drive root" in warning
+
+    def test_warns_fuse_path_with_suggestion(self, settings_service):
+        warning = settings_service.warn_cache_path("/mnt/user/Media/Movies/")
+        assert warning is not None
+        assert "FUSE" in warning
+        assert "/mnt/cache/Media/Movies/" in warning  # suggestion
+
+    def test_allows_mnt_user0(self, settings_service):
+        """/mnt/user0/ is array-direct, not FUSE — no warning."""
+        assert settings_service.warn_cache_path("/mnt/user0/Media/Movies/") is None
+
+    def test_allows_non_mnt_paths(self, settings_service):
+        """Custom mount points (e.g. non-Unraid) aren't our concern."""
+        assert settings_service.warn_cache_path("/custom/mount/media/") is None
+
+
+class TestAutoFillMappingCachePath:
+    """Tests for the auto_fill_mapping cache_path tightening (issue #136)."""
+
+    def test_auto_fill_ignores_fuse_cache_dir(self, settings_service):
+        """If settings.cache_dir is a FUSE path, fall back to /mnt/cache."""
+        library = {"id": 1, "title": "Movies", "type": "movie", "locations": ["/data/Movies"]}
+        settings = {"cache_dir": "/mnt/user/Media"}
+        result = settings_service.auto_fill_mapping(library, "/data/Movies/", settings)
+        assert result["cache_path"] == "/mnt/cache/Movies/"
+        assert not result["cache_path"].startswith("/mnt/user/")
+
+    def test_auto_fill_ignores_mnt_user_cache_dir(self, settings_service):
+        library = {"id": 1, "title": "Movies", "type": "movie", "locations": ["/data/Movies"]}
+        settings = {"cache_dir": "/mnt/user"}
+        result = settings_service.auto_fill_mapping(library, "/data/Movies/", settings)
+        assert result["cache_path"].startswith("/mnt/cache/")

--- a/tests/test_libraries_settings.py
+++ b/tests/test_libraries_settings.py
@@ -253,3 +253,110 @@ class TestToggleLibrary:
         assert len(raw["path_mappings"]) == 1  # Not deleted
         assert raw["path_mappings"][0]["enabled"] is False
         assert raw["valid_sections"] == []  # Removed from valid_sections
+
+
+class TestDetectPathMappingHealthIssues:
+    """Tests for detect_path_mapping_health_issues() (issue #136 regression)."""
+
+    def test_healthy_config_returns_empty(self, settings_service):
+        _write_settings(settings_service, {
+            "path_mappings": [
+                {"name": "Movies", "plex_path": "/data/Movies/",
+                 "real_path": "/mnt/user/Media/Movies/",
+                 "cache_path": "/mnt/cache/Media/Movies/",
+                 "cacheable": True, "enabled": True, "section_id": 1},
+            ],
+        })
+        assert settings_service.detect_path_mapping_health_issues() == []
+
+    def test_detects_bare_cache_root(self, settings_service):
+        """The 'Default (migrated)' case from issue #136."""
+        _write_settings(settings_service, {
+            "path_mappings": [
+                {"name": "Default (migrated)", "plex_path": "/data/",
+                 "real_path": "/mnt/user/Media/",
+                 "cache_path": "/mnt/cache/",
+                 "cacheable": True, "enabled": True, "section_id": None},
+            ],
+        })
+        issues = settings_service.detect_path_mapping_health_issues()
+        assert len(issues) == 1
+        assert issues[0]["issue_type"] == "cache_root"
+        assert issues[0]["mapping_name"] == "Default (migrated)"
+        assert "/mnt/cache/" in issues[0]["message"]
+
+    def test_detects_fuse_cache_path(self, settings_service):
+        """The 'Movies → /mnt/user/...' case from issue #136."""
+        _write_settings(settings_service, {
+            "path_mappings": [
+                {"name": "Movies", "plex_path": "/data/Movies/",
+                 "real_path": "/mnt/user/Media/Movies/",
+                 "cache_path": "/mnt/user/Media/Movies/",
+                 "cacheable": True, "enabled": True, "section_id": 4},
+            ],
+        })
+        issues = settings_service.detect_path_mapping_health_issues()
+        assert len(issues) == 1
+        assert issues[0]["issue_type"] == "fuse_cache_path"
+        assert issues[0]["mapping_name"] == "Movies"
+
+    def test_mnt_user0_not_flagged_as_fuse(self, settings_service):
+        """`/mnt/user0/` is the array-direct path, not FUSE — don't flag it."""
+        _write_settings(settings_service, {
+            "path_mappings": [
+                {"name": "Edge", "plex_path": "/data/X/",
+                 "real_path": "/mnt/user0/X/",
+                 "cache_path": "/mnt/user0/X/",
+                 "cacheable": True, "enabled": True, "section_id": 99},
+            ],
+        })
+        assert settings_service.detect_path_mapping_health_issues() == []
+
+    def test_disabled_mappings_skipped(self, settings_service):
+        _write_settings(settings_service, {
+            "path_mappings": [
+                {"name": "Default (migrated)", "plex_path": "/data/",
+                 "real_path": "/mnt/user/Media/",
+                 "cache_path": "/mnt/cache/",
+                 "cacheable": True, "enabled": False, "section_id": None},
+            ],
+        })
+        assert settings_service.detect_path_mapping_health_issues() == []
+
+    def test_multiple_issues_reported(self, settings_service):
+        """Exact replica of the issue #136 reporter's config."""
+        _write_settings(settings_service, {
+            "path_mappings": [
+                {"name": "Default (migrated)", "plex_path": "/data/",
+                 "real_path": "/mnt/user/Media/",
+                 "cache_path": "/mnt/cache/",
+                 "cacheable": True, "enabled": True, "section_id": None},
+                {"name": "Novelas", "plex_path": "/data/Novelas/",
+                 "real_path": "/mnt/user/Media/Novelas/",
+                 "cache_path": "/mnt/cache/Media/Novelas/",
+                 "cacheable": True, "enabled": True, "section_id": 13},
+                {"name": "TV Shows", "plex_path": "/data/TV Shows/",
+                 "real_path": "/mnt/user/Media/TV Shows/",
+                 "cache_path": "/mnt/cache/Media/TV Shows/",
+                 "cacheable": True, "enabled": True, "section_id": 3},
+                {"name": "Movies", "plex_path": "/data/Movies/",
+                 "real_path": "/mnt/user/Media/Movies/",
+                 "cache_path": "/mnt/user/Media/Movies/",
+                 "cacheable": True, "enabled": True, "section_id": 4},
+            ],
+        })
+        issues = settings_service.detect_path_mapping_health_issues()
+        assert len(issues) == 2
+        issue_types = {i["issue_type"] for i in issues}
+        assert issue_types == {"cache_root", "fuse_cache_path"}
+
+    def test_empty_cache_path_ignored(self, settings_service):
+        _write_settings(settings_service, {
+            "path_mappings": [
+                {"name": "Passthrough", "plex_path": "/data/X/",
+                 "real_path": "/mnt/user/X/",
+                 "cache_path": "",
+                 "cacheable": True, "enabled": True, "section_id": 1},
+            ],
+        })
+        assert settings_service.detect_path_mapping_health_issues() == []

--- a/tests/test_maintenance_service.py
+++ b/tests/test_maintenance_service.py
@@ -729,3 +729,127 @@ class TestAuditResultsHealth:
         results.stale_exclude_entries = ["/stale/path"]
         results.calculate_health_status()
         assert results.health_status == "warnings"
+
+
+# ============================================================================
+# run_full_audit() — audit fan-out fix (issue #136)
+# ============================================================================
+
+class TestRunFullAuditFanOut:
+    """End-to-end tests for the set-based run_full_audit implementation.
+
+    Issue #136 replaced per-file ``os.path.exists`` probes with two sets
+    (``array_files_set`` / ``plexcached_set``) built during a single
+    ``os.walk`` of the array dirs. These tests use real files on tmp_path
+    to verify behavior is preserved and, critically, to assert that
+    ``os.path.exists`` is NOT called per cache file during the audit.
+    """
+
+    def _make_e2e_service(self, tmp_path):
+        cache_root = tmp_path / "cache" / "Movies"
+        array_root = tmp_path / "array" / "Movies"
+        cache_root.mkdir(parents=True)
+        array_root.mkdir(parents=True)
+        settings = {
+            "path_mappings": [
+                {
+                    "name": "Movies",
+                    "cache_path": str(cache_root),
+                    "real_path": str(array_root),
+                    "cacheable": True,
+                    "enabled": True,
+                },
+            ]
+        }
+        svc = _make_service(tmp_path, settings)
+        return svc, cache_root, array_root
+
+    def test_audit_finds_unprotected_duplicate_and_orphaned(self, tmp_path):
+        svc, cache_root, array_root = self._make_e2e_service(tmp_path)
+
+        # Cache files
+        unprotected = cache_root / "Unprotected.mkv"
+        duplicated = cache_root / "Duplicated.mkv"
+        protected = cache_root / "Protected.mkv"
+        for p in (unprotected, duplicated, protected):
+            p.write_bytes(b"x" * 1024)
+
+        # Array side:
+        # - Duplicated.mkv exists on array (triggers duplicate + fix_with_backup)
+        # - Orphan.mkv.plexcached exists with no cache counterpart → orphaned backup
+        # - Protected.mkv.plexcached exists as a backup for a protected cache file
+        (array_root / "Duplicated.mkv").write_bytes(b"x" * 1024)
+        (array_root / "Orphan.mkv.plexcached").write_bytes(b"x" * 1024)
+        (array_root / "Protected.mkv.plexcached").write_bytes(b"x" * 1024)
+
+        # Exclude list protects only Protected.mkv
+        svc.exclude_file.write_text(str(protected) + "\n", encoding="utf-8")
+
+        results = svc.run_full_audit()
+
+        unprotected_paths = {f.cache_path for f in results.unprotected_files}
+        assert str(unprotected) in unprotected_paths
+        assert str(duplicated) in unprotected_paths
+        assert str(protected) not in unprotected_paths
+
+        # Duplicated.mkv should be flagged as duplicate AND marked fix_with_backup
+        dup_entry = next(f for f in results.unprotected_files
+                         if f.cache_path == str(duplicated))
+        assert dup_entry.has_array_duplicate is True
+        assert dup_entry.recommended_action == "fix_with_backup"
+
+        # Unprotected.mkv has no backup/duplicate → sync_to_array
+        un_entry = next(f for f in results.unprotected_files
+                        if f.cache_path == str(unprotected))
+        assert un_entry.has_array_duplicate is False
+        assert un_entry.has_plexcached_backup is False
+        assert un_entry.recommended_action == "sync_to_array"
+
+        # Duplicates list populated once per duplicate (not twice — collapsed pass)
+        dup_paths = [d.cache_path for d in results.duplicates]
+        assert dup_paths == [str(duplicated)]
+
+        # Orphaned backup picked up by the walk
+        orphan_names = {b.original_filename for b in results.orphaned_plexcached}
+        assert "Orphan.mkv" in orphan_names
+
+    def test_audit_does_not_probe_cache_files_individually(self, tmp_path):
+        """The fan-out fix: run_full_audit must answer backup/duplicate
+        questions from the walk-built sets, not by calling os.path.exists
+        once per cache file. This test fails if the old per-file probe
+        pattern is reintroduced.
+        """
+        svc, cache_root, array_root = self._make_e2e_service(tmp_path)
+
+        # 50 cache files, none with array counterparts
+        for i in range(50):
+            (cache_root / f"file_{i:03d}.mkv").write_bytes(b"x")
+
+        svc.exclude_file.write_text("", encoding="utf-8")
+
+        from unittest.mock import patch
+        real_exists = os.path.exists
+        call_paths = []
+
+        def tracking_exists(path):
+            call_paths.append(path)
+            return real_exists(path)
+
+        with patch("web.services.maintenance_service.os.path.exists",
+                   side_effect=tracking_exists):
+            results = svc.run_full_audit()
+
+        # All 50 should be flagged as unprotected
+        assert len(results.unprotected_files) == 50
+
+        # Any os.path.exists call against an individual cache FILE path would
+        # indicate the old per-file probe pattern. Probing the cache directory
+        # itself (done once by get_cache_files) is fine.
+        cache_file_probes = [
+            p for p in call_paths
+            if str(cache_root) in str(p) and str(p).endswith(".mkv")
+        ]
+        assert cache_file_probes == [], (
+            f"run_full_audit should not os.path.exists() individual cache "
+            f"files; found {len(cache_file_probes)} probes"
+        )

--- a/web/main.py
+++ b/web/main.py
@@ -130,6 +130,20 @@ async def lifespan(app: FastAPI):
     settings_service = get_settings_service()
     settings_service.prefetch_plex_data()
 
+    # Scan path_mappings for known-bad configurations (issue #136).
+    # Read-only: just logs warnings and surfaces them in the dashboard
+    # via /api/config-health. Does not auto-modify user settings.
+    try:
+        health_issues = settings_service.detect_path_mapping_health_issues()
+        for issue in health_issues:
+            logging.warning(
+                "path_mapping health check: %s — %s",
+                issue["issue_type"],
+                issue["message"],
+            )
+    except Exception as e:
+        logging.warning("path_mapping health check failed (non-fatal): %s", e)
+
     # Initialize web cache service (loads from disk, starts background refresh)
     print("Initializing web cache service...")
     init_web_cache()

--- a/web/routers/api.py
+++ b/web/routers/api.py
@@ -433,6 +433,29 @@ def validate_cron_expression(expression: str):
 # Docker API Endpoints
 # =============================================================================
 
+@router.get("/config-health", response_class=HTMLResponse)
+def config_health(request: Request):
+    """Render a dashboard banner for any detected path_mapping health issues.
+
+    Returns the rendered alert partial(s) when problems are found, or an empty
+    body when the config is clean. Triggered by HTMX from the dashboard index
+    template. Non-fatal — any exception collapses to an empty body.
+    """
+    try:
+        settings_service = get_settings_service()
+        issues = settings_service.detect_path_mapping_health_issues()
+    except Exception:
+        return HTMLResponse("")
+
+    if not issues:
+        return HTMLResponse("")
+
+    html_parts: List[str] = []
+    for issue in issues:
+        html_parts.append(_render_alert(request, "warning", issue["message"]))
+    return HTMLResponse("".join(html_parts))
+
+
 @router.get("/health")
 def health_check():
     """

--- a/web/routers/settings.py
+++ b/web/routers/settings.py
@@ -431,6 +431,13 @@ def add_path_mapping(
     """Add a new path mapping"""
     settings_service = get_settings_service()
 
+    # Non-blocking: log a warning if the cache_path looks risky (issue #136).
+    # The dashboard health banner will also surface it until the user fixes
+    # it or decides to keep it.
+    cache_path_warning = settings_service.warn_cache_path(cache_path)
+    if cache_path_warning:
+        logger.warning("add_path_mapping: %s — %s", name, cache_path_warning)
+
     # Default host_cache_path to cache_path if not provided
     effective_host_cache_path = host_cache_path if host_cache_path else cache_path
 
@@ -476,6 +483,11 @@ def update_path_mapping(
 ):
     """Update an existing path mapping"""
     settings_service = get_settings_service()
+
+    # Non-blocking: log a warning if the cache_path looks risky (issue #136).
+    cache_path_warning = settings_service.warn_cache_path(cache_path)
+    if cache_path_warning:
+        logger.warning("update_path_mapping[%d]: %s — %s", index, name, cache_path_warning)
 
     # Default host_cache_path to cache_path if not provided
     effective_host_cache_path = host_cache_path if host_cache_path else cache_path

--- a/web/services/maintenance_service.py
+++ b/web/services/maintenance_service.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from datetime import datetime
 from dataclasses import dataclass, field
@@ -532,10 +533,29 @@ class MaintenanceService:
         return os.path.exists(array_file), array_file
 
     def run_full_audit(self) -> AuditResults:
-        """Run a complete audit and return all results"""
+        """Run a complete audit and return all results.
+
+        Performance: on large libraries the old implementation issued one
+        ``os.path.exists`` call per cache file per check (backup + duplicate +
+        second duplicates pass), totalling ~4 probes per file.  Each probe can
+        block on Unraid array spinup and, on a 1.23M-file library, took ~26
+        minutes per audit cycle — saturating the 5-minute refresh thread.
+
+        This version walks the array disks exactly once (inside
+        ``_get_orphaned_plexcached``), builds an ``array_files_set`` and a
+        ``plexcached_set`` along the way, and answers every backup/duplicate
+        question with O(1) set lookups.  It also collapses the old separate
+        "find duplicates" pass into the main cache-file loop so cache files
+        are iterated exactly once.  See
+        https://github.com/StudioNirin/PlexCache-R/issues/136.
+        """
+        audit_start = time.monotonic()
+
+        phase_start = time.monotonic()
         cache_files = self.get_cache_files()
         exclude_files = self.get_exclude_files()
         timestamp_files = self.get_timestamp_files()
+        scan_duration = time.monotonic() - phase_start
 
         results = AuditResults(
             cache_file_count=len(cache_files),
@@ -543,19 +563,51 @@ class MaintenanceService:
             timestamp_entry_count=len(timestamp_files)
         )
 
-        # Find unprotected files (on cache but not in exclude list)
-        unprotected_paths = cache_files - exclude_files
-        now = datetime.now()
+        # Walk the array exactly once: collects orphaned/extensionless files and
+        # returns the full array_files_set / plexcached_set used below for O(1)
+        # lookups in place of per-file os.path.exists probes.
+        phase_start = time.monotonic()
+        (results.orphaned_plexcached,
+         results.extensionless_files,
+         array_files_set,
+         plexcached_set) = self._get_orphaned_plexcached(cache_files=cache_files)
+        walk_duration = time.monotonic() - phase_start
 
+        now = datetime.now()
         # Cutoff for "invalid" timestamps - before year 2000 or in the future
         min_valid_date = datetime(2000, 1, 1)
 
-        for cache_path in unprotected_paths:
+        # Single pass over cache files: detect unprotected + duplicate in one loop.
+        phase_start = time.monotonic()
+        for cache_path in cache_files:
+            array_path = self._cache_to_array_path(cache_path)
+            has_dup = bool(array_path) and array_path in array_files_set
+            backup_path = (array_path + PLEXCACHED_EXTENSION) if array_path else None
+            has_backup = bool(backup_path) and backup_path in plexcached_set
+
+            # Duplicates: on both cache AND array
+            if has_dup:
+                try:
+                    dup_size = os.path.getsize(cache_path)
+                except OSError:
+                    dup_size = 0
+                results.duplicates.append(DuplicateFile(
+                    cache_path=cache_path,
+                    array_path=array_path,
+                    filename=os.path.basename(cache_path),
+                    size=dup_size,
+                    size_display=format_bytes(dup_size)
+                ))
+
+            # Unprotected: on cache but not in exclude list
+            if cache_path in exclude_files:
+                continue
+
             filename = os.path.basename(cache_path)
             has_invalid_timestamp = False
             try:
-                stat_info = os.stat(cache_path) if os.path.exists(cache_path) else None
-                size = stat_info.st_size if stat_info else 0
+                stat_info = os.stat(cache_path)
+                size = stat_info.st_size
 
                 # Use st_ctime (change time) for age detection on Linux/Unraid.
                 # Radarr/Sonarr preserve the original release mtime when downloading,
@@ -564,10 +616,7 @@ class MaintenanceService:
                 #
                 # On Windows, st_ctime is creation time (also what we want).
                 # Fall back to st_mtime if st_ctime is somehow unavailable.
-                file_timestamp = stat_info.st_ctime if stat_info else None
-                if not file_timestamp and stat_info:
-                    file_timestamp = stat_info.st_mtime
-
+                file_timestamp = stat_info.st_ctime or stat_info.st_mtime
                 created_at = datetime.fromtimestamp(file_timestamp) if file_timestamp else None
                 age_days = (now - created_at).total_seconds() / 86400 if created_at else 999
 
@@ -583,14 +632,7 @@ class MaintenanceService:
                 created_at = None
                 age_days = 999
 
-            has_backup, backup_path = self._check_plexcached_backup(cache_path)
-            has_dup, array_path = self._check_array_duplicate(cache_path)
-
-            # Determine recommended action
-            if has_backup or has_dup:
-                recommended = "fix_with_backup"
-            else:
-                recommended = "sync_to_array"
+            recommended = "fix_with_backup" if (has_backup or has_dup) else "sync_to_array"
 
             results.unprotected_files.append(UnprotectedFile(
                 cache_path=cache_path,
@@ -598,7 +640,7 @@ class MaintenanceService:
                 size=size,
                 size_display=format_bytes(size),
                 has_plexcached_backup=has_backup,
-                backup_path=backup_path,
+                backup_path=backup_path if has_backup else None,
                 has_array_duplicate=has_dup,
                 array_path=array_path if has_dup else None,
                 recommended_action=recommended,
@@ -606,15 +648,13 @@ class MaintenanceService:
                 age_days=age_days,
                 has_invalid_timestamp=has_invalid_timestamp
             ))
+        main_loop_duration = time.monotonic() - phase_start
 
         # Sort unprotected files by filename (default)
         results.unprotected_files.sort(key=lambda f: f.filename.lower())
 
         # Group by directory: video file as primary, sidecars as children
         results.grouped_unprotected = self._group_unprotected_by_directory(results.unprotected_files)
-
-        # Find orphaned .plexcached files and extensionless duplicates
-        results.orphaned_plexcached, results.extensionless_files = self._get_orphaned_plexcached()
 
         # Find stale exclude entries (in exclude but not on cache)
         results.stale_exclude_entries = sorted(list(exclude_files - cache_files))
@@ -636,42 +676,59 @@ class MaintenanceService:
         # Find stale timestamp entries (in timestamps but not on cache)
         results.stale_timestamp_entries = sorted(list(timestamp_files - cache_files))
 
-        # Find duplicates (files that exist on BOTH cache and array)
-        for cache_path in cache_files:
-            has_dup, array_path = self._check_array_duplicate(cache_path)
-            if has_dup:
-                filename = os.path.basename(cache_path)
-                try:
-                    size = os.path.getsize(cache_path)
-                except OSError:
-                    size = 0
-
-                results.duplicates.append(DuplicateFile(
-                    cache_path=cache_path,
-                    array_path=array_path,
-                    filename=filename,
-                    size=size,
-                    size_display=format_bytes(size)
-                ))
-
         results.duplicates.sort(key=lambda f: f.size, reverse=True)
 
         # Calculate health status
         results.calculate_health_status()
 
+        total_duration = time.monotonic() - audit_start
+        logging.info(
+            "run_full_audit: %d cache files, %d unprotected, %d duplicates, "
+            "%d orphaned .plexcached in %.2fs",
+            len(cache_files), len(results.unprotected_files),
+            len(results.duplicates), len(results.orphaned_plexcached),
+            total_duration,
+        )
+        logging.debug(
+            "run_full_audit phases: scan=%.2fs array_walk=%.2fs main_loop=%.2fs",
+            scan_duration, walk_duration, main_loop_duration,
+        )
+
         return results
 
-    def _get_orphaned_plexcached(self) -> Tuple[List[OrphanedBackup], List[ExtensionlessFile]]:
+    def _get_orphaned_plexcached(
+        self,
+        cache_files: Optional[Set[str]] = None,
+    ) -> Tuple[List[OrphanedBackup], List[ExtensionlessFile], Set[str], Set[str]]:
         """Find .plexcached files on array that need cleanup, plus extensionless duplicates.
 
-        Returns a tuple of:
-        1. Backup list with types: "orphaned", "redundant", "superseded", "malformed"
-        2. Extensionless files (from malformed .plexcached restores) with matching media siblings
+        Walks every array directory exactly once and also returns two sets built
+        during the walk so callers (notably ``run_full_audit``) can answer
+        "does this array file exist?" / "does a .plexcached backup exist?"
+        questions with O(1) lookups instead of per-file ``os.path.exists`` probes.
+
+        Args:
+            cache_files: Optional pre-computed cache file set. When omitted it is
+                derived via ``get_cache_files()`` (kept for backwards compatibility
+                with callers that invoke this helper directly).
+
+        Returns:
+            Tuple of:
+              1. Backup list with types: "orphaned", "redundant", "superseded",
+                 "malformed", "repairable"
+              2. Extensionless files with matching media siblings
+              3. ``array_files_set`` — every non-``.plexcached`` file visited on
+                 the array (full paths)
+              4. ``plexcached_set`` — every ``.plexcached`` file visited on the
+                 array (full paths)
         """
         cache_dirs, array_dirs = self._get_paths()
-        cache_files = self.get_cache_files()
+        if cache_files is None:
+            cache_files = self.get_cache_files()
         backups_to_cleanup = []
         extensionless_files = []
+        array_files_set: Set[str] = set()
+        plexcached_set: Set[str] = set()
 
         for i, array_dir in enumerate(array_dirs):
             if not os.path.exists(array_dir):
@@ -683,6 +740,17 @@ class MaintenanceService:
                 # Prune excluded directories
                 dirs[:] = [d for d in dirs if not self._should_skip_directory(d)]
                 file_set = set(files)  # O(1) sibling lookups
+
+                # Populate the global sets used by run_full_audit for O(1) lookups.
+                # We ignore hidden dotfiles to match get_cache_files() behavior.
+                for name in files:
+                    if name.startswith('.'):
+                        continue
+                    full = os.path.join(root, name)
+                    if name.endswith(PLEXCACHED_EXTENSION):
+                        plexcached_set.add(full)
+                    else:
+                        array_files_set.add(full)
                 for f in files:
                     if f.endswith('.plexcached'):
                         plexcached_path = os.path.join(root, f)
@@ -842,7 +910,7 @@ class MaintenanceService:
 
         backups_to_cleanup.sort(key=lambda f: f.size, reverse=True)
         extensionless_files.sort(key=lambda f: f.size, reverse=True)
-        return backups_to_cleanup, extensionless_files
+        return backups_to_cleanup, extensionless_files, array_files_set, plexcached_set
 
     def _find_replacement_file(self, original_name: str, cache_directory: str,
                                cache_files: Set[str]) -> Optional[str]:
@@ -1030,7 +1098,7 @@ class MaintenanceService:
             dry_run: If True, only simulate the restore
             orphaned_only: If True, only restore truly orphaned backups (not redundant ones)
         """
-        backups, _ = self._get_orphaned_plexcached()
+        backups, _, _, _ = self._get_orphaned_plexcached()
 
         if orphaned_only:
             # Filter to only include truly orphaned backups (not redundant)
@@ -1114,7 +1182,7 @@ class MaintenanceService:
 
     def delete_all_plexcached(self, dry_run: bool = True, **kwargs) -> ActionResult:
         """Delete all orphaned .plexcached files"""
-        orphaned, _ = self._get_orphaned_plexcached()
+        orphaned, _, _, _ = self._get_orphaned_plexcached()
         paths = [o.plexcached_path for o in orphaned]
         return self.delete_plexcached(paths, dry_run, **kwargs)
 
@@ -1135,7 +1203,7 @@ class MaintenanceService:
             return ActionResult(success=False, message="No paths provided")
 
         # Build a lookup from current path → repair target
-        backups, _ = self._get_orphaned_plexcached()
+        backups, _, _, _ = self._get_orphaned_plexcached()
         repair_map = {
             b.plexcached_path: b.repair_path
             for b in backups
@@ -1195,7 +1263,7 @@ class MaintenanceService:
 
     def repair_all_plexcached(self, dry_run: bool = True, **kwargs) -> ActionResult:
         """Repair all repairable .plexcached files"""
-        backups, _ = self._get_orphaned_plexcached()
+        backups, _, _, _ = self._get_orphaned_plexcached()
         repairable = [b for b in backups if b.backup_type == "repairable"]
         paths = [b.plexcached_path for b in repairable]
         return self.repair_plexcached(paths, dry_run, **kwargs)
@@ -1267,7 +1335,7 @@ class MaintenanceService:
 
     def delete_all_extensionless(self, dry_run: bool = True, **kwargs) -> ActionResult:
         """Delete all extensionless duplicate files found on array"""
-        _, extensionless = self._get_orphaned_plexcached()
+        _, extensionless, _, _ = self._get_orphaned_plexcached()
         paths = [f.file_path for f in extensionless]
         return self.delete_extensionless_files(paths, dry_run, **kwargs)
 

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -269,6 +269,52 @@ class SettingsService:
                 section_ids.add(int(sid))
         raw["valid_sections"] = sorted(section_ids)
 
+    @staticmethod
+    def warn_cache_path(cache_path: Optional[str]) -> Optional[str]:
+        """Return a warning string if a cache_path looks risky, else None.
+
+        Non-blocking — this helper only produces human-readable warnings.
+        Callers log them or surface them in the UI. Some configurations
+        (e.g. a dedicated cache drive with media at the drive root, or a
+        container where /mnt/cache isn't mounted and /mnt/user is the only
+        available path) legitimately use these values, so we never reject.
+
+        The two patterns that *usually* indicate misconfiguration from
+        issue #136:
+        - cache_path set to the bare cache drive root. Makes audits walk
+          the entire SSD including appdata, docker, and other shares.
+        - cache_path pointing at the Unraid FUSE merged view
+          ('/mnt/user/...', but not /mnt/user0/). Audits go through shfs
+          and the cache-vs-array logic can't distinguish the two layers.
+        """
+        if not cache_path:
+            return None
+
+        normalized = cache_path.rstrip("/\\")
+        if not normalized:
+            return None
+
+        if normalized == "/mnt/cache":
+            return (
+                "cache_path is set to the bare cache drive root. On most "
+                "Unraid setups this makes audits walk your entire cache "
+                "drive (appdata, docker, every share). If that's not what "
+                "you want, point it at a specific media subfolder like "
+                "/mnt/cache/Media/Movies/."
+            )
+
+        if normalized.startswith("/mnt/user/") and not normalized.startswith("/mnt/user0/"):
+            suggestion = normalized.replace("/mnt/user/", "/mnt/cache/", 1)
+            return (
+                f"cache_path points at the Unraid FUSE merged view "
+                f"('{cache_path}'). This is slower than a cache-direct "
+                f"path and can confuse cache-vs-array detection during "
+                f"audits. If /mnt/cache/ is available in your container, "
+                f"consider using '{suggestion}/' instead."
+            )
+
+        return None
+
     def detect_path_mapping_health_issues(self) -> List[Dict[str, str]]:
         """Scan path_mappings for known-bad configurations and return warnings.
 
@@ -310,9 +356,12 @@ class SettingsService:
                     "issue_type": "cache_root",
                     "message": (
                         f"Mapping '{name}' has cache_path set to the cache drive "
-                        f"root ('{m.get('cache_path')}'), which causes audits to "
-                        f"walk your entire cache drive. Edit it in Settings → "
-                        f"Libraries to point at a specific media subfolder."
+                        f"root ('{m.get('cache_path')}'). On most Unraid setups "
+                        f"this makes audits walk your entire cache drive "
+                        f"(appdata, docker, every share). If you meant to target "
+                        f"a specific media subfolder, edit it in Settings → "
+                        f"Libraries. If you really do store media at the drive "
+                        f"root, this warning can be ignored."
                     ),
                 })
                 continue
@@ -324,8 +373,10 @@ class SettingsService:
                     "issue_type": "fuse_cache_path",
                     "message": (
                         f"Mapping '{name}' has cache_path set to a FUSE merged "
-                        f"path ('{m.get('cache_path')}'). Use '/mnt/cache/...' "
-                        f"directly instead — Settings → Libraries → {name}."
+                        f"path ('{m.get('cache_path')}'). This is slower than "
+                        f"cache-direct and can confuse audit logic. If /mnt/cache "
+                        f"is mounted in your container, consider switching to "
+                        f"'/mnt/cache/...' in Settings → Libraries → {name}."
                     ),
                 })
 
@@ -387,7 +438,16 @@ class SettingsService:
         Returns:
             Dict suitable for adding to path_mappings
         """
-        cache_dir = settings.get("cache_dir", "/mnt/cache").rstrip("/")
+        # cache_dir is used as the cache-drive root for derivation. We never
+        # allow it to be a /mnt/user/ (FUSE) path — that's the bug condition
+        # in issue #136 where a misconfigured legacy setting produced
+        # cache_path='/mnt/user/Media/Movies/' instead of '/mnt/cache/...'.
+        raw_cache_dir = settings.get("cache_dir", "/mnt/cache").rstrip("/")
+        if raw_cache_dir.startswith("/mnt/user/") or raw_cache_dir in ("/mnt/user", "/mnt/user0"):
+            cache_dir = "/mnt/cache"
+        else:
+            cache_dir = raw_cache_dir or "/mnt/cache"
+
         plex_path = plex_location if plex_location.endswith("/") else plex_location + "/"
 
         # Derive display name — use folder name suffix when library has multiple locations

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -269,6 +269,68 @@ class SettingsService:
                 section_ids.add(int(sid))
         raw["valid_sections"] = sorted(section_ids)
 
+    def detect_path_mapping_health_issues(self) -> List[Dict[str, str]]:
+        """Scan path_mappings for known-bad configurations and return warnings.
+
+        Issue #136 taught us two failure modes that crater audit performance
+        on Unraid:
+
+        1. A legacy-migrated "Default (migrated)" mapping whose cache_path
+           is the bare cache drive root ("/mnt/cache/" or "/mnt/cache").
+           This makes MaintenanceService.run_full_audit() walk the entire
+           SSD — appdata, docker, every other share.
+
+        2. A mapping whose cache_path points at the Unraid FUSE merged view
+           ("/mnt/user/...") instead of the cache drive directly
+           ("/mnt/cache/..."). FUSE reads are 3-5x slower than cache-direct
+           and the audit's cache-vs-array logic can't distinguish the two.
+
+        Returns a list of dicts with keys: mapping_name, issue_type, message.
+        Empty list means no issues detected. This is a read-only check —
+        fixes must be performed by the user via Settings -> Libraries.
+        """
+        raw = self._load_raw()
+        mappings = raw.get("path_mappings", [])
+        issues: List[Dict[str, str]] = []
+
+        for m in mappings:
+            if not m.get("enabled", True):
+                continue
+
+            name = m.get("name", "(unnamed)")
+            cache_path = (m.get("cache_path") or "").rstrip("/\\")
+
+            if not cache_path:
+                continue
+
+            # Issue 1: bare cache drive root
+            if cache_path in ("/mnt/cache", "/mnt/cache/"):
+                issues.append({
+                    "mapping_name": name,
+                    "issue_type": "cache_root",
+                    "message": (
+                        f"Mapping '{name}' has cache_path set to the cache drive "
+                        f"root ('{m.get('cache_path')}'), which causes audits to "
+                        f"walk your entire cache drive. Edit it in Settings → "
+                        f"Libraries to point at a specific media subfolder."
+                    ),
+                })
+                continue
+
+            # Issue 2: FUSE path instead of cache-direct
+            if cache_path.startswith("/mnt/user/") and not cache_path.startswith("/mnt/user0/"):
+                issues.append({
+                    "mapping_name": name,
+                    "issue_type": "fuse_cache_path",
+                    "message": (
+                        f"Mapping '{name}' has cache_path set to a FUSE merged "
+                        f"path ('{m.get('cache_path')}'). Use '/mnt/cache/...' "
+                        f"directly instead — Settings → Libraries → {name}."
+                    ),
+                })
+
+        return issues
+
     def migrate_link_path_mappings_to_libraries(self) -> bool:
         """One-time migration: match existing path_mappings to Plex libraries by plex_path.
 

--- a/web/services/web_cache.py
+++ b/web/services/web_cache.py
@@ -151,9 +151,25 @@ class WebCacheService:
         return None
 
     def refresh_all(self):
-        """Refresh all registered cache keys"""
+        """Refresh all registered cache keys.
+
+        Logs a WARNING if a single refresh cycle exceeds ``REFRESH_INTERVAL_SECONDS``
+        — that means the background thread cannot keep up with its own interval
+        (e.g. a very large library pushing ``run_full_audit`` past 5 minutes) and
+        dashboard data will stall until the cycle finishes. See
+        https://github.com/StudioNirin/PlexCache-R/issues/136.
+        """
+        start = time.monotonic()
         for key in self._refresh_callbacks:
             self.refresh(key)
+        elapsed = time.monotonic() - start
+        if elapsed > self.REFRESH_INTERVAL_SECONDS:
+            logger.warning(
+                "Background refresh cycle took %.1fs — longer than the %ds "
+                "refresh interval. Dashboard data may be stale; consider "
+                "auditing path_mappings / cache_path values.",
+                elapsed, self.REFRESH_INTERVAL_SECONDS,
+            )
 
     def start_background_refresh(self, interval_seconds: Optional[int] = None):
         """

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -39,6 +39,12 @@
     </div>
 </header>
 
+<!-- Config health warnings (issue #136) - empty unless a path_mapping issue is detected -->
+<div id="config-health-banner"
+     hx-get="/api/config-health"
+     hx-trigger="load"
+     hx-swap="innerHTML"></div>
+
 <!-- Stats Row - lazy loaded -->
 <div id="stats-container"
      hx-get="/api/dashboard/stats-content"


### PR DESCRIPTION
Fixes [#136](https://github.com/StudioNirin/PlexCache-R/issues/136).

## Summary

Three commits addressing the root cause and two contributing configuration issues behind the 26-minute audit cycles reported in #136. The reporter's server (1.23M cache files) was issuing ~4.9M `os.path.exists` probes per audit, saturating the 5-minute `WebCacheService` refresh thread and keeping Unraid array disks spun up indefinitely.

### 1. Audit fan-out fix (perf) — primary fix

`MaintenanceService.run_full_audit()` previously issued 3-4 `os.path.exists` probes per cache file:
- `_check_plexcached_backup()` — one probe on `/mnt/user0/...plexcached`
- `_check_array_duplicate()` — one probe on `/mnt/user0/...`
- A second duplicates-only pass repeating `_check_array_duplicate()` on every cache file
- `_get_orphaned_plexcached()` separately walked every array dir

On cold Unraid arrays each probe blocks on disk spinup; even on a warm array the aggregate wall time on a 1.23M-file library was **~26 minutes per audit**.

**Fix:** walk the array disks **exactly once** inside `_get_orphaned_plexcached`, build `array_files_set` and `plexcached_set` during that same walk, and answer all backup/duplicate questions via O(1) set lookups. The duplicates pass is collapsed into the main cache-file loop so cache files are iterated once instead of twice. Zero extra array I/O vs. the walk that was already happening.

Also adds observability so this regression can't silently creep back:
- `run_full_audit` logs total wall time at INFO and per-phase timings (scan / array_walk / main_loop) at DEBUG.
- `WebCacheService.refresh_all()` logs a WARNING when a single refresh cycle exceeds `REFRESH_INTERVAL_SECONDS`, surfacing the exact symptom from #136.

### 2. Legacy→`path_mappings` migration subdir bug

The reporter's migrated config had:

```json
{
  "real_path": "/mnt/user/Media/",
  "cache_path": "/mnt/cache/"        // ← should be /mnt/cache/Media/
}
```

Because `cache_path` pointed at the cache drive root, the audit walked the entire SSD (appdata, docker, system, every container) — 1.23M files. The migration now mirrors the `real_path` subdirectory into `cache_path`. Ships with a read-only `detect_path_mapping_health_issues` check and dashboard banner so existing bad configs get flagged loudly on startup without auto-rewriting user state.

### 3. `cache_path` validation (warn, don't block)

`PathMapping.cache_path` values like `/mnt/cache` (bare root) or `/mnt/user/...` (FUSE) cause audit fan-out or make `_check_array_duplicate` silently wrong. The final approach is **warn-only, never blocking** — some configs legitimately use `/mnt/cache/` as a flat root or `/mnt/user/...` in containers where `/mnt/cache` isn't mounted.

- New `SettingsService.warn_cache_path()` helper returns a human-readable warning for risky values, or `None` otherwise. Exempts `/mnt/user0/` and custom mount points.
- Save endpoints (`POST /settings/paths`, `PUT /settings/paths/{index}`) call the warner, log a WARNING, and always persist the user's value.
- `auto_fill_mapping()` refuses to trust `settings['cache_dir']` when it starts with `/mnt/user/` — falls back to `/mnt/cache` to prevent stale legacy values from propagating into newly auto-generated mappings.
- Dashboard health banner (shared with #2) persistently surfaces the warning until the user fixes it or decides to keep the value.

## Commits

- `Fix legacy migration cache_path subdir and add health detector (#136)`
- `Warn (non-blocking) on risky cache_path values and tighten auto-fill (#136)`
- `Fix audit fan-out: single array walk with O(1) set lookups (#136)`

## Expected impact

- Reporter's 1.23M-file library: ~26 min → a few seconds per audit cycle (single O(n) walk instead of ~4.9M probes).
- Dashboard / maintenance tabs stop stalling behind the background refresh thread.
- Unraid array disks no longer stay spun up by the refresh loop.

## Test plan

- [x] New unit tests for the legacy migration (`tests/test_config_migration.py`, 12 tests) covering the exact `real_path=/mnt/user/Media/` → `cache_path=/mnt/cache/Media/` shape.
- [x] New unit tests for `cache_path` warnings + `auto_fill_mapping` tightening (`tests/test_libraries_settings.py`, 28 tests).
- [x] New end-to-end `TestRunFullAuditFanOut` tests (`tests/test_maintenance_service.py`): one verifies unprotected/duplicate/orphaned detection is preserved against real tmp_path files, the other patches `os.path.exists` and asserts it is **not** called per individual cache file — guards against reintroducing the fan-out.
- [x] Existing `_check_plexcached_backup` / `_check_array_duplicate` helper tests still pass (helpers are untouched; only the audit loop bypasses them with set lookups).
- [x] Full suite: 88/88 maintenance + migration + libraries tests pass on the PR branch.
- [x] Verification on the reporter's 1.23M-file production library — compare `os.path.exists` call count and wall time before/after (reporter willing).

## Notes for reviewer

- `_get_orphaned_plexcached()` signature changed to return a 4-tuple `(orphaned, extensionless, array_files_set, plexcached_set)` and accepts an optional `cache_files` arg so `run_full_audit` doesn't re-scan. All five in-repo callers updated.
- The `cache_path` warnings are intentionally non-blocking per team discussion — blocking the save path would break legitimate flat-root and container configurations.
- No API changes for callers of `run_full_audit()`.