### PR TITLE
Color-code user badges by user type (admin/home/shared)

### DIFF
--- a/web/routers/api.py
+++ b/web/routers/api.py
@@ -223,7 +223,8 @@ def cache_files_table(
             "sort_by": sort,
             "sort_dir": dir,
             "totals": totals,
-            "eviction_enabled": eviction_enabled
+            "eviction_enabled": eviction_enabled,
+            "user_types": cache_service.get_user_types(settings),
         }
     )
 
@@ -353,7 +354,8 @@ def cache_storage_stats(request: Request, expiring_within: int = 7):
         request,
         "cache/partials/storage_stats.html",
         {
-            "data": drive_details
+            "data": drive_details,
+            "user_types": cache_service.get_user_types(),
         }
     )
 
@@ -399,7 +401,8 @@ def cache_priorities_content(
             "data": report_data,
             "eviction_enabled": eviction_enabled,
             "sort_by": sort,
-            "sort_dir": dir
+            "sort_dir": dir,
+            "user_types": cache_service.get_user_types(settings),
         }
     )
 

--- a/web/routers/cache.py
+++ b/web/routers/cache.py
@@ -85,7 +85,8 @@ def cache_list(
             "sort_by": sort,
             "sort_dir": dir,
             "totals": totals,
-            "eviction_enabled": eviction_enabled
+            "eviction_enabled": eviction_enabled,
+            "user_types": cache_service.get_user_types(settings),
         }
     )
 
@@ -108,7 +109,8 @@ def cache_drive(request: Request, expiring_within: int = 7):
         "cache/drive.html",
         {
             "page_title": "Storage",
-            "data": drive_details
+            "data": drive_details,
+            "user_types": cache_service.get_user_types(),
         }
     )
 
@@ -120,12 +122,14 @@ def cache_priorities(
     dir: str = Query("desc", description="Sort direction")
 ):
     """Priority report page with detailed analysis (lazy loaded)"""
+    cache_service = get_cache_service()
     return templates.TemplateResponse(
         request,
         "cache/priorities.html",
         {
             "page_title": "Priority Report",
             "sort_by": sort,
-            "sort_dir": dir
+            "sort_dir": dir,
+            "user_types": cache_service.get_user_types(),
         }
     )

--- a/web/routers/operations.py
+++ b/web/routers/operations.py
@@ -178,8 +178,10 @@ def get_recent_activity(request: Request):
     is_htmx = request.headers.get("HX-Request") == "true"
 
     if is_htmx:
+        from web.services import get_cache_service
         context = {
             "activity": activity,
+            "user_types": get_cache_service().get_user_types(),
         }
         # Pass extra context when activity is empty for contextual empty states
         if not activity:

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -65,6 +65,33 @@ class CacheService:
         """Load settings file"""
         return self._load_json_file(self.settings_file)
 
