### PR TITLE
Respect Stop requests during upgrade detection loop

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -110,8 +110,14 @@ class PlexCacheApp:
 
     @property
     def should_stop(self) -> bool:
-        """Check if stop has been requested."""
-        return self._stop_requested
+        """Check if stop has been requested.
+
+        ``getattr`` guards against partially-initialized instances (mainly
+        test helpers that bypass ``__init__`` via ``__new__``). In production
+        ``_stop_requested`` is always set by ``__init__`` before any phase
+        that reads this property.
+        """
+        return getattr(self, '_stop_requested', False)
 
     def run(self) -> None:
         """Run the main application."""
@@ -1517,6 +1523,10 @@ class PlexCacheApp:
 
         upgrades_detected = 0
         for rk, old_paths in pre_run_rk_index.items():
+            if self.should_stop:
+                logging.info("[UPGRADE] Stop requested — halting upgrade detection")
+                break
+
             new_paths = current_rk_paths.get(rk)
             if not new_paths:
                 continue
@@ -1530,6 +1540,9 @@ class PlexCacheApp:
             if appeared and disappeared:
                 # Match disappeared→appeared 1:1 for transfer (handles single upgrade case)
                 for old_path, new_path in zip(sorted(disappeared), sorted(appeared)):
+                    if self.should_stop:
+                        logging.info("[UPGRADE] Stop requested — halting upgrade detection")
+                        break
                     upgrades_detected += 1
                     logging.info(f"[UPGRADE] Detected file upgrade for rating_key={rk}: "
                                  f"{os.path.basename(old_path)} → {os.path.basename(new_path)}")

--- a/tests/test_rating_key_tracking.py
+++ b/tests/test_rating_key_tracking.py
@@ -552,6 +552,46 @@ class TestUpgradeDetection:
         assert "Bob" in new_entry["users"]
         assert new_entry["rating_key"] == "100"
 
+    def test_stop_requested_halts_upgrade_loop(self, mock_app):
+        """When request_stop() fires mid-loop, no further upgrades are processed.
+
+        Regression: the upgrade loop ran to completion after Stop was pressed,
+        leading to 30+ seconds of continued .plexcached churn before finishing.
+        """
+        from core.app import PlexCacheApp
+
+        # Three rating_keys all with upgrades pending
+        pre_run_rk_index = {
+            "100": {"/mnt/user/media/old1.mkv"},
+            "200": {"/mnt/user/media/old2.mkv"},
+            "300": {"/mnt/user/media/old3.mkv"},
+        }
+        ondeck_items = [
+            OnDeckItem(file_path="/plex/media/new1.mkv", username="Alice", rating_key="100"),
+            OnDeckItem(file_path="/plex/media/new2.mkv", username="Alice", rating_key="200"),
+            OnDeckItem(file_path="/plex/media/new3.mkv", username="Alice", rating_key="300"),
+        ]
+        plex_to_real = {
+            "/plex/media/new1.mkv": "/mnt/user/media/new1.mkv",
+            "/plex/media/new2.mkv": "/mnt/user/media/new2.mkv",
+            "/plex/media/new3.mkv": "/mnt/user/media/new3.mkv",
+        }
+
+        with patch.object(PlexCacheApp, '__init__', lambda self, *a, **kw: None):
+            app = PlexCacheApp.__new__(PlexCacheApp)
+            app._stop_requested = True  # Stop before the loop even starts
+            app.dry_run = False
+            app.ondeck_tracker = mock_app.ondeck_tracker
+            app.file_filter = mock_app.file_filter
+            app.file_path_modifier = mock_app.file_path_modifier
+            app.config_manager = mock_app.config_manager
+
+            app._detect_and_transfer_upgrades(ondeck_items, plex_to_real, pre_run_rk_index)
+
+        # No transfers should have happened
+        mock_app.file_filter.remove_files_from_exclude_list.assert_not_called()
+        mock_app.file_filter._add_to_exclude_file.assert_not_called()
+
 
 # ============================================================================
 # Multi-version (4K) support tests


### PR DESCRIPTION
## Summary

`_detect_and_transfer_upgrades` ran to completion after Stop was pressed. With a large `pre_run_rk_index` (hundreds of OnDeck items), each iteration could copy or re-create a multi-GB `.plexcached` backup, blocking the stop for minutes.

Checks `self.should_stop` at the top of each `rating_key` iteration and before each inner transfer. Matches the pattern used in the main `run()` phases.

Also hardens `should_stop` with `getattr(self, '_stop_requested', False)` so tests constructing `PlexCacheApp` via `__new__` (bypassing `__init__`) don't `AttributeError` when the property is read.

## Test plan

- [x] Start a cache run with an OnDeck queue that includes upgrade candidates.
- [x] Press Stop in the Web UI mid-run.
- [x] Confirm `[UPGRADE] Stop requested — halting upgrade detection` appears in logs and the run finalizes promptly instead of continuing through the remaining items.