### PR TITLE
Unify media identifier for sidecars in movie folders, including sortable-title layout

### DIFF
--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -3835,9 +3835,18 @@ class FileFilter:
     def _extract_media_name(self, file_path: str) -> Optional[str]:
         """
         Extract a comparable media identifier from a file path.
-        - For movies: returns cleaned file title
-        - For TV shows: returns show name (but episode comparison is handled separately)
-        - For non-video files (artwork, NFOs, etc.): derives name from parent directory
+        - For TV shows: returns show name (episode comparison handled separately).
+        - For movies in a per-movie folder: returns the parent directory name.
+          Detected by the filename stem starting with the parent directory's
+          name — the Plex convention for both '/MOVIE/MOVIE.mkv' and
+          '/MOVIE (2025)/MOVIE (2025) - [WEBDL]-GROUP.mkv'. Works with or
+          without year markers in the folder name.
+        - For movies at library root (e.g. '/Movies/SomeFilm.mkv'): falls back
+          to cleaning the filename.
+        The per-movie-folder case keeps the main video file and its
+        artwork/NFO/subtitle siblings in lockstep so they share an identifier
+        and the 'still needed in OnDeck' lookup matches for all of them, not
+        just the primary video.
         """
         try:
             normalized_path = os.path.normpath(file_path)
@@ -3854,9 +3863,16 @@ class FileFilter:
                         return path_parts[i - 1]
                     break
 
-            # For movies: return cleaned filename
             filename = os.path.basename(file_path)
             name, ext = os.path.splitext(filename)
+            parent_dir = os.path.basename(os.path.dirname(file_path))
+
+            # For movies in a per-movie folder: parent_dir is the canonical
+            # identifier. The "filename stem begins with parent_dir name" check
+            # distinguishes per-movie folders from library roots — a library
+            # root like "Movies" won't appear as a prefix in typical filenames.
+            if parent_dir and name.lower().startswith(parent_dir.lower()):
+                return parent_dir
 
             # Handle subtitle files - strip language code suffixes (e.g., ".en", ".eng", ".en.hi", ".forced")
             if ext.lower() in SUBTITLE_EXTENSIONS:
@@ -3867,9 +3883,9 @@ class FileFilter:
                     prev_name = name
                     name = re.sub(pattern, '', name, flags=re.IGNORECASE)
             elif not is_video_file(file_path):
