### PR TITLE
Validate external CLI PID via cmdline to prevent phantom run banner

### DIFF
--- a/tests/test_operation_runner.py
+++ b/tests/test_operation_runner.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 from datetime import datetime, timedelta
 
 import pytest
@@ -397,3 +397,85 @@ class TestGetStatusDictIdle:
         status = runner.get_status_dict()
         assert status["state"] == "idle"
         assert status["is_running"] is False
+
+
+# ============================================================================
+# External CLI detection — stale-lock handling after ungraceful shutdown
+# ============================================================================
+
+class TestCheckExternalProcess:
+    """Guard against phantom "CLI running" banners after power-loss / SIGKILL.
+
+    The lock file survives an ungraceful shutdown with a stale PID. In the new
+    container that PID is routinely held by an unrelated thread/worker, so a
+    bare ``/proc/{pid}`` existence check returns True and the dashboard parses
+    the old log header as a fresh run. ``_check_external_process`` must validate
+    the PID actually corresponds to a ``plexcache.py`` CLI invocation and clean
+    up the stale lock when it doesn't.
+    """
+
+    @pytest.fixture
+    def runner(self, tmp_path):
+        with patch('web.services.operation_runner.load_activity', return_value=[]):
+            r = OperationRunner()
+        r._lock_file = tmp_path / "plexcache.lock"
+        return r
+
+    def _write_lock(self, runner, pid: int | str):
+        runner._lock_file.write_text(str(pid))
+
+    def test_no_lock_file_returns_none(self, runner):
+        assert runner._check_external_process() is None
+
+    def test_empty_lock_file_is_cleaned_up(self, runner):
+        self._write_lock(runner, "")
+        assert runner._check_external_process() is None
+        assert not runner._lock_file.exists()
+
+    def test_own_pid_is_ignored(self, runner):
+        self._write_lock(runner, os.getpid())
+        assert runner._check_external_process() is None
+
+    def test_stale_lock_with_non_plexcache_cmdline_is_cleaned_up(self, runner):
+        """PID collision after reboot: /proc/{pid} exists but isn't plexcache."""
+        self._write_lock(runner, 999999)
+        with patch.object(OperationRunner, '_is_plexcache_cli_process', return_value=False):
+            assert runner._check_external_process() is None
+        assert not runner._lock_file.exists()
+
+    def test_live_plexcache_cli_returns_pid(self, runner):
+        self._write_lock(runner, 999999)
+        with patch.object(OperationRunner, '_is_plexcache_cli_process', return_value=True):
+            assert runner._check_external_process() == 999999
+        # Lock file should be preserved while the CLI is running
+        assert runner._lock_file.exists()
+
+    def test_non_integer_pid_does_not_crash(self, runner):
+        self._write_lock(runner, "garbage")
+        assert runner._check_external_process() is None
+
+    def test_is_plexcache_cli_process_accepts_plain_cli(self):
+        """``python3 plexcache.py`` without --web → True."""
+        fake_cmdline = b'python3\x00/app/plexcache.py\x00--verbose\x00'
+        m = mock_open(read_data=fake_cmdline)
+        with patch('builtins.open', m):
+            assert OperationRunner._is_plexcache_cli_process(1234) is True
+
+    def test_is_plexcache_cli_process_rejects_web_server(self):
+        """``plexcache.py --web`` is the web server itself, not a CLI run."""
+        fake_cmdline = b'python3\x00/app/plexcache.py\x00--web\x00--host\x000.0.0.0\x00'
+        m = mock_open(read_data=fake_cmdline)
+        with patch('builtins.open', m):
+            assert OperationRunner._is_plexcache_cli_process(1234) is False
+
+    def test_is_plexcache_cli_process_rejects_other_python_process(self):
+        """Random python process with recycled PID → False."""
+        fake_cmdline = b'python3\x00-m\x00http.server\x00'
+        m = mock_open(read_data=fake_cmdline)
+        with patch('builtins.open', m):
+            assert OperationRunner._is_plexcache_cli_process(1234) is False
+
+    def test_is_plexcache_cli_process_missing_proc_entry(self):
+        """/proc/{pid}/cmdline unreadable (process gone, permission denied) → False."""
+        with patch('builtins.open', side_effect=FileNotFoundError):
+            assert OperationRunner._is_plexcache_cli_process(1234) is False

--- a/web/services/operation_runner.py
+++ b/web/services/operation_runner.py
@@ -155,6 +155,13 @@ class OperationRunner:
 
         Returns the PID if a live external process is detected, None otherwise.
         Only detects processes NOT started by this OperationRunner.
