### PR TITLE
Docker mount validation via /proc/self/mountinfo (#139)

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -85,6 +85,8 @@ class PlexCacheApp:
 
         # Stop request flag (for web UI to abort operations)
         self._stop_requested = False
+        # Docker mount validation result (False = unsafe, blocks file moves)
+        self._mount_paths_safe = True
 
     def _record_file_activity(self, action: str, filename: str, size_bytes: int) -> None:
         """Record a file operation to the shared activity feed (CLI runs only).
@@ -201,6 +203,9 @@ class PlexCacheApp:
             # Check paths
             logging.debug("Validating paths...")
             self._check_paths()
+
+            if not self._mount_paths_safe and self.file_mover:
+                self.file_mover.mount_paths_validated = False
 
             # Connect to Plex
             self._connect_to_plex()
@@ -765,44 +770,37 @@ class PlexCacheApp:
 
     def _check_paths(self) -> None:
         """Check that required paths exist and are accessible."""
-        # In Docker, validate that mount points are properly configured
-        # This prevents writing massive amounts of data inside the container
+        # In Docker, validate that paths are backed by real bind mounts
+        # (issue #139) — prevents writing into the overlay filesystem
         if self.system_detector.is_docker:
-            paths_to_validate = set()
+            mount_issues = []
 
-            # Collect paths from path_mappings
             if self.config_manager.paths.path_mappings:
                 for mapping in self.config_manager.paths.path_mappings:
-                    if mapping.enabled:
-                        if mapping.real_path:
-                            # Extract base mount point (e.g., /mnt/user from /mnt/user/Movies/)
-                            parts = mapping.real_path.strip('/').split('/')
-                            if len(parts) >= 2:
-                                paths_to_validate.add('/' + '/'.join(parts[:2]))
-                        if mapping.cache_path:
-                            parts = mapping.cache_path.strip('/').split('/')
-                            if len(parts) >= 2:
-                                paths_to_validate.add('/' + '/'.join(parts[:2]))
+                    if not mapping.enabled:
+                        continue
+                    for path_val, label in [(mapping.real_path, "real_path"), (mapping.cache_path, "cache_path")]:
+                        if not path_val:
+                            continue
+                        is_mounted, _ = self.system_detector.is_path_bind_mounted(path_val)
+                        if not is_mounted:
+                            mount_issues.append(
+                                f"Mapping '{mapping.name}': {label} '{path_val}' is not "
+                                f"backed by a Docker bind mount — writes will go to "
+                                f"the overlay filesystem (docker.img)"
+                            )
 
-            # Also check common Unraid paths
-            paths_to_validate.update(['/mnt/cache', '/mnt/user', '/mnt/user0'])
-
-            # Validate mounts
-            mount_warnings = self.system_detector.validate_docker_mounts(list(paths_to_validate))
-            for warning in mount_warnings:
-                logging.warning(warning)
-
-            # If any critical mount is not properly mounted, abort
-            if mount_warnings:
-                raise RuntimeError(
-                    "Docker mount validation failed! One or more paths may not be properly mounted. "
-                    "This could cause data to be written inside the container instead of to mounted volumes. "
-                    "Check your Docker volume configuration and ensure source paths exist on the host."
+            if mount_issues:
+                self._mount_paths_safe = False
+                for issue in mount_issues:
+                    logging.error("Docker mount validation: %s", issue)
+                logging.error(
+                    "One or more paths are not backed by Docker bind mounts. "
+                    "File moves are blocked to prevent data loss. Check your "
+                    "container's volume configuration."
                 )
 
             # Validate /mnt/user0 mount when .plexcached backups are enabled
-            # Without this mount, .plexcached renames operate through FUSE (/mnt/user/)
-            # which targets the cache copy instead of the array original
             if self.config_manager.cache.create_plexcached_backups:
                 if not os.path.ismount('/mnt/user0'):
                     if not os.path.exists('/mnt/user0'):
@@ -819,20 +817,32 @@ class PlexCacheApp:
                         )
 
         if self.config_manager.paths.path_mappings:
-            # Multi-path mode: check paths from enabled mappings
             for mapping in self.config_manager.paths.path_mappings:
                 if mapping.enabled:
                     if mapping.real_path:
-                        self.file_utils.check_path_exists(mapping.real_path)
+                        try:
+                            self.file_utils.check_path_exists(mapping.real_path)
+                        except FileNotFoundError:
+                            logging.error(
+                                "Mapping '%s': real_path '%s' does not exist inside "
+                                "the container. Check your bind mounts — the path "
+                                "must be accessible from inside the container.",
+                                mapping.name, mapping.real_path
+                            )
+                            self._mount_paths_safe = False
                     if mapping.cacheable and mapping.cache_path:
-                        # Create cache directory if it doesn't exist
                         self._ensure_cache_path_exists(mapping.cache_path)
         else:
-            # Legacy single-path mode
             if self.config_manager.paths.real_source:
-                self.file_utils.check_path_exists(self.config_manager.paths.real_source)
+                try:
+                    self.file_utils.check_path_exists(self.config_manager.paths.real_source)
+                except FileNotFoundError:
+                    logging.error(
+                        "real_source '%s' does not exist. Check your path configuration.",
+                        self.config_manager.paths.real_source
+                    )
+                    self._mount_paths_safe = False
             if self.config_manager.paths.cache_dir:
-                # Create cache directory if it doesn't exist
                 self._ensure_cache_path_exists(self.config_manager.paths.cache_dir)
     
     def _connect_to_plex(self) -> None:

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -4084,6 +4084,9 @@ class FileMover:
         # Optional callback for recording per-file activity to shared activity feed
         # Signature: callback(action: str, filename: str, size_bytes: int)
         self._file_activity_callback = file_activity_callback
+        # Docker mount validation gate — set to False by PlexCacheApp when
+        # paths are not backed by real bind mounts (issue #139)
+        self.mount_paths_validated = True
 
     def move_media_files(self, files: List[str], destination: str,
                         max_concurrent_moves_array: int, max_concurrent_moves_cache: int,
@@ -4099,6 +4102,14 @@ class FileMover:
             source_map: Optional dict mapping file paths to their source ('ondeck' or 'watchlist').
             media_info_map: Optional dict mapping file paths to Plex media type info.
         """
+        if not self.mount_paths_validated:
+            logging.error(
+                "File moves blocked: one or more paths are not backed by "
+                "Docker bind mounts. Fix your container's volume configuration "
+                "to prevent data loss."
+            )
+            return
+
         # Store source map and media info map for use during moves
         self._source_map = source_map or {}
         self._media_info_map = media_info_map or {}

--- a/core/system_utils.py
+++ b/core/system_utils.py
@@ -5,11 +5,12 @@ Handles OS detection, system-specific operations, and path conversions.
 
 import os
 import platform
+import posixpath
 import shutil
 import subprocess
 import atexit
 import fcntl
-from typing import Tuple, Optional, NamedTuple, Callable
+from typing import List, Tuple, Optional, NamedTuple, Callable, Set
 import logging
 
 
@@ -551,14 +552,74 @@ class SystemDetector:
         """Detect if running inside a Docker container."""
         return os.path.exists('/.dockerenv')
 
-    def validate_docker_mounts(self, paths: list) -> list:
-        """
-        Validate that paths are actual mount points in Docker.
+    def _parse_mountinfo(self) -> Set[str]:
+        """Parse /proc/self/mountinfo and return the set of mount points.
 
-        In Docker, if a volume mount fails (e.g., source doesn't exist,
-        trailing space in path), the path will exist as an empty directory
-        inside the container rather than a mount point. This can cause
-        massive data to be written inside the container.
+        Cached for the process lifetime — mounts don't change without a
+        container restart. Returns an empty set (permissive) if the file
+        is unreadable.
+        """
+        if hasattr(self, '_mountinfo_cache'):
+            return self._mountinfo_cache
+
+        mount_points: Set[str] = set()
+        try:
+            with open('/proc/self/mountinfo', 'r') as f:
+                for line in f:
+                    # Format: id parent_id major:minor root mount_point options ...
+                    # Field 5 (0-indexed: 4) is the mount point
+                    parts = line.split()
+                    if len(parts) >= 5:
+                        mount_point = parts[4]
+                        # Decode octal escapes (e.g., \040 for space)
+                        mount_point = mount_point.encode('utf-8').decode('unicode_escape')
+                        mount_points.add(mount_point)
+        except (OSError, IOError):
+            logging.warning(
+                "Could not read /proc/self/mountinfo — Docker mount "
+                "validation will be permissive (all paths accepted)"
+            )
+
+        self._mountinfo_cache = mount_points
+        return mount_points
+
+    def is_path_bind_mounted(self, path: str) -> Tuple[bool, Optional[str]]:
+        """Check if a path falls under a real bind mount (not the overlay rootfs).
+
+        Returns (True, owning_mount) when the path is safe to write to,
+        or (False, None) when writes would go to docker.img.
+
+        Non-Docker callers always get (True, None).
+        """
+        if not self.is_docker:
+            return (True, None)
+
+        mount_points = self._parse_mountinfo()
+        if not mount_points:
+            return (True, None)
+
+        # Use posixpath since mountinfo is always Linux paths
+        normalized = posixpath.normpath(path)
+        best_match: Optional[str] = None
+        best_len = 0
+
+        for mp in mount_points:
+            norm_mp = posixpath.normpath(mp)
+            if normalized == norm_mp or normalized.startswith(norm_mp + '/'):
+                if len(norm_mp) > best_len:
+                    best_match = norm_mp
+                    best_len = len(norm_mp)
+
+        if best_match is None or best_match == '/':
+            return (False, None)
+
+        return (True, best_match)
+
+    def validate_docker_mounts(self, paths: list) -> list:
+        """Validate that paths are backed by real bind mounts in Docker.
+
+        Uses /proc/self/mountinfo to definitively determine if paths fall
+        under real bind mounts or the overlay rootfs (docker.img).
 
         Args:
             paths: List of paths to validate (e.g., ['/mnt/cache', '/mnt/user0'])
@@ -575,30 +636,15 @@ class SystemDetector:
             if not path:
                 continue
 
-            # Normalize path (remove trailing slashes for consistent checking)
             path = path.rstrip('/')
+            is_mounted, owning_mount = self.is_path_bind_mounted(path)
 
-            if not os.path.exists(path):
-                # Path doesn't exist - might be OK if not used
-                continue
-
-            # Check if it's a mount point
-            if not os.path.ismount(path):
-                # Not a mount point - could be a directory inside container
-                # Check if it's suspiciously small (container rootfs is typically small)
-                try:
-                    stat = os.statvfs(path)
-                    total_gb = (stat.f_blocks * stat.f_frsize) / (1024**3)
-
-                    # If the filesystem is very small (< 100GB), it's likely container rootfs
-                    if total_gb < 100:
-                        warnings.append(
-                            f"WARNING: {path} may not be properly mounted! "
-                            f"Filesystem is only {total_gb:.1f}GB. "
-                            f"Check your Docker volume configuration."
-                        )
-                except OSError:
-                    pass
+            if not is_mounted:
+                warnings.append(
+                    f"WARNING: {path} is not backed by a Docker bind mount — "
+                    f"writes will go to the container's overlay filesystem "
+                    f"(docker.img). Check your Docker volume configuration."
+                )
 
         return warnings
 

--- a/tests/test_docker_mount_validation.py
+++ b/tests/test_docker_mount_validation.py
@@ -325,6 +325,7 @@ class TestCheckPathsGraceful:
         app.file_utils = MagicMock()
         app.config_manager = MagicMock()
         app.config_manager.cache.create_plexcached_backups = False
+        app._ensure_cache_path_exists = MagicMock()
 
         if mappings is not None:
             app.config_manager.paths.path_mappings = mappings
@@ -368,7 +369,6 @@ class TestCheckPathsGraceful:
         app = self._make_app(is_docker=True, mappings=[mapping])
         app.system_detector.is_path_bind_mounted.return_value = (True, '/mnt/cache')
         app.file_utils.check_path_exists.return_value = None
-        app._ensure_cache_path_exists = MagicMock()
 
         app._check_paths()
 

--- a/tests/test_docker_mount_validation.py
+++ b/tests/test_docker_mount_validation.py
@@ -1,0 +1,375 @@
+"""Tests for Docker mount validation (issue #139).
+
+Verifies that is_path_bind_mounted() correctly identifies paths backed by
+real bind mounts vs. the overlay rootfs, and that the validation gates in
+settings service, API endpoint, and FileMover all respond correctly.
+"""
+
+import os
+import sys
+import logging
+from unittest.mock import patch, MagicMock, mock_open
+
+import pytest
+
+# Mock plexapi + requests before importing core.app (not installed in test env)
+for _mod in ['plexapi', 'plexapi.server', 'plexapi.myplex', 'plexapi.library',
+             'plexapi.video', 'plexapi.exceptions', 'plexapi.settings',
+             'requests', 'requests.exceptions']:
+    sys.modules.setdefault(_mod, MagicMock())
+
+from core.system_utils import SystemDetector
+
+
+# ============================================================================
+# Fixture: sample /proc/self/mountinfo content
+# ============================================================================
+
+SAMPLE_MOUNTINFO = """\
+22 1 0:21 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+23 1 0:22 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs rw
+24 1 0:23 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+25 1 8:1 / / rw,relatime - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/ABC
+100 1 8:17 / /mnt/cache rw,relatime - ext4 /dev/sdb1 rw
+101 1 8:33 / /mnt/user rw,relatime - fuse.shfs shfs rw
+102 1 8:49 / /mnt/user0 rw,relatime - ext4 /dev/md1 rw
+103 1 8:65 / /mnt/remotes rw,relatime - fuse.mergerfs mergerfs rw
+104 103 8:81 / /mnt/remotes/NAS_Media rw,relatime - cifs //nas/media rw
+"""
+
+
+@pytest.fixture
+def docker_detector():
+    """SystemDetector that thinks it's in Docker, with mocked mountinfo."""
+    detector = SystemDetector.__new__(SystemDetector)
+    detector.os_name = 'Linux'
+    detector.is_linux = True
+    detector.is_unraid = True
+    detector.is_docker = True
+    return detector
+
+
+@pytest.fixture
+def non_docker_detector():
+    """SystemDetector that is NOT in Docker."""
+    detector = SystemDetector.__new__(SystemDetector)
+    detector.os_name = 'Linux'
+    detector.is_linux = True
+    detector.is_unraid = True
+    detector.is_docker = False
+    return detector
+
+
+def _load_mountinfo(detector, content=SAMPLE_MOUNTINFO):
+    """Helper to load fixture mountinfo into detector cache."""
+    with patch('builtins.open', mock_open(read_data=content)):
+        detector._parse_mountinfo()
+
+
+# ============================================================================
+# is_path_bind_mounted() tests
+# ============================================================================
+
+class TestIsPathBindMounted:
+
+    def test_valid_path_under_bind_mount(self, docker_detector):
+        _load_mountinfo(docker_detector)
+        ok, mount = docker_detector.is_path_bind_mounted('/mnt/cache/Movies/Inception.mkv')
+        assert ok is True
+        assert mount == '/mnt/cache'
+
+    def test_valid_path_exact_mount_point(self, docker_detector):
+        _load_mountinfo(docker_detector)
+        ok, mount = docker_detector.is_path_bind_mounted('/mnt/cache')
+        assert ok is True
+        assert mount == '/mnt/cache'
+
+    def test_overlay_path_rejected(self, docker_detector):
+        """Path not under any bind mount falls to root overlay."""
+        _load_mountinfo(docker_detector)
+        ok, mount = docker_detector.is_path_bind_mounted('/mnt/dumpster/media/TV Shows/')
+        assert ok is False
+        assert mount is None
+
+    def test_nested_mount_longest_match(self, docker_detector):
+        """Nested mount /mnt/remotes/NAS_Media wins over /mnt/remotes."""
+        _load_mountinfo(docker_detector)
+        ok, mount = docker_detector.is_path_bind_mounted('/mnt/remotes/NAS_Media/Movies/foo.mkv')
+        assert ok is True
+        assert mount == '/mnt/remotes/NAS_Media'
+
+    def test_parent_mount_when_no_nested(self, docker_detector):
+        _load_mountinfo(docker_detector)
+        ok, mount = docker_detector.is_path_bind_mounted('/mnt/remotes/other_share/file.txt')
+        assert ok is True
+        assert mount == '/mnt/remotes'
+
+    def test_root_path_rejected(self, docker_detector):
+        _load_mountinfo(docker_detector)
+        ok, mount = docker_detector.is_path_bind_mounted('/tmp/something')
+        assert ok is False
+        assert mount is None
+
+    def test_non_docker_always_passes(self, non_docker_detector):
+        ok, mount = non_docker_detector.is_path_bind_mounted('/mnt/dumpster/anything')
+        assert ok is True
+        assert mount is None
+
+    def test_unreadable_mountinfo_graceful_degrade(self, docker_detector):
+        with patch('builtins.open', side_effect=OSError("Permission denied")):
+            docker_detector._parse_mountinfo()
+        ok, mount = docker_detector.is_path_bind_mounted('/mnt/anything')
+        assert ok is True
+        assert mount is None
+
+    def test_mountinfo_cached(self, docker_detector):
+        """Mountinfo should be parsed once and cached."""
+        _load_mountinfo(docker_detector)
+        assert hasattr(docker_detector, '_mountinfo_cache')
+        cached = docker_detector._mountinfo_cache.copy()
+        # Second call should use cache, not re-read file
+        with patch('builtins.open', side_effect=AssertionError("Should not re-read")):
+            result = docker_detector._parse_mountinfo()
+        assert result == cached
+
+    def test_path_with_spaces(self, docker_detector):
+        _load_mountinfo(docker_detector)
+        ok, mount = docker_detector.is_path_bind_mounted('/mnt/cache/TV Shows/Breaking Bad/')
+        assert ok is True
+        assert mount == '/mnt/cache'
+
+
+# ============================================================================
+# validate_docker_mounts() tests
+# ============================================================================
+
+class TestValidateDockerMounts:
+
+    def test_returns_warnings_for_overlay_paths(self, docker_detector):
+        _load_mountinfo(docker_detector)
+        warnings = docker_detector.validate_docker_mounts(['/mnt/dumpster', '/mnt/cache'])
+        assert len(warnings) == 1
+        assert '/mnt/dumpster' in warnings[0]
+        assert 'docker.img' in warnings[0]
+
+    def test_no_warnings_for_valid_mounts(self, docker_detector):
+        _load_mountinfo(docker_detector)
+        warnings = docker_detector.validate_docker_mounts(['/mnt/cache', '/mnt/user', '/mnt/user0'])
+        assert warnings == []
+
+    def test_non_docker_returns_empty(self, non_docker_detector):
+        warnings = non_docker_detector.validate_docker_mounts(['/mnt/anything'])
+        assert warnings == []
+
+    def test_skips_empty_paths(self, docker_detector):
+        _load_mountinfo(docker_detector)
+        warnings = docker_detector.validate_docker_mounts(['', None, '/mnt/cache'])
+        assert warnings == []
+
+
+# ============================================================================
+# warn_cache_path() Docker branch tests
+# ============================================================================
+
+class TestWarnCachePathDocker:
+
+    @patch('web.services.settings_service.IS_DOCKER', True)
+    @patch('web.services.settings_service.get_system_detector')
+    def test_overlay_path_returns_warning(self, mock_get_detector):
+        detector = MagicMock()
+        detector.is_path_bind_mounted.return_value = (False, None)
+        mock_get_detector.return_value = detector
+
+        from web.services.settings_service import SettingsService
+        result = SettingsService.warn_cache_path('/mnt/dumpster/media/Movies/')
+        assert result is not None
+        assert 'bind mount' in result
+        assert 'docker.img' in result
+
+    @patch('web.services.settings_service.IS_DOCKER', True)
+    @patch('web.services.settings_service.get_system_detector')
+    def test_valid_mount_no_warning(self, mock_get_detector):
+        detector = MagicMock()
+        detector.is_path_bind_mounted.return_value = (True, '/mnt/cache')
+        mock_get_detector.return_value = detector
+
+        from web.services.settings_service import SettingsService
+        result = SettingsService.warn_cache_path('/mnt/cache/Movies/')
+        assert result is None
+
+    @patch('web.services.settings_service.IS_DOCKER', False)
+    def test_non_docker_skips_mount_check(self):
+        from web.services.settings_service import SettingsService
+        result = SettingsService.warn_cache_path('/mnt/cache/Movies/')
+        assert result is None
+
+
+# ============================================================================
+# detect_path_mapping_health_issues() Docker overlay tests
+# ============================================================================
+
+class TestDetectHealthIssuesDocker:
+
+    @patch('web.services.settings_service.IS_DOCKER', True)
+    @patch('web.services.settings_service.get_system_detector')
+    def test_flags_overlay_cache_path(self, mock_get_detector):
+        detector = MagicMock()
+        detector.is_path_bind_mounted.return_value = (False, None)
+        mock_get_detector.return_value = detector
+
+        from web.services.settings_service import SettingsService
+        svc = SettingsService()
+        with patch.object(svc, '_load_raw', return_value={
+            "path_mappings": [{
+                "name": "Movies",
+                "enabled": True,
+                "cache_path": "/mnt/dumpster/Movies/",
+                "real_path": "/mnt/user/Movies/",
+            }]
+        }):
+            issues = svc.detect_path_mapping_health_issues()
+
+        overlay_issues = [i for i in issues if i["issue_type"] == "overlay_path"]
+        assert len(overlay_issues) == 2  # Both cache_path and real_path
+        assert any("cache_path" in i["message"] for i in overlay_issues)
+        assert any("real_path" in i["message"] for i in overlay_issues)
+
+    @patch('web.services.settings_service.IS_DOCKER', True)
+    @patch('web.services.settings_service.get_system_detector')
+    def test_skips_disabled_mappings(self, mock_get_detector):
+        detector = MagicMock()
+        detector.is_path_bind_mounted.return_value = (False, None)
+        mock_get_detector.return_value = detector
+
+        from web.services.settings_service import SettingsService
+        svc = SettingsService()
+        with patch.object(svc, '_load_raw', return_value={
+            "path_mappings": [{
+                "name": "Movies",
+                "enabled": False,
+                "cache_path": "/mnt/dumpster/Movies/",
+                "real_path": "/mnt/user/Movies/",
+            }]
+        }):
+            issues = svc.detect_path_mapping_health_issues()
+
+        overlay_issues = [i for i in issues if i["issue_type"] == "overlay_path"]
+        assert len(overlay_issues) == 0
+
+
+# ============================================================================
+# FileMover gate tests
+# ============================================================================
+
+class TestFileMoverGate:
+
+    def test_blocks_when_mount_validation_false(self):
+        from core.file_operations import FileMover
+        mover = FileMover.__new__(FileMover)
+        mover.mount_paths_validated = False
+        mover._source_map = {}
+        mover._media_info_map = {}
+
+        with patch('core.file_operations.logging') as mock_log:
+            mover.move_media_files(
+                files=['/fake/file.mkv'],
+                destination='cache',
+                max_concurrent_moves_array=1,
+                max_concurrent_moves_cache=1,
+            )
+            mock_log.error.assert_called_once()
+            assert 'blocked' in mock_log.error.call_args[0][0].lower()
+
+    def test_proceeds_when_mount_validation_true(self):
+        from core.file_operations import FileMover
+        mover = FileMover.__new__(FileMover)
+        mover.mount_paths_validated = True
+        mover._source_map = {}
+        mover._media_info_map = {}
+        mover._stop_check = None
+        mover._stop_requested = False
+        mover.debug = True
+        mover._successful_array_moves = []
+        mover._completed_count = 0
+        mover._total_count = 0
+        mover._completed_bytes = 0
+        mover._total_bytes = 0
+        mover._active_files = {}
+
+        # Should proceed past the gate (will fail later due to missing attrs, that's fine)
+        with patch('core.file_operations.logging'):
+            try:
+                mover.move_media_files(
+                    files=[],
+                    destination='cache',
+                    max_concurrent_moves_array=1,
+                    max_concurrent_moves_cache=1,
+                )
+            except Exception:
+                pass  # Expected — we only test that the gate doesn't block
+
+
+# ============================================================================
+# PlexCacheApp._check_paths() graceful error tests
+# ============================================================================
+
+class TestCheckPathsGraceful:
+
+    def _make_app(self, is_docker=True, mappings=None):
+        """Create a minimal PlexCacheApp mock for _check_paths testing."""
+        from core.app import PlexCacheApp
+        app = PlexCacheApp.__new__(PlexCacheApp)
+        app._mount_paths_safe = True
+        app.system_detector = MagicMock()
+        app.system_detector.is_docker = is_docker
+        app.file_utils = MagicMock()
+        app.config_manager = MagicMock()
+        app.config_manager.cache.create_plexcached_backups = False
+
+        if mappings is not None:
+            app.config_manager.paths.path_mappings = mappings
+        else:
+            app.config_manager.paths.path_mappings = []
+
+        return app
+
+    def test_missing_real_path_sets_flag(self):
+        from conftest import MockPathMapping
+        mapping = MockPathMapping(
+            name="Movies", real_path="/mnt/user/Movies/",
+            cache_path="/mnt/cache/Movies/", enabled=True, cacheable=True
+        )
+        app = self._make_app(is_docker=False, mappings=[mapping])
+        app.file_utils.check_path_exists.side_effect = FileNotFoundError("not found")
+
+        app._check_paths()
+
+        assert app._mount_paths_safe is False
+
+    def test_overlay_path_sets_flag(self):
+        from conftest import MockPathMapping
+        mapping = MockPathMapping(
+            name="Movies", real_path="/mnt/user/Movies/",
+            cache_path="/mnt/dumpster/Movies/", enabled=True, cacheable=True
+        )
+        app = self._make_app(is_docker=True, mappings=[mapping])
+        app.system_detector.is_path_bind_mounted.return_value = (False, None)
+
+        app._check_paths()
+
+        assert app._mount_paths_safe is False
+
+    def test_valid_paths_flag_stays_true(self):
+        from conftest import MockPathMapping
+        mapping = MockPathMapping(
+            name="Movies", real_path="/mnt/user/Movies/",
+            cache_path="/mnt/cache/Movies/", enabled=True, cacheable=True
+        )
+        app = self._make_app(is_docker=True, mappings=[mapping])
+        app.system_detector.is_path_bind_mounted.return_value = (True, '/mnt/cache')
+        app.file_utils.check_path_exists.return_value = None
+        app._ensure_cache_path_exists = MagicMock()
+
+        app._check_paths()
+
+        assert app._mount_paths_safe is True

--- a/web/dependencies.py
+++ b/web/dependencies.py
@@ -43,6 +43,17 @@ def get_logs_dir() -> Path:
     return LOGS_DIR
 
 
+_system_detector_instance = None
+
+def get_system_detector():
+    """Get SystemDetector singleton (caches mountinfo for process lifetime)."""
+    global _system_detector_instance
+    if _system_detector_instance is None:
+        from core.system_utils import SystemDetector
+        _system_detector_instance = SystemDetector()
+    return _system_detector_instance
+
+
 def get_config_manager():
     """Get ConfigManager instance (lazy loaded)"""
     from core.config import ConfigManager

--- a/web/main.py
+++ b/web/main.py
@@ -130,17 +130,25 @@ async def lifespan(app: FastAPI):
     settings_service = get_settings_service()
     settings_service.prefetch_plex_data()
 
-    # Scan path_mappings for known-bad configurations (issue #136).
-    # Read-only: just logs warnings and surfaces them in the dashboard
+    # Scan path_mappings for known-bad configurations (issues #136, #139).
+    # Read-only: just logs warnings/errors and surfaces them in the dashboard
     # via /api/config-health. Does not auto-modify user settings.
     try:
         health_issues = settings_service.detect_path_mapping_health_issues()
         for issue in health_issues:
-            logging.warning(
-                "path_mapping health check: %s — %s",
-                issue["issue_type"],
-                issue["message"],
-            )
+            # Docker overlay issues are ERROR-level (data loss risk)
+            if issue["issue_type"] == "overlay_path":
+                logging.error(
+                    "path_mapping health check: %s — %s",
+                    issue["issue_type"],
+                    issue["message"],
+                )
+            else:
+                logging.warning(
+                    "path_mapping health check: %s — %s",
+                    issue["issue_type"],
+                    issue["message"],
+                )
     except Exception as e:
         logging.warning("path_mapping health check failed (non-fatal): %s", e)
 

--- a/web/routers/api.py
+++ b/web/routers/api.py
@@ -11,7 +11,7 @@ from starlette.datastructures import ImmutableMultiDict
 from typing import List
 from urllib.parse import unquote
 
-from web.config import templates, PLEXCACHE_PRODUCT_VERSION
+from web.config import templates, PLEXCACHE_PRODUCT_VERSION, IS_DOCKER
 from web.dependencies import parse_form
 from core.system_utils import format_bytes, format_duration, format_cache_age
 from web.services import get_cache_service, get_settings_service, get_operation_runner, get_scheduler_service, ScheduleConfig, get_maintenance_service
@@ -728,6 +728,17 @@ def validate_path(path: str = Query("")):
         if resolved_str != "/mnt" and not resolved_str.startswith("/mnt/"):
             return HTMLResponse("")
         if p.exists() and p.is_dir():
+            # Docker: verify path is backed by a real bind mount (issue #139)
+            if IS_DOCKER:
+                from web.dependencies import get_system_detector
+                detector = get_system_detector()
+                is_mounted, _ = detector.is_path_bind_mounted(path)
+                if not is_mounted:
+                    return HTMLResponse(
+                        '<i data-lucide="alert-triangle" style="width: 14px; height: 14px; color: var(--plex-error, #e74c3c); vertical-align: middle;" '
+                        'title="Path exists but is not backed by a bind mount — writes will go to docker.img"></i>'
+                        '<script>lucide.createIcons();</script>'
+                    )
             return HTMLResponse(
                 '<i data-lucide="check-circle" style="width: 14px; height: 14px; color: var(--plex-success); vertical-align: middle;"></i>'
                 '<script>lucide.createIcons();</script>'

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass, field, asdict
 
-from web.config import DATA_DIR, SETTINGS_FILE
+from web.config import DATA_DIR, SETTINGS_FILE, IS_DOCKER
+from web.dependencies import get_system_detector
 
 logger = logging.getLogger(__name__)
 
@@ -286,6 +287,10 @@ class SettingsService:
         - cache_path pointing at the Unraid FUSE merged view
           ('/mnt/user/...', but not /mnt/user0/). Audits go through shfs
           and the cache-vs-array logic can't distinguish the two layers.
+
+        Docker-specific check (issue #139):
+        - cache_path not backed by a real bind mount. Writes go to
+          the overlay filesystem (docker.img) instead of the host drive.
         """
         if not cache_path:
             return None
@@ -293,6 +298,20 @@ class SettingsService:
         normalized = cache_path.rstrip("/\\")
         if not normalized:
             return None
+
+        # Docker mount validation (issue #139) — highest priority check
+        if IS_DOCKER:
+            detector = get_system_detector()
+            is_mounted, _ = detector.is_path_bind_mounted(normalized)
+            if not is_mounted:
+                return (
+                    f"This path is not backed by a Docker bind mount — "
+                    f"files written here will go into the container's "
+                    f"overlay filesystem (docker.img), not your host drive. "
+                    f"Check your container's volume configuration and use "
+                    f"the path as seen inside the container (e.g., "
+                    f"/mnt/cache/...), not the host path."
+                )
 
         if normalized == "/mnt/cache":
             return (
@@ -331,6 +350,12 @@ class SettingsService:
            ("/mnt/cache/..."). FUSE reads are 3-5x slower than cache-direct
            and the audit's cache-vs-array logic can't distinguish the two.
 
+        Issue #139 added a third failure mode specific to Docker:
+
+        3. A mapping whose cache_path or real_path is not backed by a real
+           bind mount. Writes go to the overlay filesystem (docker.img)
+           instead of the host drive.
+
         Returns a list of dicts with keys: mapping_name, issue_type, message.
         Empty list means no issues detected. This is a read-only check —
         fixes must be performed by the user via Settings -> Libraries.
@@ -338,6 +363,33 @@ class SettingsService:
         raw = self._load_raw()
         mappings = raw.get("path_mappings", [])
         issues: List[Dict[str, str]] = []
+
+        # Docker mount validation (issue #139)
+        if IS_DOCKER:
+            detector = get_system_detector()
+            for m in mappings:
+                if not m.get("enabled", True):
+                    continue
+                name = m.get("name", "(unnamed)")
+                for field_name, label in [("cache_path", "cache_path"), ("real_path", "real_path")]:
+                    path_val = (m.get(field_name) or "").rstrip("/\\")
+                    if not path_val:
+                        continue
+                    # host_cache_path is intentionally a host path — do NOT validate it
+                    is_mounted, _ = detector.is_path_bind_mounted(path_val)
+                    if not is_mounted:
+                        issues.append({
+                            "mapping_name": name,
+                            "issue_type": "overlay_path",
+                            "message": (
+                                f"Mapping '{name}' has {label} set to "
+                                f"'{m.get(field_name)}' which is not backed by "
+                                f"a Docker bind mount. Writes to this path will "
+                                f"go into the container's overlay filesystem "
+                                f"(docker.img), not your host drive. Check your "
+                                f"container's volume configuration."
+                            ),
+                        })
 
         for m in mappings:
             if not m.get("enabled", True):

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -19,7 +19,7 @@
                     <label for="number_episodes">Episodes to Prefetch</label>
                     <input type="number" id="number_episodes" name="number_episodes"
                            class="input-narrow"
-                           value="{{ settings.number_episodes | default(3) }}" min="0" max="10">
+                           value="{{ settings.number_episodes | default(3) }}" min="0">
                     <div class="form-hint">Number of upcoming episodes to cache for in-progress shows</div>
                 </div>
 
@@ -54,7 +54,7 @@
                         <label for="watchlist_episodes">Watchlist Episodes to Prefetch</label>
                         <input type="number" id="watchlist_episodes" name="watchlist_episodes"
                                class="input-narrow"
-                               value="{{ settings.watchlist_episodes | default(3) }}" min="0" max="10">
+                               value="{{ settings.watchlist_episodes | default(3) }}" min="0">
                     </div>
                 </div>
 

--- a/web/templates/settings/libraries.html
+++ b/web/templates/settings/libraries.html
@@ -108,13 +108,31 @@
 
 <script src="/static/js/path-browser.js"></script>
 <script>
+    function validatePathInput(input) {
+        var target = document.querySelector(input.dataset.validateTarget);
+        if (!target) return;
+        var val = input.value.trim();
+        if (!val) { target.innerHTML = ''; return; }
+        fetch('/api/validate-path?path=' + encodeURIComponent(val))
+            .then(function(r) { return r.text(); })
+            .then(function(html) { target.innerHTML = html; lucide.createIcons(); });
+    }
+
+    var _validateTimers = {};
+    document.addEventListener('input', function(e) {
+        if (!e.target.classList.contains('path-validate-input')) return;
+        var id = e.target.dataset.validateTarget;
+        clearTimeout(_validateTimers[id]);
+        _validateTimers[id] = setTimeout(function() { validatePathInput(e.target); }, 500);
+    });
+
     function toggleLibraryEdit(sectionId) {
         var editPanel = document.getElementById('library-edit-' + sectionId);
         if (!editPanel) return;
         if (editPanel.style.display === 'none') {
             editPanel.style.display = 'block';
+            editPanel.querySelectorAll('.path-validate-input').forEach(validatePathInput);
         } else {
-            // Reset all forms to original values before hiding
             editPanel.querySelectorAll('form').forEach(function(form) { form.reset(); });
             editPanel.style.display = 'none';
         }

--- a/web/templates/settings/partials/library_card.html
+++ b/web/templates/settings/partials/library_card.html
@@ -112,7 +112,8 @@
                                     <input type="text" name="real_path_{{ loop.index0 }}" value="{{ mapping.real_path }}"
                                            class="path-browse-input" required>
                                     <div class="form-hint">
-                                        The path inside this container that corresponds to Plex's <code>{{ mapping.plex_path }}</code>.
+                                        {% if is_docker %}Path as seen from <strong>inside</strong> the container. Must match a bind-mounted volume.
+                                        {% else %}The path inside this container that corresponds to Plex's <code>{{ mapping.plex_path }}</code>.{% endif %}
                                     </div>
                                 </div>
                                 <div class="form-group mb-1">
@@ -120,7 +121,8 @@
                                     <input type="text" name="cache_path_{{ loop.index0 }}" value="{{ mapping.cache_path or '' }}"
                                            class="path-browse-input">
                                     <div class="form-hint">
-                                        {% if is_unraid %}Fast drive path where cached copies are stored (e.g., <code>/mnt/cache/{{ mapping.plex_path.rstrip('/').rsplit('/', 1)[-1] }}/</code>).
+                                        {% if is_docker %}Path as seen from <strong>inside</strong> the container, not the host. If your template maps <code>/mnt/cache_nvme</code> &rarr; <code>/mnt/cache</code>, use <code>/mnt/cache/...</code> here.
+                                        {% elif is_unraid %}Fast drive path where cached copies are stored (e.g., <code>/mnt/cache/{{ mapping.plex_path.rstrip('/').rsplit('/', 1)[-1] }}/</code>).
                                         {% else %}Fast drive path where cached copies are stored.{% endif %}
                                     </div>
                                 </div>

--- a/web/templates/settings/partials/library_card.html
+++ b/web/templates/settings/partials/library_card.html
@@ -108,18 +108,40 @@
 
                             <div class="grid grid-2 mb-1">
                                 <div class="form-group mb-1">
-                                    <label>Real Path</label>
+                                    <label>Real Path
+                                        <span class="path-validation"
+                                              hx-get="/api/validate-path?path={{ mapping.real_path | urlencode }}"
+                                              hx-trigger="load"
+                                              hx-swap="innerHTML"></span>
+                                    </label>
                                     <input type="text" name="real_path_{{ loop.index0 }}" value="{{ mapping.real_path }}"
-                                           class="path-browse-input" required>
+                                           class="path-browse-input" required
+                                           hx-get="/api/validate-path"
+                                           hx-trigger="input changed delay:500ms"
+                                           hx-target="previous .path-validation"
+                                           hx-swap="innerHTML"
+                                           hx-params="none"
+                                           hx-vals='js:{"path": event.target.value}'>
                                     <div class="form-hint">
                                         {% if is_docker %}Path as seen from <strong>inside</strong> the container. Must match a bind-mounted volume.
                                         {% else %}The path inside this container that corresponds to Plex's <code>{{ mapping.plex_path }}</code>.{% endif %}
                                     </div>
                                 </div>
                                 <div class="form-group mb-1">
-                                    <label>Cache Path</label>
+                                    <label>Cache Path
+                                        <span class="path-validation"
+                                              hx-get="/api/validate-path?path={{ mapping.cache_path | urlencode }}"
+                                              hx-trigger="load"
+                                              hx-swap="innerHTML"></span>
+                                    </label>
                                     <input type="text" name="cache_path_{{ loop.index0 }}" value="{{ mapping.cache_path or '' }}"
-                                           class="path-browse-input">
+                                           class="path-browse-input"
+                                           hx-get="/api/validate-path"
+                                           hx-trigger="input changed delay:500ms"
+                                           hx-target="previous .path-validation"
+                                           hx-swap="innerHTML"
+                                           hx-params="none"
+                                           hx-vals='js:{"path": event.target.value}'>
                                     <div class="form-hint">
                                         {% if is_docker %}Path as seen from <strong>inside</strong> the container, not the host. If your template maps <code>/mnt/cache_nvme</code> &rarr; <code>/mnt/cache</code>, use <code>/mnt/cache/...</code> here.
                                         {% elif is_unraid %}Fast drive path where cached copies are stored (e.g., <code>/mnt/cache/{{ mapping.plex_path.rstrip('/').rsplit('/', 1)[-1] }}/</code>).

--- a/web/templates/settings/partials/library_card.html
+++ b/web/templates/settings/partials/library_card.html
@@ -109,19 +109,11 @@
                             <div class="grid grid-2 mb-1">
                                 <div class="form-group mb-1">
                                     <label>Real Path
-                                        <span class="path-validation"
-                                              hx-get="/api/validate-path?path={{ mapping.real_path | urlencode }}"
-                                              hx-trigger="load"
-                                              hx-swap="innerHTML"></span>
+                                        <span class="path-validation" id="rv-real-{{ card.library.id }}-{{ loop.index0 }}"></span>
                                     </label>
                                     <input type="text" name="real_path_{{ loop.index0 }}" value="{{ mapping.real_path }}"
-                                           class="path-browse-input" required
-                                           hx-get="/api/validate-path"
-                                           hx-trigger="input changed delay:500ms"
-                                           hx-target="previous .path-validation"
-                                           hx-swap="innerHTML"
-                                           hx-params="none"
-                                           hx-vals='js:{"path": event.target.value}'>
+                                           class="path-browse-input path-validate-input" required
+                                           data-validate-target="#rv-real-{{ card.library.id }}-{{ loop.index0 }}">
                                     <div class="form-hint">
                                         {% if is_docker %}Path as seen from <strong>inside</strong> the container. Must match a bind-mounted volume.
                                         {% else %}The path inside this container that corresponds to Plex's <code>{{ mapping.plex_path }}</code>.{% endif %}
@@ -129,19 +121,11 @@
                                 </div>
                                 <div class="form-group mb-1">
                                     <label>Cache Path
-                                        <span class="path-validation"
-                                              hx-get="/api/validate-path?path={{ mapping.cache_path | urlencode }}"
-                                              hx-trigger="load"
-                                              hx-swap="innerHTML"></span>
+                                        <span class="path-validation" id="rv-cache-{{ card.library.id }}-{{ loop.index0 }}"></span>
                                     </label>
                                     <input type="text" name="cache_path_{{ loop.index0 }}" value="{{ mapping.cache_path or '' }}"
-                                           class="path-browse-input"
-                                           hx-get="/api/validate-path"
-                                           hx-trigger="input changed delay:500ms"
-                                           hx-target="previous .path-validation"
-                                           hx-swap="innerHTML"
-                                           hx-params="none"
-                                           hx-vals='js:{"path": event.target.value}'>
+                                           class="path-browse-input path-validate-input"
+                                           data-validate-target="#rv-cache-{{ card.library.id }}-{{ loop.index0 }}">
                                     <div class="form-hint">
                                         {% if is_docker %}Path as seen from <strong>inside</strong> the container, not the host. If your template maps <code>/mnt/cache_nvme</code> &rarr; <code>/mnt/cache</code>, use <code>/mnt/cache/...</code> here.
                                         {% elif is_unraid %}Fast drive path where cached copies are stored (e.g., <code>/mnt/cache/{{ mapping.plex_path.rstrip('/').rsplit('/', 1)[-1] }}/</code>).

--- a/web/templates/settings/partials/path_mapping_card.html
+++ b/web/templates/settings/partials/path_mapping_card.html
@@ -80,7 +80,8 @@
                             <label>Real Path</label>
                             <input type="text" name="real_path" value="{{ mapping.real_path }}" required>
                             <div class="form-hint">
-                                {% if is_unraid %}Where files live on your Unraid share (e.g., <code>/mnt/user/Movies/</code>). Works with both array and ZFS pool shares.
+                                {% if is_docker %}Path as seen from <strong>inside</strong> the container. Must match a bind-mounted volume.
+                                {% elif is_unraid %}Where files live on your Unraid share (e.g., <code>/mnt/user/Movies/</code>). Works with both array and ZFS pool shares.
                                 {% else %}Actual filesystem path where your media files are stored.{% endif %}
                             </div>
                         </div>
@@ -88,7 +89,8 @@
                             <label>Cache Path</label>
                             <input type="text" name="cache_path" value="{{ mapping.cache_path or '' }}">
                             <div class="form-hint">
-                                {% if is_unraid %}Fast drive path to cache files to (e.g., <code>/mnt/cache/Movies/</code>).
+                                {% if is_docker %}Path as seen from <strong>inside</strong> the container, not the host. If your template maps <code>/mnt/cache_nvme</code> &rarr; <code>/mnt/cache</code>, use <code>/mnt/cache/...</code> here.
+                                {% elif is_unraid %}Fast drive path to cache files to (e.g., <code>/mnt/cache/Movies/</code>).
                                 {% else %}Fast drive path where cached copies are stored.{% endif %}
                             </div>
                         </div>

--- a/web/templates/settings/paths.html
+++ b/web/templates/settings/paths.html
@@ -54,7 +54,8 @@
                         <input type="text" id="new_real_path" name="real_path"
                                placeholder="{% if is_unraid %}/mnt/user/TV Shows/{% else %}/media/tv{% endif %}" required>
                         <div class="form-hint">
-                            {% if is_unraid %}Where files live on your Unraid share (e.g., <code>/mnt/user/Movies/</code>). Works with both array and ZFS pool shares.
+                            {% if is_docker %}Path as seen from <strong>inside</strong> the container. Must match a bind-mounted volume.
+                            {% elif is_unraid %}Where files live on your Unraid share (e.g., <code>/mnt/user/Movies/</code>). Works with both array and ZFS pool shares.
                             {% else %}Actual filesystem path where your media files are stored.{% endif %}
                         </div>
                     </div>
@@ -63,7 +64,8 @@
                         <input type="text" id="new_cache_path" name="cache_path"
                                placeholder="{% if is_unraid %}/mnt/cache/TV Shows/{% else %}/mnt/ssd/tv{% endif %}">
                         <div class="form-hint">
-                            {% if is_unraid %}Fast drive path to cache files to (e.g., <code>/mnt/cache/Movies/</code>).
+                            {% if is_docker %}Path as seen from <strong>inside</strong> the container, not the host. If your template maps <code>/mnt/cache_nvme</code> &rarr; <code>/mnt/cache</code>, use <code>/mnt/cache/...</code> here.
+                            {% elif is_unraid %}Fast drive path to cache files to (e.g., <code>/mnt/cache/Movies/</code>).
                             {% else %}Fast drive path where cached copies are stored (optional).{% endif %}
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

- **Mountinfo-backed path validation** — parses `/proc/self/mountinfo` to verify every `cache_path` and `real_path` falls under a real bind mount, not the overlay rootfs. Replaces the unreliable `ismount()` + `statvfs` heuristic.
- **Truthful `/api/validate-path`** — returns red error icon (not green check) when a Docker path exists but isn't bind-mounted.
- **Graceful config errors** — `_check_paths()` catches `FileNotFoundError` from missing `real_path` and surfaces it as an ERROR log instead of crashing with a stack trace.
- **FileMover pre-move gate** — refuses to start file moves when `mount_paths_validated=False`, preventing data loss.
- **Docker-specific UI hints** — Cache Path and Real Path fields show "path as seen from inside the container" guidance in Docker mode.
- **Live path validation in edit form** — validation icons update as user types (500ms debounce), validate on edit panel open.
- **Startup health escalation** — overlay path issues logged at ERROR level, surfaced via `/api/config-health`.
- **Remove max=10 cap** on Episodes to Prefetch settings (both OnDeck and Watchlist).

## Context

Addresses [StudioNirin/PlexCache-D#139](https://github.com/StudioNirin/PlexCache-D/issues/139). Two users hit distinct data-loss failures:

1. **Boasdfae** — typed host path into Cache Path field, overlay auto-created the dir, UI showed green checkmark, media filled docker.img (100 GB)
2. **Tolagarf** — phantom bind mounts not actually active, app crashed with FileNotFoundError stack trace

## Test plan

- [x] 24 dedicated unit tests covering mountinfo parsing, bind mount detection, nested mounts, overlay rejection, non-Docker no-op, graceful degrade, settings service Docker checks, FileMover gate, _check_paths graceful error handling
- [x] Full test suite passes (834 passed, 0 regressions)
- [x] Docker smoke test: misconfigure a cache_path to a non-mounted path, verify red warning icon + file moves blocked
- [x] Verify existing valid mounts still show green checks (no false positives)