### PR TITLE
Default real paths to /mnt/user0/ and handle legacy /mnt/user/ mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ docker run -d \
   -v /mnt/user/appdata/plexcache:/config \
   -v /mnt/cache:/mnt/cache \
   -v /mnt/user0:/mnt/user0 \
-  -v /mnt/user:/mnt/user \
   -e PUID=99 \
   -e PGID=100 \
   -e TZ=America/Los_Angeles \
@@ -156,12 +155,13 @@ docker run -d \
    - `/config` → `/mnt/user/appdata/plexcache`
    - `/mnt/cache` → `/mnt/cache` (read-write)
    - `/mnt/user0` → `/mnt/user0` (read-write)
-   - `/mnt/user` → `/mnt/user` (read-write)
 4. Set **WebUI**: `http://[IP]:[PORT:5757]`
 5. Set a port mapping: `5757:5757`
 6. Click **Apply**
 
-> **Important:** All media paths (`/mnt/cache`, `/mnt/user0`, `/mnt/user`) must be **read-write** for PlexCache-D to move files between cache and array.
+> **Important:** Both media paths (`/mnt/cache`, `/mnt/user0`) must be **read-write** for PlexCache-D to move files between cache and array.
+
+> **ZFS pool-only shares:** If your media share lives on a ZFS pool with `shareUseCache=only`, files never appear under `/mnt/user0/`. Mount your pool path instead (e.g., `-v /mnt/plex:/mnt/plex`) and use that as the **Array Path** in your path mappings.
 
 ### First Run
 
@@ -172,7 +172,7 @@ Open `http://[YOUR_IP]:5757` - the Setup Wizard will guide you through:
 - Caching behavior configuration
 - Security settings (optional Plex OAuth authentication)
 
-**Important:** Volume paths for `/mnt/cache`, `/mnt/user0`, and `/mnt/user` must match exactly between container and host for Plex path resolution.
+**Important:** Volume paths for `/mnt/cache` and `/mnt/user0` must match exactly between container and host for Plex path resolution.
 
 See `docker/UNRAID_SETUP.md` for detailed Unraid setup instructions including CA Mover Tuning integration.
 

--- a/core/app.py
+++ b/core/app.py
@@ -1507,6 +1507,19 @@ class PlexCacheApp:
         if not pre_run_rk_index:
             return
 
+        def _canonicalize(p: str) -> str:
+            """Treat /mnt/user/X and /mnt/user0/X as the same logical file.
+
+            Users who switch their real_path default from /mnt/user/ → /mnt/user0/
+            (array-direct) end up with tracker entries keyed under the old prefix
+            while the current run reports the new prefix. Without this, the same
+            rating_key would show "disappeared" + "appeared" for every file and
+            misfire upgrade detection on the first run after the switch.
+            """
+            if p.startswith('/mnt/user/'):
+                return '/mnt/user0/' + p[len('/mnt/user/'):]
+            return p
+
         # Build current rating_key → set of real paths
         current_rk_paths = {}
         for item in ondeck_items_list:
@@ -1521,26 +1534,37 @@ class PlexCacheApp:
             if not new_paths:
                 continue
 
-            # Paths that appeared (not in old set) and paths that disappeared
-            appeared = new_paths - old_paths
-            disappeared = old_paths - new_paths
+            # Compare on canonical form so a /mnt/user/ → /mnt/user0/ prefix
+            # swap is not mistaken for a file upgrade.
+            canonical_old = {_canonicalize(p) for p in old_paths}
+            canonical_new = {_canonicalize(p) for p in new_paths}
+            appeared_canon = canonical_new - canonical_old
+            disappeared_canon = canonical_old - canonical_new
 
             # An upgrade is when a path disappears and a new one appears for the same key.
             # Multi-version additions (new path, nothing disappeared) are NOT upgrades.
