### PR TITLE
Feature: Skip hard-linked files on restore from cache

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -198,6 +198,8 @@ class PlexCacheApp:
             # Log hard-linked files handling mode
             if self.config_manager.cache.hardlinked_files == "move":
                 logging.info("[CONFIG] Hard-linked files mode: MOVE - Hard-linked files will be cached (seed copies preserved via remaining hard links)")
+            if self.config_manager.cache.check_hardlinks_on_restore:
+                logging.info("[CONFIG] Hard-link restore check: ENABLED - Hard-linked files in cache will be skipped")
 
             # Log associated files mode
             assoc_mode = self.config_manager.cache.cache_associated_files
@@ -563,6 +565,7 @@ class PlexCacheApp:
             path_modifier=self.file_path_modifier,
             is_docker=self.system_detector.is_docker,
             use_symlinks=self.config_manager.cache.use_symlinks,
+            check_hardlinks_on_restore=self.config_manager.cache.check_hardlinks_on_restore,
             dry_run=self.dry_run
         )
 

--- a/core/config.py
+++ b/core/config.py
@@ -203,6 +203,11 @@ class CacheConfig:
     # "move" - Cache hard-linked files; seed copy preserved via remaining hard link
     hardlinked_files: str = "skip"
 
+    # Check for hard links when restoring files from cache back to array
+    # When True, cache files with multiple hard links (e.g., actively seeding from cache)
+    # are skipped and kept on cache until their links are resolved.
+    check_hardlinks_on_restore: bool = False
+
     # Associated files handling: which sibling files to cache alongside media
     # "all" - Cache all sibling files (subtitles, artwork, NFOs, metadata)
     # "subtitles" - Cache subtitle files only
@@ -541,6 +546,9 @@ class ConfigManager:
             logging.warning(f"Invalid hardlinked_files '{hardlinked_files}', using 'skip'")
             hardlinked_files = 'skip'
         self.cache.hardlinked_files = hardlinked_files
+
+        # Load hard-link check on restore setting (default False for backward compat)
+        self.cache.check_hardlinks_on_restore = self.settings_data.get('check_hardlinks_on_restore', False)
 
         # Load associated files caching mode (default "subtitles" for backward compat)
         cache_associated_files = self.settings_data.get('cache_associated_files', 'subtitles')

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -3044,6 +3044,7 @@ class FileFilter:
                  path_modifier: Optional['MultiPathModifier'] = None,
                  is_docker: bool = False,
                  use_symlinks: bool = False,
+                 check_hardlinks_on_restore: bool = False,
                  dry_run: bool = False):
         self.real_source = real_source
         self.cache_dir = cache_dir
@@ -3056,6 +3057,7 @@ class FileFilter:
         self.path_modifier = path_modifier  # For multi-path support
         self.is_docker = is_docker  # For path translation in Docker
         self.use_symlinks = use_symlinks  # Whether to create/preserve symlinks at original locations
+        self.check_hardlinks_on_restore = check_hardlinks_on_restore
         self.dry_run = dry_run  # Skip all file operations when True
         self.last_already_cached_count = 0  # Track files already on cache during filtering
         self._media_info_map = {}  # Plex media type info (set via set_media_info_map)
@@ -3670,6 +3672,19 @@ class FileFilter:
                     display_name = self._extract_display_name(cache_file)
                     logging.debug(f"Active session, keeping protected: {display_name}")
                     continue
+
+                # Skip files with active hard links
+                if self.check_hardlinks_on_restore:
+                    try:
+                        stat_info = os.stat(check_path)
+                        if stat_info.st_nlink > 1:
+                            display_name = self._extract_display_name(cache_file)
+                            logging.warning(
+                                f"Hard-linked ({stat_info.st_nlink} links), keeping in cache: {display_name}"
+                            )
+                            continue
+                    except OSError as e:
+                        logging.debug(f"Could not check hard link count for {cache_file}: {e}")
 
                 # Move file back to array (use container path for path conversion)
                 if self.path_modifier:

--- a/core/setup.py
+++ b/core/setup.py
@@ -978,6 +978,20 @@ def _setup_advanced_settings():
             hardlink_choice = 'skip'
         settings_data['hardlinked_files'] = hardlink_choice
 
+    # Hard-linked files on restore (cache → array)
+    if 'check_hardlinks_on_restore' not in settings_data:
+        print('\n--- Hard-Linked Files on Restore ---')
+        print('When restoring files from cache back to the array, PlexCache can')
+        print('skip files that are still actively hard-linked (e.g., being seeded')
+        print('by a torrent client from the cache drive).')
+        print('')
+        print('When enabled, any cached file with more than one hard link is left')
+        print('on cache until its extra links are resolved, avoiding unnecessary')
+        print('array spin-ups while seeding is active.')
+        print('')
+        restore_hardlink_choice = input('Skip hard-linked files on restore? [y/N] ').strip().lower()
+        settings_data['check_hardlinks_on_restore'] = restore_hardlink_choice == 'y'
+
     # Symlink Support (non-Unraid systems)
     if 'use_symlinks' not in settings_data:
         print('\n--- Symlink Support ---')
@@ -1449,6 +1463,7 @@ def check_for_missing_settings(settings: dict) -> list:
         'webhook_level',
         'create_plexcached_backups',
         'hardlinked_files',
+        'check_hardlinks_on_restore',
         'use_symlinks',
     ]
     missing = [s for s in optional_new_settings if s not in settings]

--- a/docs/example_settings.json
+++ b/docs/example_settings.json
@@ -90,6 +90,7 @@
 
     "create_plexcached_backups": true,
     "hardlinked_files": "skip",
