### PR TITLE
Banner UX: episode grouping and sub-row contrast

### DIFF
--- a/web/services/operation_runner.py
+++ b/web/services/operation_runner.py
@@ -341,6 +341,7 @@ class OperationRunner:
                         "action": action,
                         "filename": filename,
                         "size": format_bytes(size_bytes) if size_bytes else "",
+                        "size_bytes": size_bytes,
                         "users": users,
                     })
 
@@ -351,8 +352,10 @@ class OperationRunner:
                 if fname not in completed_files
             ]
 
-            # Trim recent files to last 8
-            result["recent_files"] = result["recent_files"][:8]
+            # Keep up to 50 raw entries so the grouping pass has enough data
+            # to collapse same-show episodes meaningfully. Downstream consumers
+            # (running vs completed) apply their own caps.
+            result["recent_files"] = result["recent_files"][:50]
             # Last 5 log lines
             result["recent_logs"] = all_logs[-5:]
 
@@ -439,7 +442,7 @@ class OperationRunner:
             "eta_display": eta_display,
             "bytes_display": self._format_bytes(total_bytes) if total_bytes > 0 else "",
             "recent_logs": log_state["recent_logs"],
-            "recent_files": log_state["recent_files"],
+            "recent_files": log_state["recent_files"][:8],
             "active_files": log_state["active_files"],
             "message": log_state["current_phase_display"],
         }
@@ -484,7 +487,7 @@ class OperationRunner:
             "error_count": log_state["error_count"],
             "error_messages": log_state["error_messages"][:5],
             "was_stopped": False,
-            "recent_files": log_state["recent_files"],
+            "recent_files": self._group_episodes_by_show(log_state["recent_files"])[:15],
             "message": message,
         }
 
@@ -785,6 +788,7 @@ class OperationRunner:
                     "action": action,
                     "filename": filename,
                     "size": activity._format_size(size_bytes),
+                    "size_bytes": size_bytes,
                 })
                 # Increment real-time progress counters
                 if self._current_result:
@@ -1173,6 +1177,73 @@ class OperationRunner:
         if merged_indices:
             self._current_run_files = [f for i, f in enumerate(self._current_run_files) if i not in merged_indices]
 
+    # Matches "<show> - S##E##" — the Sonarr/Plex TV naming convention.
+    # Non-TV files (movies, specials without episode numbering) don't match
+    # and pass through as singletons.
+    _SHOW_EPISODE_PATTERN = re.compile(r'^(.+?) - S\d+E\d+', re.IGNORECASE)
+
+    def _group_episodes_by_show(self, files: List[dict]) -> List[dict]:
+        """Collapse multi-episode TV runs into a single parent row per show.
+
+        Movies and shows with only one episode in the payload stay as
+        individual rows (grouping a single entry offers no compression).
+        Preserves first-seen order so the banner doesn't reshuffle on re-render.
+        """
+        groups: Dict[tuple, dict] = {}
+        order: List[tuple] = []
+
+        for idx, f in enumerate(files):
+            match = self._SHOW_EPISODE_PATTERN.match(f.get("filename", ""))
+            if match:
+                show_name = match.group(1).strip()
+                key = (f.get("action", ""), show_name)
+                if key not in groups:
+                    groups[key] = {
+                        "action": f.get("action", ""),
+                        "show_name": show_name,
+                        "episodes": [],
+                        "total_bytes": 0,
+                    }
+                    order.append(key)
+                groups[key]["episodes"].append({
+                    "filename": f.get("filename", ""),
+                    "size": f.get("size", ""),
+                    "size_bytes": f.get("size_bytes", 0),
+                    "associated_files": f.get("associated_files", []),
+                })
+                groups[key]["total_bytes"] += f.get("size_bytes", 0)
+            else:
+                key = ("__singleton__", idx)
+                groups[key] = f
+                order.append(key)
+
+        result: List[dict] = []
+        for key in order:
+            entry = groups[key]
+            if key[0] == "__singleton__":
+                result.append(entry)
+            elif len(entry["episodes"]) == 1:
+                ep = entry["episodes"][0]
+                result.append({
+                    "action": entry["action"],
+                    "filename": ep["filename"],
+                    "size": ep.get("size", ""),
+                    "size_bytes": ep.get("size_bytes", 0),
+                    "associated_files": ep.get("associated_files", []),
+                })
+            else:
+                result.append({
+                    "action": entry["action"],
+                    "is_group": True,
+                    "show_name": entry["show_name"],
+                    "episode_count": len(entry["episodes"]),
+                    "episodes": entry["episodes"],
+                    "size_bytes": entry["total_bytes"],
+                    "size": self._format_bytes(entry["total_bytes"]) if entry["total_bytes"] > 0 else "",
+                })
+
+        return result
+
     def get_status_dict(self) -> dict:
         """Get status as a dictionary for API responses"""
         result = self.current_result