-            if appeared and disappeared:
-                # Match disappeared→appeared 1:1 for transfer (handles single upgrade case)
-                for old_path, new_path in zip(sorted(disappeared), sorted(appeared)):
-                    upgrades_detected += 1
-                    logging.info(f"[UPGRADE] Detected file upgrade for rating_key={rk}: "
-                                 f"{os.path.basename(old_path)} → {os.path.basename(new_path)}")
-                    # Find an OnDeckItem for the new path to pass metadata
-                    item_for_transfer = next(
-                        (i for i in ondeck_items_list if i.rating_key == rk
-                         and plex_to_real.get(i.file_path, i.file_path) == new_path),
-                        None
-                    )
-                    if item_for_transfer:
-                        self._transfer_upgrade_tracking(old_path, new_path, item_for_transfer)
+            if not (appeared_canon and disappeared_canon):
+                continue
+
+            # Map canonical back to original paths for the transfer call.
+            old_by_canon = {_canonicalize(p): p for p in old_paths}
+            new_by_canon = {_canonicalize(p): p for p in new_paths}
+
+            # Match disappeared→appeared 1:1 for transfer (handles single upgrade case)
+            for old_canon, new_canon in zip(sorted(disappeared_canon), sorted(appeared_canon)):
+                old_path = old_by_canon[old_canon]
+                new_path = new_by_canon[new_canon]
+                upgrades_detected += 1
+                logging.info(f"[UPGRADE] Detected file upgrade for rating_key={rk}: "
+                             f"{os.path.basename(old_path)} → {os.path.basename(new_path)}")
+                # Find an OnDeckItem for the new path to pass metadata
+                item_for_transfer = next(
+                    (i for i in ondeck_items_list if i.rating_key == rk
+                     and plex_to_real.get(i.file_path, i.file_path) == new_path),
+                    None
+                )
+                if item_for_transfer:
+                    self._transfer_upgrade_tracking(old_path, new_path, item_for_transfer)
 
         if upgrades_detected:
             logging.info(f"[UPGRADE] Processed {upgrades_detected} media file upgrade(s)")

