### PR TITLE
Clean up _log_api_error formatting for plex.tv outages

### DIFF
--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -51,26 +51,33 @@ RSS_TIMEOUT = 15  # seconds
 
 
 def _log_api_error(context: str, error: Exception) -> None:
-    """Log API errors with specific detection for common HTTP status codes."""
+    """Log API errors with specific detection for common HTTP status codes.
+
+    Strips HTML from error messages — plex.tv's nginx returns full HTML error
+    pages on 5xx responses that otherwise get dumped into logs and notifications.
+    Transient 5xx errors are logged at WARNING (not ERROR) because the caching
+    layer falls back to cached data and the outage isn't user-actionable.
+    """
     error_str = str(error)
+    clean_error = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", error_str)).strip()
 
     if "401" in error_str or "Unauthorized" in error_str:
-        logging.error(f"[PLEX API] Authentication failed ({context}): {error}")
+        logging.error(f"[PLEX API] Authentication failed ({context}): {clean_error}")
         logging.error(f"[PLEX API] Your Plex token is invalid or has been revoked.")
         logging.error(f"[PLEX API] To fix: Run 'python3 plexcache_setup.py' and select 'y' to re-authenticate.")
     elif "429" in error_str or "Too Many Requests" in error_str:
-        logging.warning(f"[PLEX API] Rate limited by Plex.tv ({context}): {error}")
+        logging.warning(f"[PLEX API] Rate limited by Plex.tv ({context}): {clean_error}")
         logging.warning(f"[PLEX API] Consider increasing delays between API calls")
     elif "403" in error_str or "Forbidden" in error_str:
-        logging.error(f"[PLEX API] Access forbidden ({context}): {error}")
+        logging.error(f"[PLEX API] Access forbidden ({context}): {clean_error}")
         logging.error(f"[PLEX API] User may not have permission for this resource")
     elif "404" in error_str or "Not Found" in error_str:
-        logging.warning(f"[PLEX API] Resource not found ({context}): {error}")
+        logging.warning(f"[PLEX API] Resource not found ({context}): {clean_error}")
     elif "500" in error_str or "502" in error_str or "503" in error_str:
-        logging.error(f"[PLEX API] Plex server error ({context}): {error}")
-        logging.error(f"[PLEX API] Plex.tv may be experiencing issues")
+        logging.warning(f"[PLEX API] Plex server error ({context}): {clean_error}")
+        logging.warning(f"[PLEX API] Plex.tv may be experiencing issues — using cached data when available")
     else:
-        logging.error(f"[PLEX API] Error ({context}): {error}")
+        logging.error(f"[PLEX API] Error ({context}): {clean_error}")
 
 
 class UserProxy:

--- a/tests/test_log_api_error.py
+++ b/tests/test_log_api_error.py
@@ -1,0 +1,117 @@
+"""Tests for the _log_api_error helper in core.plex_api.
+
+Verifies that HTML (e.g. nginx 5xx error pages) is stripped from log output
+and that transient 5xx responses are logged at WARNING rather than ERROR.
+"""
+
+import logging
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+for _mod in [
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions', 'requests',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.plex_api import _log_api_error
+
+
+NGINX_503_HTML = (
+    "(503) Service Temporarily Unavailable; "
+    "<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n"
+    "<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n"
+    "<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
+)
+
+
+class TestLogApiErrorHtmlStripping:
+    """HTML tags from upstream error bodies must not reach logs."""
+
+    def test_503_html_body_is_stripped(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("load user tokens", Exception(NGINX_503_HTML))
+
+        combined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "<" not in combined
+        assert ">" not in combined
+        assert "503 Service Temporarily Unavailable" in combined
+        assert "nginx" in combined
+
+    def test_whitespace_is_collapsed(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("ctx", Exception("line1\r\n\r\n\tline2   line3"))
+
+        combined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "line1 line2 line3" in combined
+
+    def test_plain_error_message_preserved(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("fetch watchlist", Exception("Something simple went wrong"))
+
+        combined = "\n".join(r.getMessage() for r in caplog.records)
+        assert "Something simple went wrong" in combined
+
+
+class TestLogApiErrorSeverity:
+    """Transient plex.tv outages should not trip error-level notification handlers."""
+
+    @pytest.mark.parametrize("status", ["500", "502", "503"])
+    def test_5xx_logged_as_warning(self, caplog, status):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("get Plex account for main", Exception(f"({status}) Bad Gateway"))
+
+        levels = {r.levelno for r in caplog.records}
+        assert logging.ERROR not in levels
+        assert logging.WARNING in levels
+
+    def test_401_still_logged_as_error(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("load user tokens", Exception("(401) Unauthorized"))
+
+        levels = {r.levelno for r in caplog.records}
+        assert logging.ERROR in levels
+
+    def test_403_still_logged_as_error(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("switchHomeUser", Exception("(403) Forbidden"))
+
+        levels = {r.levelno for r in caplog.records}
+        assert logging.ERROR in levels
+
+    def test_429_logged_as_warning(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("fetch OnDeck", Exception("(429) Too Many Requests"))
+
+        levels = {r.levelno for r in caplog.records}
+        assert logging.WARNING in levels
+        assert logging.ERROR not in levels
+
+    def test_404_logged_as_warning(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("resolve UUID", Exception("(404) Not Found"))
+
+        levels = {r.levelno for r in caplog.records}
+        assert logging.WARNING in levels
+        assert logging.ERROR not in levels
+
+    def test_unrecognized_error_logged_as_error(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="root"):
+            _log_api_error("ctx", Exception("Some unrecognized failure"))
+
+        levels = {r.levelno for r in caplog.records}
+        assert logging.ERROR in levels


### PR DESCRIPTION
## Summary

During plex.tv outages, `_log_api_error` dumps the raw exception string (which includes plex.tv's full nginx HTML error page) into logs and Discord notifications. Users saw walls of `<html><head><title>503 Service Temporarily Unavailable</title>...<center>nginx</center></body></html>` for each affected call (`load user tokens`, `get Plex account for main`, etc.).

This PR:

- **Strips HTML tags** from the error message (simple regex) and collapses whitespace — status code + reason phrase are preserved, raw nginx markup is gone.
- **Downgrades 5xx responses from ERROR to WARNING.** The caching layer already has an offline-resilient fallback (`_plex_tv_reachable = False` → use cached data), so transient plex.tv outages aren't user-actionable. WARNING is the correct severity and avoids tripping error-level notification handlers.

The `401`/`403`/`404`/`429`/unrecognized-error branches keep their current log levels — only the 5xx branch changes severity.

## Changes

- `core/plex_api.py` — `_log_api_error` strips HTML, 5xx logs at WARNING
- `tests/test_log_api_error.py` — 11 new tests covering HTML stripping, whitespace collapse, plain-text preservation, and log-level expectations for each status-code branch

## Test plan

- [x] `pytest tests/test_log_api_error.py` — 11/11 pass
- [x] Full suite: 845 passed, 22 skipped, 1 pre-existing Windows-only failure in `test_file_operations_safety` (unrelated to this change)

## Notes

Rate-limiting duplicate 5xx notifications was discussed as a stretch goal but deferred — it would add per-context state that isn't justified by the immediate cleanup goal.