+    def get_user_types(self, settings: Dict = None) -> Dict[str, str]:
+        """Build {username: 'admin'|'home'|'shared'} map from _cached_users.
+
+        The map is keyed by the `title` field because CachedFile.users stores
+        title strings (see core/plex_api.py: `username = user_entry.get("title")`).
+        `username` is also indexed as a fallback for entries where the two differ.
+        Admin wins when both is_admin and is_home are true.
+        """
+        if settings is None:
+            settings = self._load_settings()
+
+        user_types: Dict[str, str] = {}
+        for entry in settings.get("_cached_users", []):
+            if entry.get("is_admin"):
+                t = "admin"
+            elif entry.get("is_home"):
+                t = "home"
+            else:
+                t = "shared"
+            title = entry.get("title")
+            username = entry.get("username")
+            if title:
+                user_types[title] = t
+            if username and username != title:
+                user_types.setdefault(username, t)
+        return user_types
+
     def _get_cache_dir(self, settings: Dict = None) -> str:
         """Get the cache directory, preferring path_mappings over cache_dir setting.
 

--- a/web/static/css/plex-theme.css
+++ b/web/static/css/plex-theme.css
@@ -25,6 +25,9 @@ body {
     --plex-warning: #ff9800;
     --plex-error: #FF453A;
     --plex-info: #0A84FF;
+    --plex-user-admin: var(--plex-orange);
+    --plex-user-home: var(--plex-info);
+    --plex-user-shared: var(--plex-success);
     --sidebar-width: 200px;
     --sidebar-collapsed: 60px;
 
@@ -814,6 +817,21 @@ body {
 .badge-pinned {
     background: rgba(229, 160, 13, 0.18);
     color: var(--plex-orange);
+}
+
+.user-badge--admin {
+    background: rgba(229, 160, 13, 0.18);
+    color: var(--plex-user-admin);
+}
+
+.user-badge--home {
+    background: rgba(33, 150, 243, 0.15);
+    color: var(--plex-user-home);
+}
+
+.user-badge--shared {
+    background: rgba(76, 175, 80, 0.15);
+    color: var(--plex-user-shared);
 }
 
 /* Source badges column - show multiple badges inline */

--- a/web/templates/cache/partials/file_table.html
+++ b/web/templates/cache/partials/file_table.html
@@ -1,5 +1,6 @@
 <!-- Cache files table body - HTMX partial -->
 {% from "macros/associated_files.html" import af_popup, af_popup_init %}
+{% from "macros/user_badge.html" import user_badge %}
 {% if files %}
     {% for file in files %}
     {% set assoc_count = file.subtitle_count + file.sidecar_count %}
@@ -47,7 +48,7 @@
         <td>
             {% if file.users %}
                 {% for user in file.users %}
-                <span class="badge badge-success" style="margin-right: 0.25rem;">{{ user }}</span>
+                {{ user_badge(user, user_types, style='margin-right: 0.25rem;') }}
                 {% endfor %}
             {% else %}
             <span class="text-muted">-</span>

--- a/web/templates/cache/partials/priorities_content.html
+++ b/web/templates/cache/partials/priorities_content.html
@@ -1,4 +1,5 @@
 {% from "macros/associated_files.html" import af_badge %}
+{% from "macros/user_badge.html" import user_badge %}
 <!-- Priority Report Content - loaded via HTMX -->
 
 {% if data.files %}
@@ -196,7 +197,7 @@
                     <td>
                         {% if file.users %}
                             {% for user in file.users %}
-                            <span class="badge badge-success" style="margin-right: 0.25rem;">{{ user }}</span>
+                            {{ user_badge(user, user_types, style='margin-right: 0.25rem;') }}
                             {% endfor %}
                         {% else %}
                         <span class="text-muted">-</span>

--- a/web/templates/cache/partials/storage_stats.html
+++ b/web/templates/cache/partials/storage_stats.html
@@ -1,4 +1,5 @@
 {% from "macros/associated_files.html" import af_popup, af_popup_init %}
+{% from "macros/user_badge.html" import user_badge %}
 <!-- ZFS Warning (only shown when ZFS detected without manual override) -->
 {% if data.storage.is_zfs and not data.storage.has_manual_drive_size %}
 <div class="alert alert-warning mb-2" style="display: flex; align-items: flex-start; gap: 0.75rem; padding: 0.75rem 1rem;">
@@ -343,7 +344,7 @@
                             <td class="user-badges">
                                 {% if file.users %}
                                     {% for user in file.users %}
-                                    <span class="badge badge-success badge-sm">{{ user }}</span>
+                                    {{ user_badge(user, user_types, classes='badge-sm') }}
                                     {% endfor %}
                                 {% else %}
                                 <span class="text-muted">-</span>
@@ -409,7 +410,7 @@
                             <td class="user-badges">
                                 {% if file.users %}
                                     {% for user in file.users %}
-                                    <span class="badge badge-success badge-sm">{{ user }}</span>
+                                    {{ user_badge(user, user_types, classes='badge-sm') }}
                                     {% endfor %}
                                 {% else %}
                                 <span class="text-muted">-</span>
@@ -485,7 +486,7 @@
                             <td class="user-badges">
                                 {% if file.users %}
                                     {% for user in file.users %}
-                                    <span class="badge badge-success badge-sm">{{ user }}</span>
+                                    {{ user_badge(user, user_types, classes='badge-sm') }}
                                     {% endfor %}
                                 {% else %}
                                 <span class="text-muted">-</span>
@@ -564,7 +565,7 @@
                             <td class="user-badges">
                                 {% if item.file.users %}
                                     {% for user in item.file.users %}
-                                    <span class="badge badge-success badge-sm">{{ user }}</span>
+                                    {{ user_badge(user, user_types, classes='badge-sm') }}
                                     {% endfor %}
                                 {% else %}
                                 <span class="text-muted">-</span>

--- a/web/templates/components/recent_activity.html
+++ b/web/templates/components/recent_activity.html
@@ -1,5 +1,6 @@
 <!-- Recent Activity component - HTMX partial (grouped by date) -->
 {% from "macros/associated_files.html" import af_expand_badge, af_expand_rows, af_expand_onclick %}
+{% from "macros/user_badge.html" import user_badge %}
 {% if activity %}
 {% for group in activity|groupby('date_key')|reverse %}
 <tr class="date-group-header" data-date-group="{{ group.grouper }}">
@@ -32,7 +33,7 @@
     <td class="user-badges">
         {% if item.users and item.users|length > 0 %}
             {% for user in item.users[:3] %}
-            <span class="badge badge-success badge-sm">{{ user }}</span>
+            {{ user_badge(user, user_types, classes='badge-sm') }}
             {% endfor %}
             {% if item.users|length > 3 %}
             <span class="badge badge-muted badge-sm">+{{ item.users|length - 3 }}</span>

--- a/web/templates/macros/user_badge.html
+++ b/web/templates/macros/user_badge.html
@@ -1,0 +1,17 @@
+{#
+  user_badge(user, user_types, classes='', style='')
+
+  Render a username as a color-coded badge. Color is derived from user_types
+  (a {username: 'admin'|'home'|'shared'} map built from _cached_users). Unknown
+  usernames fall back to 'shared' — current behavior for users not yet synced.
+
+  Args:
+    user:       The username string (as stored in CachedFile.users).
+    user_types: Dict mapping username -> type. Pass {} or None to skip typing.
+    classes:    Extra CSS classes to append (e.g. 'badge-sm').
+    style:      Inline style string (e.g. 'margin-right: 0.25rem;').
+#}
+{% macro user_badge(user, user_types, classes='', style='') -%}
+{%- set t = (user_types or {}).get(user, 'shared') -%}
+<span class="badge user-badge user-badge--{{ t }}{% if classes %} {{ classes }}{% endif %}"{% if style %} style="{{ style }}"{% endif %}>{{ user }}</span>
+{%- endmacro %}


### PR DESCRIPTION
## Summary

Replaces the uniform green `badge-success` styling across the cache UI with three semantic colors, so the server owner can tell at a glance which user is the admin, which are Home users, and which are shared friends.

Originated from a user request on GitHub Discussions ("Is there a way to color code the USERS column...right now all user names are green.").

### Classification

Admin wins when both `is_admin` and `is_home` are True.

| Type | Rule | Color |
|------|------|-------|
| **Admin** (server owner) | `is_admin == True` | Gold — `var(--plex-orange)` |
| **Home user** (managed profile) | `is_admin == False AND is_home == True` | Blue — `var(--plex-info)` |
| **Shared user** (friend) | neither | Green — `var(--plex-success)` (unchanged) |

Unknown usernames (not in the settings map) fall back to shared green — preserves today's behavior for users not yet synced.

### Approach

Classification is a property of the user in settings, not of the cached file. `CacheService.get_user_types(settings)` builds a `{title: type}` map from the existing `_cached_users` array (already populated and refreshed hourly by `settings_service.get_plex_users()`). No new persistence, no schema change, no extra Plex calls at render time.

A new Jinja macro `web/templates/macros/user_badge.html` emits the `<span>` with the correct class. Seven render sites swapped from `<span class="badge badge-success">{{ user }}</span>` to `{{ user_badge(user, user_types) }}`.

### Files changed (10)

- `web/services/cache_service.py` — new `get_user_types()` helper
- `web/routers/cache.py`, `web/routers/api.py`, `web/routers/operations.py` — inject `user_types` into render contexts (list, priorities, storage stats, recent activity, HTMX partials)
- `web/static/css/plex-theme.css` — three semantic tokens (`--plex-user-admin/home/shared`) that alias existing colors + three classes (`.user-badge--admin/home/shared`) with rgba backgrounds that work in both themes
- `web/templates/macros/user_badge.html` — new macro (single render site for all user badges)
- `web/templates/cache/partials/file_table.html`, `priorities_content.html`, `storage_stats.html` (4 tables), `web/templates/components/recent_activity.html` — swap hardcoded spans for the macro

## Test plan

- [x] Open the Cached Files list — verify badge colors for admin/home/shared users match expectations
- [x] Open Recent Activity on the Dashboard — verify badge colors render
- [x] Open the Storage Stats breakdowns (movies/shows/users/etc.) — verify colors render across all four tables
- [x] Toggle light/dark theme — verify contrast is readable on both (semantic tokens have light-theme overrides)
- [x] With a user not yet synced (not in `_cached_users`) — verify fallback to shared green
- [x] With `users` empty — verify the existing `-` placeholder still renders (no badge)