--- a/core/setup.py
+++ b/core/setup.py
@@ -161,8 +161,9 @@ def prompt_library_path_mapping(library_name: str, plex_locations: list, cache_r
         else:
             mapping_name = library_name
 
-        # Suggest a real path based on common patterns
-        suggested_real = plex_path.replace('/data/', '/mnt/user/').replace('/media/', '/mnt/user/')
+        # Suggest a real path based on common patterns. Default to /mnt/user0/
+        # (array-direct) so the container only needs /mnt/user0 + /mnt/cache mounted.
+        suggested_real = plex_path.replace('/data/', '/mnt/user0/').replace('/media/', '/mnt/user0/')
 
         print(f"  Where is this located on your filesystem?")
         real_path = input(f"  Real path [{suggested_real}]: ").strip() or suggested_real
@@ -200,7 +201,7 @@ def prompt_library_path_mapping(library_name: str, plex_locations: list, cache_r
                 cache_path = cache_path + '/'
         elif cacheable and not cache_root:
             # No cache root set - shouldn't happen in new flow but handle gracefully
-            suggested_cache = real_path.replace('/mnt/user/', '/mnt/cache/')
+            suggested_cache = real_path.replace('/mnt/user0/', '/mnt/cache/').replace('/mnt/user/', '/mnt/cache/')
             print(f"\n  Where should cached files be stored?")
             cache_path = input(f"  Cache path [{suggested_cache}]: ").strip() or suggested_cache
             if cache_path and not cache_path.endswith('/'):

--- a/docker/UNRAID_SETUP.md
+++ b/docker/UNRAID_SETUP.md
@@ -51,12 +51,14 @@ PlexCache-D automatically caches your frequently-accessed Plex media (OnDeck and
 |---------------|-----------|------|-------------|
 | `/config` | `/mnt/user/appdata/plexcache` | rw | Config, data, logs, exclude file |
 | `/mnt/cache` | `/mnt/cache` | rw | Your cache drive (destination for cached files) |
-| `/mnt/user0` | `/mnt/user0` | rw | Array-only view (for .plexcached backups) |
-| `/mnt/user` | `/mnt/user` | rw | Merged share (source for caching operations) |
+| `/mnt/user0` | `/mnt/user0` | rw | Array-direct access (source/destination for array operations) |
 
 **Important**:
-- All media paths (`/mnt/cache`, `/mnt/user0`, `/mnt/user`) must be **read-write** for PlexCache-D to move files between cache and array
+- Both media paths (`/mnt/cache`, `/mnt/user0`) must be **read-write** for PlexCache-D to move files between cache and array
 - These paths **must match exactly** between container and host for Plex path resolution to work correctly
+- `/mnt/user/` (the FUSE merged share) is **not** mounted by default. PlexCache-D operates on `/mnt/user0/` directly to avoid the FUSE layer's cache/array ambiguity, which is the safer pattern for caching operations.
+
+> **ZFS pool-only shares:** If your media share lives on a ZFS pool with `shareUseCache=only`, files never appear under `/mnt/user0/` — they only exist on the pool. For these setups, mount your pool path instead (e.g., `/mnt/plex` → `/mnt/plex`) and use that as the **Array Path** in your path mappings. Hybrid ZFS shares (cache pool + array disks) work normally with `/mnt/user0/`.
 
 ### Docker Path Translation (Host Cache Path)
 

--- a/docker/plexcache-d.xml
+++ b/docker/plexcache-d.xml
@@ -42,8 +42,7 @@ CA Mover Tuning plugin recommended (optional) for mover exclude list integration
     <!-- Paths -->
     <Config Name="Config" Target="/config" Default="/mnt/user/appdata/plexcache" Mode="rw" Description="Persistent storage for settings, logs, and tracking data" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/plexcache</Config>
     <Config Name="Cache" Target="/mnt/cache" Default="/mnt/cache" Mode="rw" Description="Your Unraid cache drive where media files are cached for fast access" Type="Path" Display="always" Required="true" Mask="false">/mnt/cache</Config>
-    <Config Name="Array" Target="/mnt/user0" Default="/mnt/user0" Mode="rw" Description="Direct array access (user0) for creating .plexcached backups" Type="Path" Display="always" Required="true" Mask="false">/mnt/user0</Config>
-    <Config Name="User" Target="/mnt/user" Default="/mnt/user" Mode="rw" Description="User share for Plex library path resolution" Type="Path" Display="always" Required="true" Mask="false">/mnt/user</Config>
+    <Config Name="Array" Target="/mnt/user0" Default="/mnt/user0" Mode="rw" Description="Direct array access (user0) for reading and writing array files. ZFS pool-only shares: mount your pool path (e.g. /mnt/plex) instead." Type="Path" Display="always" Required="true" Mask="false">/mnt/user0</Config>
 
     <!-- Environment Variables -->
     <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="User ID for file permissions (99 = nobody on Unraid)" Type="Variable" Display="always" Required="false" Mask="false">99</Config>

--- a/tests/test_docker_mount_validation.py
+++ b/tests/test_docker_mount_validation.py
@@ -256,6 +256,39 @@ class TestDetectHealthIssuesDocker:
         overlay_issues = [i for i in issues if i["issue_type"] == "overlay_path"]
         assert len(overlay_issues) == 0
 
+    @patch('web.services.settings_service.IS_DOCKER', True)
+    @patch('web.services.settings_service.get_system_detector')
+    def test_suggests_user0_when_legacy_user_real_path_and_user0_mounted(self, mock_get_detector):
+        """After dropping /mnt/user mount, a legacy real_path should recommend /mnt/user0/."""
+        detector = MagicMock()
+
+        def is_mounted(path: str):
+            # /mnt/user0 IS mounted; cache is mounted; real_path (/mnt/user/...) is NOT.
+            return (path.startswith("/mnt/user0") or path.startswith("/mnt/cache"), None)
+
+        detector.is_path_bind_mounted.side_effect = is_mounted
+        mock_get_detector.return_value = detector
+
+        from web.services.settings_service import SettingsService
+        svc = SettingsService()
+        with patch.object(svc, '_load_raw', return_value={
+            "path_mappings": [{
+                "name": "TV Shows",
+                "enabled": True,
+                "cache_path": "/mnt/cache/TV Shows/",
+                "real_path": "/mnt/user/TV Shows/",
+            }]
+        }):
+            issues = svc.detect_path_mapping_health_issues()
+
+        legacy_issues = [i for i in issues if i["issue_type"] == "legacy_user_real_path"]
+        assert len(legacy_issues) == 1
+        assert "/mnt/user0/TV Shows/" in legacy_issues[0]["message"]
+        assert "Settings → Paths" in legacy_issues[0]["message"]
+        # Should NOT double-report as generic overlay_path
+        overlay_issues = [i for i in issues if i["issue_type"] == "overlay_path"]
+        assert all("real_path" not in i["message"] for i in overlay_issues)
+
 
 # ============================================================================
 # FileMover gate tests

--- a/tests/test_libraries_settings.py
+++ b/tests/test_libraries_settings.py
@@ -140,7 +140,7 @@ class TestAutoFillMapping:
     """Tests for auto_fill_mapping()."""
 
     def test_auto_fill_mapping_docker_pattern(self, settings_service):
-        """/data/tv/ → /mnt/user/tv/ real path translation."""
+        """/data/tv/ → /mnt/user0/tv/ real path translation (array-direct default)."""
         library = {"id": 2, "title": "TV Shows", "type": "show", "type_label": "TV Shows",
                    "locations": ["/data/tv/"]}
         settings = {"cache_dir": "/mnt/cache"}
@@ -148,7 +148,7 @@ class TestAutoFillMapping:
         result = settings_service.auto_fill_mapping(library, "/data/tv/", settings)
 
         assert result["plex_path"] == "/data/tv/"
-        assert result["real_path"] == "/mnt/user/tv/"
+        assert result["real_path"] == "/mnt/user0/tv/"
         assert result["section_id"] == 2
         assert result["enabled"] is True
         assert result["cacheable"] is True
@@ -165,14 +165,14 @@ class TestAutoFillMapping:
         assert result["name"] == "Movies"
 
     def test_auto_fill_mapping_media_prefix(self, settings_service):
-        """/media/ prefix also maps to /mnt/user/."""
+        """/media/ prefix also maps to /mnt/user0/ (array-direct default)."""
         library = {"id": 3, "title": "Music", "type": "artist", "type_label": "Music",
                    "locations": ["/media/music/"]}
         settings = {"cache_dir": "/mnt/cache"}
 
         result = settings_service.auto_fill_mapping(library, "/media/music/", settings)
 
-        assert result["real_path"] == "/mnt/user/music/"
+        assert result["real_path"] == "/mnt/user0/music/"
 
     def test_auto_fill_mapping_no_trailing_slash(self, settings_service):
         """Plex paths without trailing slash get one added."""

--- a/tests/test_rating_key_tracking.py
+++ b/tests/test_rating_key_tracking.py
@@ -378,6 +378,41 @@ class TestUpgradeDetection:
         # No exclude list changes
         mock_app.file_filter.remove_files_from_exclude_list.assert_not_called()
 
+    def test_user_to_user0_prefix_swap_is_not_upgrade(self, mock_app):
+        """Switching real_path from /mnt/user/ → /mnt/user0/ must not misfire as upgrade.
+
+        Regression: users who adopt the new array-direct default end up with
+        pre-run tracker keys at /mnt/user/X while the current run reports
+        /mnt/user0/X. Same rating_key, same basename — same file. Upgrade
+        detector should treat the two prefixes as equivalent.
+        """
+        from core.app import PlexCacheApp
+
+        pre_run_rk_index = {"100": {"/mnt/user/media/movie.mkv"}}
+
+        ondeck_items = [
+            OnDeckItem(
+                file_path="/plex/media/movie.mkv",
+                username="Alice",
+                rating_key="100"
+            )
+        ]
+        plex_to_real = {"/plex/media/movie.mkv": "/mnt/user0/media/movie.mkv"}
+
+        with patch.object(PlexCacheApp, '__init__', lambda self, *a, **kw: None):
+            app = PlexCacheApp.__new__(PlexCacheApp)
+            app.dry_run = False
+            app.ondeck_tracker = mock_app.ondeck_tracker
+            app.file_filter = mock_app.file_filter
+            app.file_path_modifier = mock_app.file_path_modifier
+            app.config_manager = mock_app.config_manager
+
+            app._detect_and_transfer_upgrades(ondeck_items, plex_to_real, pre_run_rk_index)
+
+        # No upgrade should have fired — this is the same logical file
+        mock_app.file_filter.remove_files_from_exclude_list.assert_not_called()
+        mock_app.file_filter._add_to_exclude_file.assert_not_called()
+
     def test_missing_rating_key_skipped(self, mock_app):
         """Items without rating_key are skipped."""
         from core.app import PlexCacheApp

--- a/web/routers/setup.py
+++ b/web/routers/setup.py
@@ -279,10 +279,11 @@ def setup_step3_post(request: Request, form_data: ImmutableMultiDict = Depends(p
                 else:
                     mapping_name = lib_title
 
-                # Suggest real_path based on common Docker path patterns
-                # Common patterns: /data/ -> /mnt/user/, /media/ -> /mnt/user/
+                # Suggest real_path based on common Docker path patterns.
+                # Default to /mnt/user0/ (array-direct) so the container only
+                # needs /mnt/user0 + /mnt/cache mounted — no /mnt/user FUSE share.
                 real_path = plex_path_normalized
-                for docker_prefix, host_prefix in [('/data/', '/mnt/user/'), ('/media/', '/mnt/user/')]:
+                for docker_prefix, host_prefix in [('/data/', '/mnt/user0/'), ('/media/', '/mnt/user0/')]:
                     if plex_path_normalized.startswith(docker_prefix):
                         real_path = plex_path_normalized.replace(docker_prefix, host_prefix, 1)
                         break

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -367,6 +367,12 @@ class SettingsService:
         # Docker mount validation (issue #139)
         if IS_DOCKER:
             detector = get_system_detector()
+            # Container switched the default from /mnt/user/ to /mnt/user0/.
+            # If the user updated their Docker template but still has legacy
+            # /mnt/user/... paths in their mappings, point them at the exact
+            # replacement instead of the generic "check your mounts" message.
+            user0_mounted, _ = detector.is_path_bind_mounted("/mnt/user0")
+
             for m in mappings:
                 if not m.get("enabled", True):
                     continue
@@ -377,19 +383,44 @@ class SettingsService:
                         continue
                     # host_cache_path is intentionally a host path — do NOT validate it
                     is_mounted, _ = detector.is_path_bind_mounted(path_val)
-                    if not is_mounted:
+                    if is_mounted:
+                        continue
+
+                    # Specific case: legacy /mnt/user/... path while /mnt/user0
+                    # IS mounted. Recommend the array-direct replacement.
+                    if (
+                        user0_mounted
+                        and label == "real_path"
+                        and path_val.startswith("/mnt/user/")
+                        and not path_val.startswith("/mnt/user0/")
+                    ):
+                        suggestion = "/mnt/user0/" + path_val[len("/mnt/user/"):]
                         issues.append({
                             "mapping_name": name,
-                            "issue_type": "overlay_path",
+                            "issue_type": "legacy_user_real_path",
                             "message": (
-                                f"Mapping '{name}' has {label} set to "
-                                f"'{m.get(field_name)}' which is not backed by "
-                                f"a Docker bind mount. Writes to this path will "
-                                f"go into the container's overlay filesystem "
-                                f"(docker.img), not your host drive. Check your "
-                                f"container's volume configuration."
+                                f"Mapping '{name}' has real_path '{m.get(field_name)}' "
+                                f"but /mnt/user/ is no longer mounted in this container. "
+                                f"Update the Array Path to '{suggestion}/' in "
+                                f"Settings → Paths. /mnt/user0/ is the array-direct "
+                                f"path and the new default — it avoids the FUSE layer "
+                                f"entirely."
                             ),
                         })
+                        continue
+
+                    issues.append({
+                        "mapping_name": name,
+                        "issue_type": "overlay_path",
+                        "message": (
+                            f"Mapping '{name}' has {label} set to "
+                            f"'{m.get(field_name)}' which is not backed by "
+                            f"a Docker bind mount. Writes to this path will "
+                            f"go into the container's overlay filesystem "
+                            f"(docker.img), not your host drive. Check your "
+                            f"container's volume configuration."
+                        ),
+                    })
 
         for m in mappings:
             if not m.get("enabled", True):

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -510,10 +510,12 @@ class SettingsService:
             if folder_name and folder_name.lower() != name.lower():
                 name = f"{name} ({folder_name})"
 
-        # Suggest real_path based on common Docker path patterns
+        # Suggest real_path based on common Docker path patterns. Default to
+        # /mnt/user0/ (array-direct) so the container only needs /mnt/user0 +
+        # /mnt/cache mounted — no /mnt/user FUSE share.
         real_path = plex_path
         path_recognized = False
-        for docker_prefix, host_prefix in [("/data/", "/mnt/user/"), ("/media/", "/mnt/user/")]:
+        for docker_prefix, host_prefix in [("/data/", "/mnt/user0/"), ("/media/", "/mnt/user0/")]:
             if plex_path.startswith(docker_prefix):
                 real_path = plex_path.replace(docker_prefix, host_prefix, 1)
                 path_recognized = True


### PR DESCRIPTION
## Summary

Three related changes that make `/mnt/user0/` (array-direct) the default real_path across setup, the Unraid template, and documentation, and handle the upgrade friction for users still on `/mnt/user/`.

Operating on `/mnt/user0/` directly avoids Unraid's FUSE layer, which shows both cache and array files at the same path — the root cause of several data-safety edge cases addressed elsewhere in the codebase. Existing `/mnt/user/` mappings continue to work — the two-layer path-safety code (`_move_to_cache`, `_move_to_array`, `_evict_file_via_array`) still probes `/mnt/user0/` for safety-critical operations.

## Commits

- **Default path suggestions and Docker template to `/mnt/user0/`** — Setup wizard, web setup, and Settings auto-fill suggest `/mnt/user0/` real paths. Unraid template no longer requires the `/mnt/user` FUSE mount. README + `UNRAID_SETUP.md` add a callout for ZFS pool-only shares (users mount their pool path, e.g. `/mnt/plex`).

- **Surface actionable fix when legacy `/mnt/user/` real_path is unmounted** — When a user's Docker template drops `/mnt/user` but their saved path_mappings still use `/mnt/user/...`, the Dashboard now emits a targeted warning with the exact replacement path instead of the generic "not backed by a Docker bind mount" message. This is a narrow, specific-case slice of the reverse-suggestion engine deferred in #139 — aimed squarely at the upgrade path every existing user will travel exactly once. Full arbitrary-path-to-bind-mount correlation remains deferred.

- **Treat `/mnt/user/` and `/mnt/user0/` as equivalent in upgrade detection** — When a user updates path_mappings from `/mnt/user/` → `/mnt/user0/`, OnDeck tracker keys from prior runs still use the `/mnt/user/` prefix. Upgrade detection was comparing old-prefix tracker paths against new-prefix Plex-derived paths, seeing "path disappeared + new path appeared" with the same rating_key, and misfiring as a file upgrade on every OnDeck entry — wasting I/O re-creating `.plexcached` backups. Canonicalize both sides; normal tracker reconciliation still migrates the entries on the next run.

## Test plan

- [x] Fresh Docker install: wizard suggests `/mnt/user0/...` real paths.
- [x] Existing install with `/mnt/user/...` mappings + new template (no `/mnt/user` mount): Dashboard warning points at exact `/mnt/user0/...` replacement.
- [ ] Run a migration cycle with old `/mnt/user/` tracker entries and updated `/mnt/user0/` mappings — confirm no false upgrade-detection events in logs.
- [ ] ZFS pool-only share: no regressions, `detect_zfs()` still skips the user0 conversion.