### PR TITLE
Fix Home user tokens dropped when watchlist disabled

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -851,11 +851,11 @@ class PlexCacheApp:
 
         # Load user tokens once at startup (reduces plex.tv API calls)
         if self.config_manager.plex.users_toggle:
-            # Combine all skip lists for token loading
-            skip_users = list(set(
-                (self.config_manager.plex.skip_ondeck or []) +
-                (self.config_manager.plex.skip_watchlist or [])
-            ))
+            # Only exclude a token when the user is skipped for BOTH operations.
+            # A user skipped for only one still needs their token for the other.
+            ondeck_skip = set(self.config_manager.plex.skip_ondeck or [])
+            watchlist_skip = set(self.config_manager.plex.skip_watchlist or [])
+            skip_users = list(ondeck_skip & watchlist_skip)
             # Pass users from settings file (includes remote users with tokens)
             # Use "main" as fallback username if plex.tv unreachable
             self.plex_manager.load_user_tokens(

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -383,13 +383,19 @@ class PlexManager:
                     self._newly_discovered_users.append(build_user_info(cached_token))
                     continue
 
-                # Fetch fresh token from plex.tv (may return None due to Plex API changes)
-                try:
-                    self._rate_limited_api_call()
-                    token = user.get_token(machine_id)
-                except Exception as e:
-                    _log_api_error(f"get token for {username}", e)
-                    token = None
+                # Fetch fresh token from plex.tv. Home/managed users from
+                # plexapi arrive as UserProxy-like objects without get_token;
+                # they authenticate via switchHomeUser at runtime instead.
+                token = None
+                if hasattr(user, 'get_token'):
+                    try:
+                        self._rate_limited_api_call()
+                        token = user.get_token(machine_id)
+                    except Exception as e:
+                        _log_api_error(f"get token for {username}", e)
+                        token = None
+                else:
+                    logging.debug(f"[USER:{username}] Home/managed user — no individual token, will use switchHomeUser at runtime")
 
                 if token:
                     if token in skip_users:
@@ -553,18 +559,21 @@ class PlexManager:
             with self._token_lock:
                 token = self._user_tokens.get(username)
             if not token:
-                # Fall back to fetching token (shouldn't happen if load_user_tokens was called)
-                logging.warning(f"[PLEX API] No cached token for {username}, fetching fresh...")
-                try:
-                    self._rate_limited_api_call()
-                    token = user.get_token(self.plex.machineIdentifier)
-                    if token:
-                        with self._token_lock:
-                            self._user_tokens[username] = token
-                        self._token_cache.set_token(username, token, self.plex.machineIdentifier)
-                except Exception as e:
-                    _log_api_error(f"get token for {username}", e)
-                    return None, None
+                # Our internal UserProxy wrapper and Home/managed users have no
+                # individual plex.tv token — skip get_token and let the
+                # switchHomeUser fallback below handle auth.
+                is_home = self._user_is_home.get(username, False)
+                if hasattr(user, 'get_token') and not is_home:
+                    logging.warning(f"[PLEX API] No cached token for {username}, fetching fresh...")
+                    try:
+                        self._rate_limited_api_call()
+                        token = user.get_token(self.plex.machineIdentifier)
+                        if token:
+                            with self._token_lock:
+                                self._user_tokens[username] = token
+                            self._token_cache.set_token(username, token, self.plex.machineIdentifier)
+                    except Exception as e:
+                        _log_api_error(f"get token for {username}", e)
 
             if not token:
                 # Try switchHomeUser for home/managed users (no individual token needed)


### PR DESCRIPTION
## Summary

Fixes [#142](https://github.com/StudioNirin/PlexCache-D/issues/142) — Plex Home users with OnDeck enabled but Watchlist disabled were failing with `'UserProxy' object has no attribute 'get_token'` and silently skipping OnDeck fetch.

## Root Cause

Token loading combined `skip_ondeck` and `skip_watchlist` into a single exclusion list. A user skipped for one operation still needs their token for the other — so a Home user with Watchlist off but OnDeck on had their token silently dropped from `_user_tokens` at startup. Then `get_on_deck_media` picked them up via the home-user fallback loop (gated on `is_local=true`), wrapped them in our internal `UserProxy` class, and `get_plex_instance` tried to call `get_token()` on that wrapper — which doesn't have the method. The exception handler then early-returned, skipping the `switchHomeUser` fallback that would have worked.

## Changes

- **`core/app.py`** — `skip_users` for token loading is now the **intersection** of `skip_ondeck` and `skip_watchlist` instead of the union. A user's token is only excluded when they're skipped for both operations.
- **`core/plex_api.py` (`get_plex_instance`)** — guard `get_token` with `hasattr()` and skip it for home users entirely; on exception, fall through to the `switchHomeUser` branch instead of early-returning.
- **`core/plex_api.py` (`_discover_new_users`)** — same `hasattr` guard to avoid logging errors for home users returned without individual tokens.

## Test plan

- [x] ~339 unit tests pass locally (one pre-existing Windows-only failure in `test_file_operations_safety`, unrelated)
- [x] Reporter on #142 tested beta image (`v3.2.0-beta18`) against their nightly schedule and confirmed no more errors, OnDeck items fetched for both previously-affected Home users