### PR TITLE
Handle legacy /mnt/user/ real_paths gracefully

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -1513,6 +1513,19 @@ class PlexCacheApp:
         if not pre_run_rk_index:
             return
 
+        def _canonicalize(p: str) -> str:
+            """Treat /mnt/user/X and /mnt/user0/X as the same logical file.
+
+            Users who switch their real_path default from /mnt/user/ → /mnt/user0/
+            (array-direct) end up with tracker entries keyed under the old prefix
+            while the current run reports the new prefix. Without this, the same
+            rating_key would show "disappeared" + "appeared" for every file and
+            misfire upgrade detection on the first run after the switch.
+            """
+            if p.startswith('/mnt/user/'):
+                return '/mnt/user0/' + p[len('/mnt/user/'):]
+            return p
+
         # Build current rating_key → set of real paths
         current_rk_paths = {}
         for item in ondeck_items_list:
@@ -1531,29 +1544,40 @@ class PlexCacheApp:
             if not new_paths:
                 continue
 
-            # Paths that appeared (not in old set) and paths that disappeared
-            appeared = new_paths - old_paths
-            disappeared = old_paths - new_paths
+            # Compare on canonical form so a /mnt/user/ → /mnt/user0/ prefix
+            # swap is not mistaken for a file upgrade.
+            canonical_old = {_canonicalize(p) for p in old_paths}
+            canonical_new = {_canonicalize(p) for p in new_paths}
+            appeared_canon = canonical_new - canonical_old
+            disappeared_canon = canonical_old - canonical_new
 
             # An upgrade is when a path disappears and a new one appears for the same key.
             # Multi-version additions (new path, nothing disappeared) are NOT upgrades.
-            if appeared and disappeared:
-                # Match disappeared→appeared 1:1 for transfer (handles single upgrade case)
-                for old_path, new_path in zip(sorted(disappeared), sorted(appeared)):
-                    if self.should_stop:
-                        logging.info("[UPGRADE] Stop requested — halting upgrade detection")
-                        break
-                    upgrades_detected += 1
-                    logging.info(f"[UPGRADE] Detected file upgrade for rating_key={rk}: "
-                                 f"{os.path.basename(old_path)} → {os.path.basename(new_path)}")
-                    # Find an OnDeckItem for the new path to pass metadata
-                    item_for_transfer = next(
-                        (i for i in ondeck_items_list if i.rating_key == rk
-                         and plex_to_real.get(i.file_path, i.file_path) == new_path),
-                        None
-                    )
-                    if item_for_transfer:
-                        self._transfer_upgrade_tracking(old_path, new_path, item_for_transfer)
+            if not (appeared_canon and disappeared_canon):
+                continue
+
+            # Map canonical back to original paths for the transfer call.
+            old_by_canon = {_canonicalize(p): p for p in old_paths}
+            new_by_canon = {_canonicalize(p): p for p in new_paths}
+
+            # Match disappeared→appeared 1:1 for transfer (handles single upgrade case)
+            for old_canon, new_canon in zip(sorted(disappeared_canon), sorted(appeared_canon)):
+                if self.should_stop:
+                    logging.info("[UPGRADE] Stop requested — halting upgrade detection")
+                    break
+                old_path = old_by_canon[old_canon]
+                new_path = new_by_canon[new_canon]
+                upgrades_detected += 1
+                logging.info(f"[UPGRADE] Detected file upgrade for rating_key={rk}: "
+                             f"{os.path.basename(old_path)} → {os.path.basename(new_path)}")
+                # Find an OnDeckItem for the new path to pass metadata
+                item_for_transfer = next(
+                    (i for i in ondeck_items_list if i.rating_key == rk
+                     and plex_to_real.get(i.file_path, i.file_path) == new_path),
+                    None
+                )
+                if item_for_transfer:
+                    self._transfer_upgrade_tracking(old_path, new_path, item_for_transfer)
 
         if upgrades_detected:
             logging.info(f"[UPGRADE] Processed {upgrades_detected} media file upgrade(s)")

--- a/tests/test_docker_mount_validation.py
+++ b/tests/test_docker_mount_validation.py
@@ -256,6 +256,39 @@ class TestDetectHealthIssuesDocker:
         overlay_issues = [i for i in issues if i["issue_type"] == "overlay_path"]
         assert len(overlay_issues) == 0
 
