### PR TITLE
Retry plex.tv watchlist calls on transient network errors

### DIFF
--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -49,6 +49,45 @@ PLEX_API_DELAY = 1.0
 RSS_MAX_RETRIES = 3
 RSS_TIMEOUT = 15  # seconds
 
+# plex.tv API retry settings for transient network errors
+PLEXTV_MAX_RETRIES = 3
+PLEXTV_RETRY_BASE_WAIT = 2  # seconds (exponential: 2s, 4s)
+
+
+def _retry_plextv_call(func, label: str, max_attempts: int = PLEXTV_MAX_RETRIES):
+    """Call a plex.tv function, retrying on transient network errors.
+
+    Retries only `requests.Timeout` and `requests.ConnectionError` — other
+    exceptions (auth failures, parse errors, logic bugs) are raised immediately
+    so callers can distinguish retry-worthy failures from permanent ones.
+
+    Args:
+        func: Zero-argument callable to invoke (wrap args via lambda).
+        label: Short description for log messages (e.g. "watchlist for Brandon").
+        max_attempts: Total attempts including the first try.
+
+    Returns:
+        The return value of func() on success.
+
+    Raises:
+        The underlying exception if all attempts fail, or any non-retriable
+        exception on the first hit.
+    """
+    last_error = None
+    for attempt in range(max_attempts):
+        try:
+            return func()
+        except (requests.Timeout, requests.ConnectionError) as e:
+            last_error = e
+            if attempt < max_attempts - 1:
+                wait_time = PLEXTV_RETRY_BASE_WAIT ** (attempt + 1)  # 2s, 4s
+                logging.warning(
+                    f"plex.tv {label} attempt {attempt + 1}/{max_attempts} "
+                    f"timed out: {e}. Retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+    raise last_error
+
 
 def _log_api_error(context: str, error: Exception) -> None:
     """Log API errors with specific detection for common HTTP status codes.
@@ -1163,12 +1202,18 @@ class PlexManager:
         # --- Local Plex watchlist processing ---
         try:
             self._rate_limited_api_call()
-            watchlist = account.watchlist(filter='released', sort='watchlistedAt:desc')
+            watchlist = _retry_plextv_call(
+                lambda: account.watchlist(filter='released', sort='watchlistedAt:desc'),
+                label=f"watchlist for {current_username}",
+            )
             logging.debug(f"[USER:{current_username}] Found {len(watchlist)} watchlist items")
             for item in watchlist:
                 watchlisted_at = None
                 try:
-                    user_state = account.userState(item)
+                    user_state = _retry_plextv_call(
+                        lambda: account.userState(item),
+                        label=f"userState for '{item.title}'",
+                    )
                     watchlisted_at = getattr(user_state, 'watchlistedAt', None)
                 except Exception as e:
                     logging.debug(f"Could not get userState for {item.title}: {e}")

--- a/tests/test_plex_api_retry.py
+++ b/tests/test_plex_api_retry.py
@@ -1,0 +1,90 @@
+"""Tests for _retry_plextv_call helper.
+
+Verifies that transient plex.tv network errors (timeouts, connection errors)
+are retried with backoff, while permanent errors raise immediately.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import requests
+
+from core.plex_api import _retry_plextv_call, PLEXTV_MAX_RETRIES
+
+
+class TestRetryPlexTvCall:
+    """Verify retry semantics for the plex.tv retry helper."""
+
+    def test_returns_immediately_on_success(self):
+        func = MagicMock(return_value="ok")
+        result = _retry_plextv_call(func, label="test")
+        assert result == "ok"
+        assert func.call_count == 1
+
+    def test_retries_on_read_timeout_then_succeeds(self):
+        func = MagicMock(side_effect=[requests.Timeout("read timeout"), "ok"])
+        with patch('core.plex_api.time.sleep') as mock_sleep:
+            result = _retry_plextv_call(func, label="test")
+        assert result == "ok"
+        assert func.call_count == 2
+        mock_sleep.assert_called_once()
+
+    def test_retries_on_connection_error_then_succeeds(self):
+        func = MagicMock(side_effect=[requests.ConnectionError("dns fail"), "ok"])
+        with patch('core.plex_api.time.sleep'):
+            result = _retry_plextv_call(func, label="test")
+        assert result == "ok"
+        assert func.call_count == 2
+
+    def test_gives_up_after_max_attempts_and_raises(self):
+        err = requests.Timeout("read timeout")
+        func = MagicMock(side_effect=err)
+        with patch('core.plex_api.time.sleep'), pytest.raises(requests.Timeout):
+            _retry_plextv_call(func, label="test")
+        assert func.call_count == PLEXTV_MAX_RETRIES
+
+    def test_non_retriable_exception_raised_immediately(self):
+        """Auth errors, logic bugs, etc. should not be retried."""
+        func = MagicMock(side_effect=ValueError("bad token"))
+        with pytest.raises(ValueError):
+            _retry_plextv_call(func, label="test")
+        assert func.call_count == 1
+
+    def test_backoff_is_exponential(self):
+        """Wait times should be 2s, 4s (PLEXTV_RETRY_BASE_WAIT ** attempt)."""
+        func = MagicMock(side_effect=[
+            requests.Timeout("t1"), requests.Timeout("t2"), "ok"
+        ])
+        with patch('core.plex_api.time.sleep') as mock_sleep:
+            _retry_plextv_call(func, label="test")
+        wait_times = [c.args[0] for c in mock_sleep.call_args_list]
+        assert wait_times == [2, 4]
+
+    def test_respects_custom_max_attempts(self):
+        func = MagicMock(side_effect=requests.Timeout("t"))
+        with patch('core.plex_api.time.sleep'), pytest.raises(requests.Timeout):
+            _retry_plextv_call(func, label="test", max_attempts=2)
+        assert func.call_count == 2
+
+    def test_logs_warning_with_label_on_retry(self, caplog):
+        import logging
+        func = MagicMock(side_effect=[requests.Timeout("oops"), "ok"])
+        with patch('core.plex_api.time.sleep'), caplog.at_level(logging.WARNING):
+            _retry_plextv_call(func, label="watchlist for Brandon")
+        assert any("watchlist for Brandon" in rec.message for rec in caplog.records)
+        assert any("1/3" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Transient `plex.tv` timeouts during a watchlist fetch were failing the entire fetch for that user, flipping the `watchlist_data_complete` flag to `False` and causing the subsequent array-restore phase to be skipped for the entire run. On a server that hits this even once a week, watched media accumulates on cache because nothing gets restored to the array.

This PR adds a small retry helper that wraps the two plex.tv calls most prone to transient failures (`account.watchlist()` and `account.userState()`) and retries them on `requests.Timeout` / `requests.ConnectionError` only.

## Changes

- **`core/plex_api.py`** — adds `_retry_plextv_call(func, label, max_attempts=3)` helper. Retries up to 3 attempts with exponential backoff (2s, 4s). Only catches `requests.Timeout` and `requests.ConnectionError` — auth failures, parse errors, and other exceptions still propagate immediately so callers can distinguish retry-worthy failures from permanent ones. Wraps `account.watchlist(...)` and `account.userState(...)` inside `_process_user_watchlist`.
- **`tests/test_plex_api_retry.py`** — unit tests covering: success on first try, retry-then-succeed, retry-then-give-up, non-retriable errors raise immediately, and the exponential backoff schedule.

## Test Plan

- [x] Unit tests pass (`pytest tests/test_plex_api_retry.py`)
- [x] Existing watchlist tests still pass — retry helper is a transparent wrapper, behavior unchanged on non-network errors
- [x] Manual: run a normal cache cycle and confirm watchlist is fetched without spurious retries (no transient errors should produce zero retry log lines)
- [x] Manual: simulate a transient timeout (e.g. firewall block plex.tv briefly mid-run) and confirm the helper logs warnings and recovers without flipping `watchlist_data_complete` to False

## Notes

- Scope is intentionally narrow — only the two plex.tv calls inside the watchlist user loop. Other plex.tv calls (auth, server discovery, etc.) are not wrapped because their failure modes are different and they're only called once per run rather than per-user-per-item.
- The helper raises the last caught exception after exhausting attempts, so existing error handling at the call site (the `except Exception` around `userState`) continues to work unchanged.