-                # Non-video, non-subtitle file (artwork, NFO, etc.)
-                # Use parent directory name as the media identifier
-                parent_dir = os.path.basename(os.path.dirname(file_path))
+                # Non-video, non-subtitle file (artwork, NFO, etc.) whose filename
+                # doesn't begin with the parent dir name (e.g. bare "poster.jpg").
+                # Use parent directory name as the media identifier.
                 if parent_dir:
                     return parent_dir
 

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -42,6 +42,12 @@ SUBTITLE_EXTENSIONS = {'.srt', '.sub', '.ass', '.ssa', '.vtt', '.idx', '.sbv', '
 # Combined media extensions (video + subtitle)
 MEDIA_EXTENSIONS = VIDEO_EXTENSIONS | SUBTITLE_EXTENSIONS
 
+# Sortable folder convention: "Title, The (Year)" / "Title, A (Year)" / "Title, An (Year)".
+# Sonarr and Radarr default to this layout when "Use Sortable Title" is enabled, but the
+# files inside still start with the natural-order title ("The Title (Year) ..."), so the
+# folder-name prefix check in _extract_media_name needs to handle both forms.
+ARTICLE_SUFFIX_RE = re.compile(r'^(.*?),\s+(The|A|An)(\s*\(\d{4}\))?\s*$', re.IGNORECASE)
+
 
 def save_json_atomically(filepath: str, data, label: str = "data") -> None:
     """Save JSON data to file atomically (write-to-temp-then-rename).
@@ -3871,8 +3877,21 @@ class FileFilter:
             # identifier. The "filename stem begins with parent_dir name" check
             # distinguishes per-movie folders from library roots — a library
             # root like "Movies" won't appear as a prefix in typical filenames.
-            if parent_dir and name.lower().startswith(parent_dir.lower()):
-                return parent_dir
+            if parent_dir:
+                pd_lower = parent_dir.lower()
+                name_lower = name.lower()
+                if name_lower.startswith(pd_lower):
+                    return parent_dir
+                # Sortable convention: folder is "Title, The (Year)" but the file
+                # inside is named "The Title (Year) - ...". Rotate the trailing
+                # article to the front and retry the prefix check so the .mkv and
+                # its sidecars produce the same identifier.
+                m = ARTICLE_SUFFIX_RE.match(parent_dir)
+                if m:
+                    body, article, year = m.group(1).strip(), m.group(2), (m.group(3) or '').strip()
+                    rotated = f"{article} {body} {year}".strip() if year else f"{article} {body}"
+                    if name_lower.startswith(rotated.lower()):
+                        return parent_dir
 
             # Handle subtitle files - strip language code suffixes (e.g., ".en", ".eng", ".en.hi", ".forced")
             if ext.lower() in SUBTITLE_EXTENSIONS:

--- a/tests/test_extract_media_name.py
+++ b/tests/test_extract_media_name.py
@@ -1,0 +1,120 @@
+"""Tests for FileFilter._extract_media_name().
+
+Regression tests for the associated-file thrash bug: main video files and
+their artwork/NFO/subtitle siblings in the same movie folder must produce
+the same identifier so the "still needed in OnDeck" lookup matches for all
+of them, not just the main .mkv.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions', 'requests',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.file_operations import FileFilter
+
+
+@pytest.fixture
+def file_filter():
+    """Bare FileFilter instance (skips __init__ — we only exercise _extract_media_name)."""
+    return FileFilter.__new__(FileFilter)
+
+
+class TestMovieFolderConsistency:
+    """Regression: main video and associated siblings must share an identifier."""
+
+    def test_mkv_and_png_in_same_movie_folder_return_same_name(self, file_filter):
+        folder = "/mnt/cache/Movies/A Minecraft Movie (2025)"
+        mkv = f"{folder}/A Minecraft Movie (2025) - [WEBDL-1080P][EAC3 ATMOS 5.1][X264][8Bit]-TECHNOBLADENEVERDIES.mkv"
+        png = f"{folder}/A Minecraft Movie (2025) - [WEBDL-1080P][EAC3 ATMOS 5.1][X264][8Bit]-TECHNOBLADENEVERDIES-clearlogo.png"
+
+        assert file_filter._extract_media_name(mkv) == file_filter._extract_media_name(png)
+
+    def test_mkv_and_all_artwork_variants_match(self, file_filter):
+        folder = "/mnt/cache/Movies/The Running Man (2025)"
+        mkv = f"{folder}/The Running Man (2025) - [WEBDL-1080P][EAC3 ATMOS 5.1][H264][8Bit]-BYNDR.mkv"
+        poster = f"{folder}/The Running Man (2025) - [WEBDL-1080P][EAC3 ATMOS 5.1][H264][8Bit]-BYNDR-poster.jpg"
+        fanart = f"{folder}/The Running Man (2025) - [WEBDL-1080P][EAC3 ATMOS 5.1][H264][8Bit]-BYNDR-fanart.jpg"
+        clearlogo = f"{folder}/The Running Man (2025) - [WEBDL-1080P][EAC3 ATMOS 5.1][H264][8Bit]-BYNDR-clearlogo.png"
+        nfo = f"{folder}/The Running Man (2025) - [WEBDL-1080P][EAC3 ATMOS 5.1][H264][8Bit]-BYNDR.nfo"
+
+        mkv_name = file_filter._extract_media_name(mkv)
+        assert mkv_name == file_filter._extract_media_name(poster)
+        assert mkv_name == file_filter._extract_media_name(fanart)
+        assert mkv_name == file_filter._extract_media_name(clearlogo)
+        assert mkv_name == file_filter._extract_media_name(nfo)
+
+    def test_movie_in_yearless_folder_is_consistent(self, file_filter):
+        """Users who don't include (YYYY) in folder names still get siblings matched."""
+        folder = "/mnt/cache/Movies/A Minecraft Movie"
+        mkv = f"{folder}/A Minecraft Movie - [WEBDL-1080P][EAC3 ATMOS 5.1][X264][8Bit]-TECHNOBLADENEVERDIES.mkv"
+        poster = f"{folder}/A Minecraft Movie - [WEBDL-1080P][EAC3 ATMOS 5.1][X264][8Bit]-TECHNOBLADENEVERDIES-poster.jpg"
+
+        assert file_filter._extract_media_name(mkv) == file_filter._extract_media_name(poster)
+        assert file_filter._extract_media_name(mkv) == "A Minecraft Movie"
+
+    def test_simple_mkv_equals_folder_name(self, file_filter):
+        """'/MOVIE/MOVIE.mkv' layout without any release-group or quality tags."""
+        path = "/mnt/cache/Movies/The Matrix/The Matrix.mkv"
+        assert file_filter._extract_media_name(path) == "The Matrix"
+
+
+class TestTvShowPathsUnchanged:
+    """TV-show-in-Season-folder behavior must keep working unchanged."""
+
+    def test_tv_mkv_returns_show_name(self, file_filter):
+        path = "/mnt/cache/TV Shows/Scrubs (2026)/Season 01/Scrubs (2026) - S01E02 - My 2nd First Day [WEBDL-1080p][5.1][EAC3][8Bit][h264]-Sonarr.mkv"
+        assert file_filter._extract_media_name(path) == "Scrubs (2026)"
+
+    def test_tv_episode_artwork_returns_show_name(self, file_filter):
+        path = "/mnt/cache/TV Shows/Scrubs (2026)/Season 01/Scrubs (2026) - S01E02-thumb.jpg"
+        assert file_filter._extract_media_name(path) == "Scrubs (2026)"
+
+    def test_tv_specials_folder_returns_show_name(self, file_filter):
+        path = "/mnt/cache/TV Shows/Some Show/Specials/Some Show - S00E01.mkv"
+        assert file_filter._extract_media_name(path) == "Some Show"
+
+    def test_tv_numeric_season_folder_returns_show_name(self, file_filter):
+        path = "/mnt/cache/TV Shows/Some Show/01/Some Show - S01E01.mkv"
+        assert file_filter._extract_media_name(path) == "Some Show"
+
+
+class TestMovieAtLibraryRoot:
+    """Movies without per-movie subfolders (filename directly under library root)."""
+
+    def test_flat_movie_file_falls_back_to_cleaned_filename(self, file_filter):
+        # No per-movie folder → parent_dir is "Movies" (no year), can't use it.
+        # Must fall back to filename cleanup.
+        path = "/mnt/cache/Movies/Some Old Movie (1999).mkv"
+        result = file_filter._extract_media_name(path)
+        assert result is not None
+        # Should extract something meaningful — the movie title.
+        assert "Some Old Movie" in result
+
+
+class TestAssociatedFilesFallback:
+    """Non-video sibling files behave the same as the main video."""
+
+    def test_subtitle_file_delegates_to_parent_folder_in_movie(self, file_filter):
+        folder = "/mnt/cache/Movies/A Minecraft Movie (2025)"
+        mkv = f"{folder}/A Minecraft Movie (2025) - [WEBDL-1080P]-TECHNOBLADENEVERDIES.mkv"
+        sub = f"{folder}/A Minecraft Movie (2025) - [WEBDL-1080P]-TECHNOBLADENEVERDIES.en.srt"
+
+        assert file_filter._extract_media_name(mkv) == file_filter._extract_media_name(sub)
+
+    def test_subtitle_in_tv_season_returns_show_name(self, file_filter):
+        path = "/mnt/cache/TV Shows/Scrubs (2026)/Season 01/Scrubs (2026) - S01E02.en.srt"
+        assert file_filter._extract_media_name(path) == "Scrubs (2026)"

--- a/tests/test_extract_media_name.py
+++ b/tests/test_extract_media_name.py
@@ -72,6 +72,72 @@ class TestMovieFolderConsistency:
         assert file_filter._extract_media_name(path) == "The Matrix"
 
 
+class TestSortableArticleSuffixFolders:
+    """Sonarr/Radarr "Use Sortable Title" puts the article at the end of the
+    folder name ("SpongeBob Movie ..., The (2015)") while the files inside still
+    start with the article ("The SpongeBob Movie ..."). Both shapes must produce
+    the same identifier so the eviction needed-set lookup matches all siblings.
+    """
+
+    def test_article_the_suffix_mkv_and_sidecars_share_identifier(self, file_filter):
+        folder = "/mnt/cache/Movies/SpongeBob Movie Sponge Out of Water, The (2015)"
+        mkv = f"{folder}/The SpongeBob Movie Sponge Out of Water (2015) - [BLURAY-1080P][AC3 5.1][X264][8Bit].mkv"
+        nfo = f"{folder}/The SpongeBob Movie Sponge Out of Water (2015) - [BLURAY-1080P][AC3 5.1][X264][8Bit].nfo"
+        poster = f"{folder}/The SpongeBob Movie Sponge Out of Water (2015) - [BLURAY-1080P][AC3 5.1][X264][8Bit]-poster.jpg"
+        fanart = f"{folder}/The SpongeBob Movie Sponge Out of Water (2015) - [BLURAY-1080P][AC3 5.1][X264][8Bit]-fanart.jpg"
+        clearlogo = f"{folder}/The SpongeBob Movie Sponge Out of Water (2015) - [BLURAY-1080P][AC3 5.1][X264][8Bit]-clearlogo.png"
+
+        mkv_id = file_filter._extract_media_name(mkv)
+        assert mkv_id == "SpongeBob Movie Sponge Out of Water, The (2015)"
+        assert mkv_id == file_filter._extract_media_name(nfo)
+        assert mkv_id == file_filter._extract_media_name(poster)
+        assert mkv_id == file_filter._extract_media_name(fanart)
+        assert mkv_id == file_filter._extract_media_name(clearlogo)
+
+    def test_article_a_suffix_consistent(self, file_filter):
+        folder = "/mnt/cache/Movies/Christmas Story, A (1983)"
+        mkv = f"{folder}/A Christmas Story (1983) - [BLURAY-1080P][DTS 5.1][X264][8Bit]-GROUP.mkv"
+        poster = f"{folder}/A Christmas Story (1983) - [BLURAY-1080P][DTS 5.1][X264][8Bit]-GROUP-poster.jpg"
+
+        mkv_id = file_filter._extract_media_name(mkv)
+        assert mkv_id == "Christmas Story, A (1983)"
+        assert mkv_id == file_filter._extract_media_name(poster)
+
+    def test_article_an_suffix_consistent(self, file_filter):
+        folder = "/mnt/cache/Movies/Inconvenient Truth, An (2006)"
+        mkv = f"{folder}/An Inconvenient Truth (2006) - [WEBDL-1080P][AAC 2.0][H264][8Bit]-GROUP.mkv"
+        nfo = f"{folder}/An Inconvenient Truth (2006) - [WEBDL-1080P][AAC 2.0][H264][8Bit]-GROUP.nfo"
+
+        mkv_id = file_filter._extract_media_name(mkv)
+        assert mkv_id == "Inconvenient Truth, An (2006)"
+        assert mkv_id == file_filter._extract_media_name(nfo)
+
+    def test_article_suffix_yearless_folder_consistent(self, file_filter):
+        folder = "/mnt/cache/Movies/Matrix, The"
+        mkv = f"{folder}/The Matrix - [BLURAY-1080P][DTS 5.1][X264][8Bit]-GROUP.mkv"
+        poster = f"{folder}/The Matrix - [BLURAY-1080P][DTS 5.1][X264][8Bit]-GROUP-poster.jpg"
+
+        mkv_id = file_filter._extract_media_name(mkv)
+        assert mkv_id == "Matrix, The"
+        assert mkv_id == file_filter._extract_media_name(poster)
+
+    def test_article_suffix_lowercase_filename_still_matches(self, file_filter):
+        """Case-insensitive match — filename article casing shouldn't matter."""
+        folder = "/mnt/cache/Movies/Big Lebowski, The (1998)"
+        mkv = f"{folder}/the big lebowski (1998) - [BLURAY-1080P]-GROUP.mkv"
+
+        assert file_filter._extract_media_name(mkv) == "Big Lebowski, The (1998)"
+
+    def test_non_article_comma_in_folder_not_treated_as_article(self, file_filter):
+        """Folder ending in a comma + non-article word must not be rotated."""
+        folder = "/mnt/cache/Movies/Kill Bill, Vol. 1 (2003)"
+        mkv = f"{folder}/Kill Bill, Vol. 1 (2003) - [BLURAY-1080P]-GROUP.mkv"
+
+        # Filename starts with the literal folder name → original path matches,
+        # rotation is never attempted.
+        assert file_filter._extract_media_name(mkv) == "Kill Bill, Vol. 1 (2003)"
+
+
 class TestTvShowPathsUnchanged:
     """TV-show-in-Season-folder behavior must keep working unchanged."""
 


### PR DESCRIPTION
## Summary

`_extract_media_name()` is the function eviction uses to decide whether a cached file is still wanted: it derives a comparable identifier from the file path so the cached entry can be looked up against the OnDeck/Watchlist set.

Two related issues caused video files and their sidecars (`.nfo`, `-poster.jpg`, `-fanart.jpg`, `-clearlogo.png`, subtitles) in the same per-movie folder to produce **different** identifiers, causing the sidecars to be evicted while the `.mkv` was correctly kept — then re-discovered and re-cached on the next run. The same evict-then-recache loop repeats every scheduled run.

**1. Per-movie-folder identifier consolidation** (commit `9de5941`)
For movies in a per-movie folder, the `.mkv` was returning the cleaned filename while sidecars were returning the parent directory name. When the filename carried release-group/quality suffixes (e.g. `A Minecraft Movie (2025) - [WEBDL-1080P]-TECHNOBLADENEVERDIES`), the strings didn't match. Detect the per-movie-folder case via the "filename stem starts with parent_dir" check and return `parent_dir` for both the main video and its siblings.

**2. Sortable-title folder convention** (commit `6ba5962`)
Sonarr/Radarr's "Use Sortable Title" lays out folders as `Title, The`, `Title, A`, or `Title, An` (with or without `(YEAR)`), but the files inside still start with the natural-order title. The literal `name.startswith(parent_dir)` check from #1 fails because `"the spongebob..."` does not start with `"spongebob movie..., the (2015)"`. When the literal check fails, retry against the article-rotated form of `parent_dir` so both shapes collapse to the same identifier.

| Folder | Files | Identifier |
|---|---|---|
| `Title (Year)` | `Title (Year) - ....mkv/.jpg/.nfo` | `Title (Year)` |
| `Title` | `Title.mkv/.jpg/.nfo` | `Title` |
| `Title, The (Year)` | `The Title (Year) - ....mkv/.jpg/.nfo` | `Title, The (Year)` |
| `Title, The` | `The Title - ....mkv/.jpg/.nfo` | `Title, The` |
| `Title, A (Year)` / `Title, An (Year)` | `A Title ...` / `An Title ...` | `Title, A (Year)` / `Title, An (Year)` |

## Test plan

- [x] All 17 tests in `tests/test_extract_media_name.py` pass — covering per-movie folders, library-root files, TV shows in `Season XX` / numeric / `Specials` subfolders, subtitles with language suffixes, and the new `TestSortableArticleSuffixFolders` class (6 cases).
- [x] Folders in `Title (Year)` natural-order layout still extract correctly — regression-covered.
- [x] Folders in `Title, The`, `Title, A`, `Title, An` (with or without `(YEAR)`) now collapse `.mkv` and sidecars to the same identifier.
- [x] Negative case covered: `Kill Bill, Vol. 1 (2003)` is **not** treated as an article-suffix folder — the regex requires `The`/`A`/`An` literally, so the comma in `, Vol. 1` doesn't trigger rotation.
- [x] TV show paths in `Show Name/Season XX/...` layout extract `Show Name` unchanged (Season-folder detection runs first).
- [x] Library-root files (no per-movie subfolder) still fall back to cleaned filename.