+
+        Validates by inspecting ``/proc/{pid}/cmdline`` — a bare ``os.path.exists``
+        check is unreliable because after an ungraceful shutdown (power outage,
+        SIGKILL) the lock file survives with a stale PID, and low PIDs in the
+        new container are routinely held by unrelated threads/workers. Without
+        cmdline validation this produces a phantom "CLI running" banner whose
+        start time is parsed out of the old log header.
         """
         if not self._lock_file.exists():
             return None
@@ -163,15 +170,50 @@ class OperationRunner:
             with open(self._lock_file, 'r') as f:
                 pid_str = f.read().strip()
             if not pid_str:
+                self._cleanup_stale_lock()
                 return None
             pid = int(pid_str)
 
-            # Verify process is actually alive via /proc (Linux/Docker)
-            if os.path.exists(f'/proc/{pid}'):
+            if pid == os.getpid():
+                return None
+
+            if self._is_plexcache_cli_process(pid):
                 return pid
+
+            self._cleanup_stale_lock()
         except (ValueError, IOError, OSError):
             pass
         return None
+
+    @staticmethod
+    def _is_plexcache_cli_process(pid: int) -> bool:
+        """Return True if PID points to a running ``plexcache.py`` CLI process.
+
+        Reads ``/proc/{pid}/cmdline`` (NUL-separated) and looks for a
+        ``plexcache.py`` invocation that is *not* the web server itself. This
+        distinguishes a genuine CLI run from an unrelated process that happens
+        to have inherited the stale PID written in the lock file.
+        """
+        try:
+            with open(f'/proc/{pid}/cmdline', 'rb') as f:
+                cmdline = f.read().replace(b'\x00', b' ').decode('utf-8', 'replace')
+        except (IOError, OSError):
+            return False
+        if 'plexcache.py' not in cmdline:
+            return False
+        if '--web' in cmdline:
+            return False
+        return True
+
+    def _cleanup_stale_lock(self) -> None:
+        """Remove a lock file left behind by an ungraceful shutdown."""
+        try:
+            self._lock_file.unlink(missing_ok=True)
+            logging.info(
+                "[CLI-DETECT] Removed stale lock file (no active plexcache CLI process)"
+            )
+        except OSError as e:
+            logging.warning(f"[CLI-DETECT] Failed to remove stale lock file: {e}")
 
     def _parse_external_log(self) -> dict:
         """Parse the log file to extract progress for an external CLI run.


### PR DESCRIPTION
## Summary

After an ungraceful shutdown (power outage, SIGKILL, OOM kill), `plexcache.lock` survives on disk with a stale PID. In the new container, that low-numbered PID is routinely held by an unrelated thread/worker, so the existing `os.path.exists(f'/proc/{pid}')` check returns True and the dashboard parses the old log header as a fresh run — e.g. a 7-hour phantom "CLI running" banner that persists indefinitely after a reboot.

This change validates the lock by inspecting `/proc/{pid}/cmdline`. A PID is only treated as an active CLI run when its cmdline references `plexcache.py` and is not the web server itself (`--web`). Any other outcome — missing entry, non-plexcache cmdline, unreadable cmdline — is treated as a stale lock and the file is removed, so the banner clears on the next poll instead of sticking around forever.

Refs StudioNirin/PlexCache-D#127.

### Changes

- `OperationRunner._check_external_process()` now delegates PID validation to `_is_plexcache_cli_process()` instead of checking `/proc/{pid}` existence alone.
- New `_is_plexcache_cli_process(pid)` reads `/proc/{pid}/cmdline` (NUL-separated), requires `plexcache.py` in the cmdline, rejects `--web`.
- New `_cleanup_stale_lock()` removes the lock file and logs `[CLI-DETECT] Removed stale lock file ...`.
- Self-PID guard: if the lock points at the web server's own PID, treat as not-an-external-run.
- Empty/unreadable lock files are now also cleaned up rather than silently retained.

## Test plan

- [x] Phantom run reproduction: create `plexcache.lock` containing a PID held by an unrelated process (e.g. `echo 1 > plexcache.lock`), start the web UI, confirm dashboard does **not** show a "CLI running" banner and that `plexcache.lock` is removed with a `[CLI-DETECT] Removed stale lock file` log line.
- [x] Empty lock: `: > plexcache.lock`, start web UI, confirm lock is removed and no banner appears.
- [x] Genuine CLI run: start `python3 plexcache.py` in another shell while the web UI is up; dashboard banner should show the active run as before.
- [x] Web-server PID guard: ensure the web UI itself never appears as an external CLI run when its own PID is in the lock file.
- [x] `pytest tests/test_operation_runner.py` passes (covers cmdline validation, stale-lock cleanup, web-server cmdline rejection, missing-cmdline handling).