+    @patch('web.services.settings_service.IS_DOCKER', True)
+    @patch('web.services.settings_service.get_system_detector')
+    def test_suggests_user0_when_legacy_user_real_path_and_user0_mounted(self, mock_get_detector):
+        """After dropping /mnt/user mount, a legacy real_path should recommend /mnt/user0/."""
+        detector = MagicMock()
+
+        def is_mounted(path: str):
+            # /mnt/user0 IS mounted; cache is mounted; real_path (/mnt/user/...) is NOT.
+            return (path.startswith("/mnt/user0") or path.startswith("/mnt/cache"), None)
+
+        detector.is_path_bind_mounted.side_effect = is_mounted
+        mock_get_detector.return_value = detector
+
+        from web.services.settings_service import SettingsService
+        svc = SettingsService()
+        with patch.object(svc, '_load_raw', return_value={
+            "path_mappings": [{
+                "name": "TV Shows",
+                "enabled": True,
+                "cache_path": "/mnt/cache/TV Shows/",
+                "real_path": "/mnt/user/TV Shows/",
+            }]
+        }):
+            issues = svc.detect_path_mapping_health_issues()
+
+        legacy_issues = [i for i in issues if i["issue_type"] == "legacy_user_real_path"]
+        assert len(legacy_issues) == 1
+        assert "/mnt/user0/TV Shows/" in legacy_issues[0]["message"]
+        assert "Settings → Paths" in legacy_issues[0]["message"]
+        # Should NOT double-report as generic overlay_path
+        overlay_issues = [i for i in issues if i["issue_type"] == "overlay_path"]
+        assert all("real_path" not in i["message"] for i in overlay_issues)
+
 
 # ============================================================================
 # FileMover gate tests

--- a/tests/test_rating_key_tracking.py
+++ b/tests/test_rating_key_tracking.py
@@ -378,6 +378,41 @@ class TestUpgradeDetection:
         # No exclude list changes
         mock_app.file_filter.remove_files_from_exclude_list.assert_not_called()
 
+    def test_user_to_user0_prefix_swap_is_not_upgrade(self, mock_app):
+        """Switching real_path from /mnt/user/ → /mnt/user0/ must not misfire as upgrade.
+
+        Regression: users who adopt the new array-direct default end up with
+        pre-run tracker keys at /mnt/user/X while the current run reports
+        /mnt/user0/X. Same rating_key, same basename — same file. Upgrade
+        detector should treat the two prefixes as equivalent.
+        """
+        from core.app import PlexCacheApp
+
+        pre_run_rk_index = {"100": {"/mnt/user/media/movie.mkv"}}
+
+        ondeck_items = [
+            OnDeckItem(
+                file_path="/plex/media/movie.mkv",
+                username="Alice",
+                rating_key="100"
+            )
+        ]
+        plex_to_real = {"/plex/media/movie.mkv": "/mnt/user0/media/movie.mkv"}
+
+        with patch.object(PlexCacheApp, '__init__', lambda self, *a, **kw: None):
+            app = PlexCacheApp.__new__(PlexCacheApp)
+            app.dry_run = False
+            app.ondeck_tracker = mock_app.ondeck_tracker
+            app.file_filter = mock_app.file_filter
+            app.file_path_modifier = mock_app.file_path_modifier
+            app.config_manager = mock_app.config_manager
+
+            app._detect_and_transfer_upgrades(ondeck_items, plex_to_real, pre_run_rk_index)
+
+        # No upgrade should have fired — this is the same logical file
+        mock_app.file_filter.remove_files_from_exclude_list.assert_not_called()
+        mock_app.file_filter._add_to_exclude_file.assert_not_called()
+
     def test_missing_rating_key_skipped(self, mock_app):
         """Items without rating_key are skipped."""
         from core.app import PlexCacheApp

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -367,6 +367,12 @@ class SettingsService:
         # Docker mount validation (issue #139)
         if IS_DOCKER:
             detector = get_system_detector()