@@ -1317,9 +1388,11 @@ class OperationRunner:
             status["error_messages"] = result.error_messages[:5]
             status["was_stopped"] = self._stop_requested
 
-            # Files processed in this run for hover detail
+            # Files processed in this run, grouped by show to compress TV runs.
+            # Cap at 15 groups so long runs stay readable; overflow links to Recent Activity.
             with self._lock:
-                status["recent_files"] = list(self._current_run_files[:8])
+                grouped = self._group_episodes_by_show(list(self._current_run_files))
+                status["recent_files"] = grouped[:15]
 
             if self._stop_requested:
                 status["message"] = f"Stopped by user after {self._format_duration(result.duration_seconds)}"

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -923,6 +923,9 @@ footer {
     font-size: 0.65rem;
     opacity: 0.55;
 }
+.di-file-row--sub .di-file-row__size {
+    color: rgba(255,255,255,0.55);
+}
 .di-sub-arrow {
     color: rgba(255,255,255,0.25);
     flex-shrink: 0;

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -931,6 +931,36 @@ footer {
     flex-shrink: 0;
     font-size: 0.7rem;
 }
+.di-expand-chev {
+    color: rgba(255,255,255,0.4);
+    flex-shrink: 0;
+    font-size: 0.85rem;
+    transition: transform 0.18s ease;
+    margin-left: 0.25rem;
+}
+.di-expand-chev.open {
+    transform: rotate(90deg);
+}
+.di-file-row--group:hover {
+    background: rgba(255,255,255,0.04);
+    border-radius: 4px;
+}
+.di-more-link {
+    display: block;
+    text-align: center;
+    color: rgba(229, 160, 13, 0.85);
+    font-size: 0.72rem;
+    padding: 0.45rem;
+    margin-top: 0.25rem;
+    text-decoration: none;
+    border-top: 1px dashed rgba(255,255,255,0.08);
+    transition: background 0.15s, color 0.15s;
+}
+.di-more-link:hover {
+    color: var(--plex-accent, #e5a00d);
+    background: rgba(229, 160, 13, 0.06);
+    text-decoration: none;
+}
 
 /* ── Buttons ─────────────────────────────────────────── */
 

--- a/web/templates/components/global_operation_banner.html
+++ b/web/templates/components/global_operation_banner.html
@@ -261,6 +261,12 @@ function diPillClick() {
     else diSmoothSetState('false');  /* tier3 → collapse back to compact */
 }
 
+// Preserve window scroll position across banner swaps.
+// During running ops the banner polls every 2s with innerHTML swaps; if the
+// user had focus or selection inside the banner, the destroyed element can
+// cause the browser to reset scroll to top. Snapshot before, restore after.
+var _diSavedScrollY = null;
+
 // Skip the swap if the banner state hasn't meaningfully changed.
 // Prevents the pill from flashing on every idle/completed poll cycle.
 // innerHTML comparison doesn't work because script tags differ between
@@ -269,6 +275,7 @@ function diPillClick() {
 // Running/maintenance polls always swap (they show live progress).
 document.addEventListener('htmx:beforeSwap', function(evt) {
     if (evt.detail.target && evt.detail.target.id === 'global-operation-banner') {
+        _diSavedScrollY = window.scrollY;
         var banner = evt.detail.target;
         var oldPill = banner.querySelector('.di-pill');
         if (!oldPill) return;  // No pill yet — allow first swap
@@ -361,6 +368,12 @@ document.addEventListener('htmx:responseError', function(evt) {
 // After every HTMX swap: re-render icons, sync animations, one-shot entrance
 document.addEventListener('htmx:afterSwap', function(evt) {
     if (evt.detail.target && evt.detail.target.id === 'global-operation-banner') {
+        // Restore scroll position snapshotted in beforeSwap.
+        if (_diSavedScrollY !== null) {
+            window.scrollTo(0, _diSavedScrollY);
+            _diSavedScrollY = null;
+        }
+
         // Successful swap — reset connection failure tracking
         _diBannerFailCount = 0;
         _diBannerDisconnected = false;

--- a/web/templates/components/global_operation_banner.html
+++ b/web/templates/components/global_operation_banner.html
@@ -261,6 +261,23 @@ function diPillClick() {
     else diSmoothSetState('false');  /* tier3 → collapse back to compact */
 }
 
+// Toggle a grouped show row in the completed-state detail view.
+// Hides/shows the adjacent .di-file-row--ep sub-rows without re-rendering
+// (which would require replaying the IIFE that built detailHtml).
+function bannerToggleShow(evt, el) {
+    if (evt && evt.stopPropagation) evt.stopPropagation();
+    var show = el.getAttribute('data-show');
+    var chev = el.querySelector('.di-expand-chev');
+    var expand = !chev.classList.contains('open');
+    chev.classList.toggle('open');
+
+    var subs = document.querySelectorAll('.di-file-row--ep[data-parent-show="' + (show || '').replace(/"/g, '\\"') + '"]');
+    subs.forEach(function(s) { s.style.display = expand ? 'flex' : 'none'; });
+
+    if (!window.__bannerExpandedShows) window.__bannerExpandedShows = {};
+    window.__bannerExpandedShows[show] = expand;
+}
+
 // Preserve window scroll position across banner swaps.
 // During running ops the banner polls every 2s with innerHTML swaps; if the
 // user had focus or selection inside the banner, the destroyed element can
@@ -977,12 +994,24 @@ function dismissMaintCompletionBanner() {
     }
     statsHtml += '</div>';
 
-    // File detail rows
+    // File detail rows — each entry is either a single file or a grouped show
+    // (is_group=true with episodes[]). Grouping collapses e.g. 5 eps of one
+    // show into one expandable parent row.
     var recentFiles = [
         {% for f in status.recent_files|default([]) %}
+        {%- if f.is_group is defined and f.is_group %}
+        { action: '{{ f.action }}', isGroup: true, showName: {{ f.show_name|tojson }}, episodeCount: {{ f.episode_count }}, size: '{{ f.size }}', episodes: [
+            {%- for ep in f.episodes %}
+            { filename: '{{ ep.filename|truncate_filename(45)|e }}', fullFilename: '{{ ep.filename|e }}', size: '{{ ep.size }}', associatedFiles: [
+                {%- if ep.associated_files %}{% for af in ep.associated_files %}{ filename: '{{ af.filename|truncate_filename(45)|e }}', fullFilename: '{{ af.filename|e }}', size: '{{ af.size }}' },{% endfor %}{% endif -%}
+            ] },
+            {%- endfor %}
+        ] },
+        {%- else %}
         { action: '{{ f.action }}', filename: '{{ f.filename|truncate_filename(45)|e }}', fullFilename: '{{ f.filename|e }}', size: '{{ f.size }}', associatedFiles: [
             {%- if f.associated_files is defined and f.associated_files %}{% for af in f.associated_files %}{ filename: '{{ af.filename|truncate_filename(45)|e }}', fullFilename: '{{ af.filename|e }}', size: '{{ af.size }}' },{% endfor %}{% endif -%}
         ] },
+        {%- endif %}
         {% endfor %}
     ];
     var errorMessages = [
@@ -996,26 +1025,60 @@ function dismissMaintCompletionBanner() {
     if (hasDetails) {
         hintHtml = '<div class="di-expand-hint"><span>Click for details</span><i data-lucide="chevron-down" style="width: 12px; height: 12px;"></i></div>';
         detailHtml = '<div class="di-pill__detail"><div class="di-divider"></div>';
+        // Persist expand state across 10s polls so the user's drill-down
+        // survives HTMX re-renders of the banner.
+        var expandedShows = window.__bannerExpandedShows || (window.__bannerExpandedShows = {});
+
+        // Count files actually shown (grouped entries contribute their episode count)
+        var shownFiles = 0;
+        recentFiles.forEach(function(f) {
+            shownFiles += f.isGroup ? f.episodeCount : 1;
+        });
+
         recentFiles.forEach(function(f) {
             var tagClass = f.action === 'Cached' ? 'di-action-tag--cached' : 'di-action-tag--restored';
-            var assocBadge = f.associatedFiles.length > 0 ? '<span class="di-file-row__assoc-badge">+' + f.associatedFiles.length + '</span>' : '';
-            detailHtml += '<div class="di-file-row">' +
-                '<span class="di-action-tag ' + tagClass + '">' + f.action.toUpperCase() + '</span>' +
-                '<span class="di-file-row__name" title="' + f.fullFilename + '">' + f.filename + '</span>' +
-                (f.size !== '-' ? '<span class="di-file-row__size">' + f.size + '</span>' : '') +
-                assocBadge +
-                '</div>';
-            f.associatedFiles.forEach(function(af) {
-                detailHtml += '<div class="di-file-row di-file-row--sub">' +
-                    '<span class="di-sub-arrow">&#8627;</span>' +
-                    '<span class="di-file-row__name" title="' + af.fullFilename + '">' + af.filename + '</span>' +
-                    (af.size ? '<span class="di-file-row__size">' + af.size + '</span>' : '') +
+
+            if (f.isGroup) {
+                var isExpanded = expandedShows[f.showName] === true;
+                var chevClass = isExpanded ? 'di-expand-chev open' : 'di-expand-chev';
+                var epLabel = f.episodeCount + ' ep' + (f.episodeCount !== 1 ? 's' : '');
+                detailHtml += '<div class="di-file-row di-file-row--group" data-show="' + f.showName + '" onclick="bannerToggleShow(event, this)" style="cursor:pointer">' +
+                    '<span class="di-action-tag ' + tagClass + '">' + f.action.toUpperCase() + '</span>' +
+                    '<span class="di-file-row__name">' + f.showName + '</span>' +
+                    '<span class="di-file-row__assoc-badge">' + epLabel + '</span>' +
+                    (f.size ? '<span class="di-file-row__size">' + f.size + '</span>' : '') +
+                    '<span class="' + chevClass + '">&#8250;</span>' +
                     '</div>';
-            });
+                f.episodes.forEach(function(ep) {
+                    var epAssoc = ep.associatedFiles.length > 0 ? '<span class="di-file-row__assoc-badge">+' + ep.associatedFiles.length + '</span>' : '';
+                    detailHtml += '<div class="di-file-row di-file-row--sub di-file-row--ep" data-parent-show="' + f.showName + '" style="display:' + (isExpanded ? 'flex' : 'none') + '">' +
+                        '<span class="di-sub-arrow">&#8627;</span>' +
+                        '<span class="di-file-row__name" title="' + ep.fullFilename + '">' + ep.filename + '</span>' +
+                        epAssoc +
+                        (ep.size ? '<span class="di-file-row__size">' + ep.size + '</span>' : '') +
+                        '</div>';
+                });
+            } else {
+                var assocBadge = f.associatedFiles.length > 0 ? '<span class="di-file-row__assoc-badge">+' + f.associatedFiles.length + '</span>' : '';
+                detailHtml += '<div class="di-file-row">' +
+                    '<span class="di-action-tag ' + tagClass + '">' + f.action.toUpperCase() + '</span>' +
+                    '<span class="di-file-row__name" title="' + f.fullFilename + '">' + f.filename + '</span>' +
+                    (f.size !== '-' ? '<span class="di-file-row__size">' + f.size + '</span>' : '') +
+                    assocBadge +
+                    '</div>';
+                f.associatedFiles.forEach(function(af) {
+                    detailHtml += '<div class="di-file-row di-file-row--sub">' +
+                        '<span class="di-sub-arrow">&#8627;</span>' +
+                        '<span class="di-file-row__name" title="' + af.fullFilename + '">' + af.filename + '</span>' +
+                        (af.size ? '<span class="di-file-row__size">' + af.size + '</span>' : '') +
+                        '</div>';
+                });
+            }
         });
         var totalFiles = filesCached + filesRestored;
-        if (totalFiles > recentFiles.length) {
-            detailHtml += '<div class="di-more-files">+ ' + (totalFiles - recentFiles.length) + ' more files</div>';
+        if (totalFiles > shownFiles) {
+            detailHtml += '<a class="di-more-link" href="/#recent-activity" onclick="event.stopPropagation()">' +
+                'View all ' + (totalFiles - shownFiles) + ' more in Recent Activity &rarr;</a>';
         }
         if (errorMessages.length > 0) {
             if (recentFiles.length > 0) detailHtml += '<div class="di-divider"></div>';

--- a/web/templates/components/global_operation_banner.html
+++ b/web/templates/components/global_operation_banner.html
@@ -282,7 +282,9 @@ function bannerToggleShow(evt, el) {
 // During running ops the banner polls every 2s with innerHTML swaps; if the
 // user had focus or selection inside the banner, the destroyed element can
 // cause the browser to reset scroll to top. Snapshot before, restore after.
-var _diSavedScrollY = null;
+// Stored on window because this script re-runs on every innerHTML swap and
+// would otherwise wipe the saved value between beforeSwap and afterSwap.
+if (typeof window.__diSavedScrollY === 'undefined') window.__diSavedScrollY = null;
 
 // Skip the swap if the banner state hasn't meaningfully changed.
 // Prevents the pill from flashing on every idle/completed poll cycle.
@@ -292,7 +294,7 @@ var _diSavedScrollY = null;
 // Running/maintenance polls always swap (they show live progress).
 document.addEventListener('htmx:beforeSwap', function(evt) {
     if (evt.detail.target && evt.detail.target.id === 'global-operation-banner') {
-        _diSavedScrollY = window.scrollY;
+        window.__diSavedScrollY = window.scrollY;
         var banner = evt.detail.target;
         var oldPill = banner.querySelector('.di-pill');
         if (!oldPill) return;  // No pill yet — allow first swap
@@ -386,9 +388,9 @@ document.addEventListener('htmx:responseError', function(evt) {
 document.addEventListener('htmx:afterSwap', function(evt) {
     if (evt.detail.target && evt.detail.target.id === 'global-operation-banner') {
         // Restore scroll position snapshotted in beforeSwap.
-        if (_diSavedScrollY !== null) {
-            window.scrollTo(0, _diSavedScrollY);
-            _diSavedScrollY = null;
+        if (window.__diSavedScrollY !== null) {
+            window.scrollTo(0, window.__diSavedScrollY);
+            window.__diSavedScrollY = null;
         }
 
         // Successful swap — reset connection failure tracking


### PR DESCRIPTION
## Summary

Two polish fixes to the global operation banner.

### Group episodes by show in completed-banner detail view
A long TV run previously rendered every episode as its own row, filling the banner pill with near-duplicate entries. Sibling episodes from the same show now collapse into one parent row showing show name + episode count + summed size (e.g. `For All Mankind · 5 eps · 12.4 GB`), with a chevron to expand to per-episode rows. Movies and one-episode shows stay flat — grouping only triggers when it actually compresses. Expand state is stored on `window` so it survives the 10s banner-poll innerHTML swaps. The "+N more files" footer becomes a link into the dashboard's Recent Activity.

`_current_run_files` entries now carry `size_bytes` alongside the formatted size string so the grouping pass can sum episode sizes for the parent row.

### Restore sub-row size-column readability
Associated-file rows (subtitles, sidecars under a parent) inherit reduced opacity from their parent row, and the size column has its own dimming on top. Compounded, sizes rendered at ~0.14 effective alpha — basically invisible. Explicit color override on `.af-popup-row` brings effective alpha back to ~0.30, matching parent rows.

## Test plan

- [x] **Episode grouping (multi-episode show):** trigger a cache run that pulls multiple episodes of the same show, open the completed banner's detail view — confirm episodes collapse into a single parent row with show name + episode count + summed size, chevron expands to individual episodes.
- [x] **Single-episode / movie still flat:** confirm a run with only movies or a single episode of a show shows individual rows, no spurious grouping.
- [x] **Expand state across polls:** click a show's chevron to expand, wait through several 10s banner polls — expanded state must persist.
- [x] **"+N more files" link:** with a run large enough to truncate, confirm the footer link navigates to the Recent Activity section on the dashboard.
- [x] **Sub-row contrast:** with the operation banner expanded to tier-3 detail showing associated files (subtitles/sidecars), confirm size text is legible at the same intensity as the parent row's size column.