+    "check_hardlinks_on_restore": false,
     "cleanup_empty_folders": true,
     "use_symlinks": false,
     "auto_transfer_upgrades": true,

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -555,6 +555,7 @@ class SettingsService:
             "cleanup_empty_folders": raw.get("cleanup_empty_folders", True),
             "use_symlinks": raw.get("use_symlinks", False),
             "hardlinked_files": raw.get("hardlinked_files", "skip"),
+            "check_hardlinks_on_restore": raw.get("check_hardlinks_on_restore", False),
             "cache_associated_files": raw.get("cache_associated_files", "subtitles"),
             "cache_retention_hours": raw.get("cache_retention_hours", 12),
             "cache_drive_size": raw.get("cache_drive_size", ""),
@@ -599,6 +600,7 @@ class SettingsService:
             "cleanup_empty_folders": ("cleanup_empty_folders", lambda x: x == "on" or x is True),
             "use_symlinks": ("use_symlinks", lambda x: x == "on" or x is True),
             "hardlinked_files": ("hardlinked_files", str),
+            "check_hardlinks_on_restore": ("check_hardlinks_on_restore", lambda x: x == "on" or x is True),
             "cache_associated_files": ("cache_associated_files", str),
             "cache_retention_hours": ("cache_retention_hours", safe_int),
             "cache_drive_size": ("cache_drive_size", str),
@@ -624,7 +626,8 @@ class SettingsService:
         boolean_fields = {
             "watchlist_toggle", "watched_move", "create_plexcached_backups",
             "cleanup_empty_folders", "use_symlinks", "auto_transfer_upgrades",
-            "backup_upgraded_files", "remote_watchlist_toggle", "exit_if_active_session"
+            "backup_upgraded_files", "remote_watchlist_toggle", "exit_if_active_session",
+            "check_hardlinks_on_restore"
         }
 
         for form_field, (setting_key, converter) in field_mapping.items():

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -1546,7 +1546,7 @@ class SettingsService:
             "PLEX_URL", "PLEX_TOKEN", "valid_sections", "path_mappings", "users",
             "users_toggle", "skip_ondeck", "skip_watchlist", "watchlist_toggle",
             "watchlist_episodes", "watchlist_retention_days", "watched_move",
-            "create_plexcached_backups", "hardlinked_files", "use_symlinks", "cache_retention_hours",
+            "create_plexcached_backups", "hardlinked_files", "check_hardlinks_on_restore", "use_symlinks", "cache_retention_hours",
             "cache_limit", "min_free_space", "plexcache_quota", "cache_eviction_mode", "cache_eviction_threshold_percent",
             "eviction_min_priority", "remote_watchlist_toggle", "remote_watchlist_rss_url",
             "notification_type", "unraid_level", "unraid_levels", "webhook_url",

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -185,6 +185,15 @@
             </div>
 
             <div class="form-group">
+                <label class="switch">
+                    <input type="checkbox" name="check_hardlinks_on_restore"
+                           {% if settings.check_hardlinks_on_restore | default(false) %}checked{% endif %}>
+                    <span>Check Hard-Linked Files on Restore (Cache → Array)</span>
+                </label>
+                <div class="form-hint">When enabled, cached files with multiple hard links (e.g., actively seeding from cache) are skipped and kept on cache until their links are resolved.</div>
+            </div>
+
+            <div class="form-group">
                 <label for="cache_associated_files">Associated Files</label>
                 <select id="cache_associated_files" name="cache_associated_files">
                     <option value="all" {% if settings.cache_associated_files == 'all' %}selected{% endif %}>All (subtitles, artwork, NFOs, metadata)</option>


### PR DESCRIPTION
# Feature: Skip Hard-Linked Files on Restore from Cache

## Summary

Adds an optional setting to skip hard-linked files when restoring from cache back to the array. When enabled, any cached file with more than one hard link is left on cache instead of being moved back.

The motivation is a use case where a custom script keeps actively seeding torrents on the SSD cache drive. Without this setting, PlexCache-D moves watched episodes back to the array even while they are still being seeded, causing unnecessary disk spin-ups on the array drive. With this feature enabled, hard-linked files (i.e. files still held by the torrent client) stay on cache until their hard links are resolved, avoiding the spin-ups entirely.

The feature is opt-in and defaults to `False` for full backward compatibility.

## Changes

- **`core/config.py`** — New `check_hardlinks_on_restore: bool = False` field on `CacheConfig`; loaded from settings with a safe default.
- **`core/file_operations.py`** — `FileFilter` accepts the new flag and, during the restore loop, calls `os.stat()` on each cache file. If `st_nlink > 1`, the file is skipped and a warning is logged.
- **`core/app.py`** — Passes the config value into `FileFilter` and logs the active mode at startup.
- **`web/services/settings_service.py`** — Reads, writes, and validates `check_hardlinks_on_restore` as a boolean form field.
- **`web/templates/settings/cache.html`** — New toggle in the Cache settings UI ("Check Hard-Linked Files on Restore (Cache → Array)").

## Test Plan

**Manual**

1. Enable "Check Hard-Linked Files on Restore" in Settings → Cache.
2. Create a hard link of any cached file using `ln`.
3. Trigger a restore run. Confirm the hard-linked file stays on cache and a `WARNING … Hard-linked (N links), keeping in cache` entry appears in the log.
4. Remove the extra hard link, re-run restore. Confirm the file is now moved back to the array.
5. Repeat steps 2–4 with the setting **disabled**. Confirm the file is moved regardless of link count (no regression).