+            # Container switched the default from /mnt/user/ to /mnt/user0/.
+            # If the user updated their Docker template but still has legacy
+            # /mnt/user/... paths in their mappings, point them at the exact
+            # replacement instead of the generic "check your mounts" message.
+            user0_mounted, _ = detector.is_path_bind_mounted("/mnt/user0")
+
             for m in mappings:
                 if not m.get("enabled", True):
                     continue
@@ -377,19 +383,44 @@ class SettingsService:
                         continue
                     # host_cache_path is intentionally a host path — do NOT validate it
                     is_mounted, _ = detector.is_path_bind_mounted(path_val)
-                    if not is_mounted:
+                    if is_mounted:
+                        continue
+
+                    # Specific case: legacy /mnt/user/... path while /mnt/user0
+                    # IS mounted. Recommend the array-direct replacement.
+                    if (
+                        user0_mounted
+                        and label == "real_path"
+                        and path_val.startswith("/mnt/user/")
+                        and not path_val.startswith("/mnt/user0/")
+                    ):
+                        suggestion = "/mnt/user0/" + path_val[len("/mnt/user/"):]
                         issues.append({
                             "mapping_name": name,
-                            "issue_type": "overlay_path",
+                            "issue_type": "legacy_user_real_path",
                             "message": (
-                                f"Mapping '{name}' has {label} set to "
-                                f"'{m.get(field_name)}' which is not backed by "
-                                f"a Docker bind mount. Writes to this path will "
-                                f"go into the container's overlay filesystem "
-                                f"(docker.img), not your host drive. Check your "
-                                f"container's volume configuration."
+                                f"Mapping '{name}' has real_path '{m.get(field_name)}' "
+                                f"but /mnt/user/ is no longer mounted in this container. "
+                                f"Update the Array Path to '{suggestion}/' in "
+                                f"Settings → Paths. /mnt/user0/ is the array-direct "
+                                f"path and the new default — it avoids the FUSE layer "
+                                f"entirely."
                             ),
                         })
+                        continue
+
+                    issues.append({
+                        "mapping_name": name,
+                        "issue_type": "overlay_path",
+                        "message": (
+                            f"Mapping '{name}' has {label} set to "
+                            f"'{m.get(field_name)}' which is not backed by "
+                            f"a Docker bind mount. Writes to this path will "
+                            f"go into the container's overlay filesystem "
+                            f"(docker.img), not your host drive. Check your "
+                            f"container's volume configuration."
+                        ),
+                    })
 
         for m in mappings:
             if not m.get("enabled", True):


### PR DESCRIPTION
## Summary

Two small, independent defensive improvements for path mappings that still reference `/mnt/user/` (the Unraid FUSE share):

1. **Upgrade detection: treat `/mnt/user/X` and `/mnt/user0/X` as the same file.** Users who switch their `real_path` default from `/mnt/user/` to `/mnt/user0/` (array-direct) end up with tracker entries keyed under the old prefix while the current run reports the new prefix. Without this, the same `rating_key` shows `disappeared` + `appeared` for every file and misfires upgrade detection on the first run after the switch.

2. **Health check: surface an actionable fix when a `real_path: /mnt/user/...` mapping has no `/mnt/user` bind mount but `/mnt/user0` is mounted.** Instead of the generic "overlay filesystem" warning, the user gets a specific suggestion to update the Array Path to `/mnt/user0/<same subpath>` in Settings → Paths.

Both changes are purely defensive — they don't change any defaults or touch the Unraid template. A broader PR reworking setup-wizard defaults and the Docker template (previously #146) is being re-scoped separately.

## Test plan

- [x] `tests/test_rating_key_tracking.py::TestUpgradeDetection::test_user_to_user0_prefix_swap_is_not_upgrade` — confirms the canonicalization prevents a false upgrade when only the prefix differs.
- [x] `tests/test_docker_mount_validation.py::TestDetectHealthIssuesDocker::test_suggests_user0_when_legacy_user_real_path_and_user0_mounted` — confirms the new `legacy_user_real_path` issue fires with the correct suggestion and suppresses the duplicate generic warning.
- [x] Manual: on a setup where a user still has `real_path: /mnt/user/...` and `/mnt/user` mounted, upgrade detection continues to work identically (regression check).
- [x] Manual: on a setup where `/mnt/user` has been dropped from the container but `/mnt/user0` is mounted, the Dashboard surfaces the new specific warning instead of the generic one.