### PR TITLE
Retry pinned-item fetch on transient local-Plex timeouts

### DIFF
--- a/core/pinned_cli.py
+++ b/core/pinned_cli.py
@@ -89,7 +89,7 @@ def _connect_plex(config_manager: ConfigManager):
         return None
     try:
         from plexapi.server import PlexServer
-        return PlexServer(plex_url, plex_token, timeout=10)
+        return PlexServer(plex_url, plex_token, timeout=30)
     except Exception as e:
         print(f"Error: Could not connect to Plex server: {e}")
         return None

--- a/core/pinned_media.py
+++ b/core/pinned_media.py
@@ -24,10 +24,17 @@ with an optional ``media_id`` field. The global rule remains the default.
 import logging
 import os
 import threading
+import time
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from core.file_operations import JSONTracker
+
+# Retry settings for transient local-Plex network errors during pin resolution.
+# Runs inside the audit loop (every ~5 min), so short, bounded retries are
+# preferable to letting a single transient timeout spam the error channel.
+_PIN_FETCH_MAX_ATTEMPTS = 3
+_PIN_FETCH_RETRY_WAIT = 2  # seconds between attempts
 
 
 VALID_PIN_TYPES = {"show", "season", "episode", "movie"}
@@ -255,6 +262,14 @@ def resolve_pins_to_paths(
         _NotFound = Exception
     NotFound = _NotFound
 
+    try:
+        import requests as _requests
+        _Timeout = _requests.Timeout
+        _ConnectionError = _requests.ConnectionError
+    except ImportError:
+        _Timeout = _ConnectionError = Exception
+    TransientNetError = (_Timeout, _ConnectionError)
+
     resolved: List[Tuple[str, str, str]] = []
     orphaned: List[str] = []
 
@@ -263,23 +278,53 @@ def resolve_pins_to_paths(
         pin_type = pin["type"]
         title = pin.get("title", rk)
 
-        try:
-            # plexapi.fetchItem accepts int or str rating_key
-            item = plex_server.fetchItem(int(rk))
-        except (NotFound, ValueError) as e:
-            logging.warning(
-                f"Pinned item no longer in Plex: '{title}' "
-                f"(rating_key={rk}) — removing pin. ({type(e).__name__}: {e})"
-            )
-            tracker.remove_pin(rk)
-            orphaned.append(rk)
-            continue
-        except Exception as e:
-            # Don't remove the pin on transient errors (connection loss, etc.)
-            logging.error(
-                f"Failed to fetch pinned item '{title}' (rating_key={rk}): "
-                f"{type(e).__name__}: {e}. Leaving pin in place."
-            )
+        item = None
+        last_transient_err: Optional[Exception] = None
+        for attempt in range(_PIN_FETCH_MAX_ATTEMPTS):
+            try:
+                # plexapi.fetchItem accepts int or str rating_key
+                item = plex_server.fetchItem(int(rk))
+                break
+            except TransientNetError as e:
+                # Check network errors BEFORE NotFound — some test environments
+                # fall NotFound back to `Exception`, which would otherwise swallow
+                # requests.Timeout/ConnectionError and mark the pin as orphaned.
+                last_transient_err = e
+                if attempt < _PIN_FETCH_MAX_ATTEMPTS - 1:
+                    logging.warning(
+                        f"Pinned item fetch attempt {attempt + 1}/{_PIN_FETCH_MAX_ATTEMPTS} "
+                        f"timed out for '{title}' (rating_key={rk}): {e}. "
+                        f"Retrying in {_PIN_FETCH_RETRY_WAIT}s..."
+                    )
+                    time.sleep(_PIN_FETCH_RETRY_WAIT)
+            except (NotFound, ValueError) as e:
+                logging.warning(
+                    f"Pinned item no longer in Plex: '{title}' "
+                    f"(rating_key={rk}) — removing pin. ({type(e).__name__}: {e})"
+                )
+                tracker.remove_pin(rk)
+                orphaned.append(rk)
+                item = None
+                last_transient_err = None
+                break
+            except Exception as e:
+                # Non-retriable error (e.g. malformed response, unexpected exception)
+                logging.error(
+                    f"Failed to fetch pinned item '{title}' (rating_key={rk}): "
+                    f"{type(e).__name__}: {e}. Leaving pin in place."
+                )
+                last_transient_err = None
+                break
+
+        if item is None:
+            if last_transient_err is not None:
+                # Don't remove the pin — server might be back up next audit cycle.
+                logging.error(
+                    f"Failed to fetch pinned item '{title}' (rating_key={rk}) "
+                    f"after {_PIN_FETCH_MAX_ATTEMPTS} attempts: "
+                    f"{type(last_transient_err).__name__}: {last_transient_err}. "
+                    f"Leaving pin in place."
+                )
             continue
 
         try:

--- a/tests/test_resolve_pins_to_paths.py
+++ b/tests/test_resolve_pins_to_paths.py
@@ -342,3 +342,116 @@ class TestPreferenceRespected:
         assert sorted(p for p, _, _ in lowest) == sorted([
             "/plex/E01.1080p.mkv", "/plex/E02.1080p.mkv"
         ])
+
+
+class TestFetchItemRetryOnTimeout:
+    """Transient local-Plex timeouts should be retried, not surfaced as ERROR."""
+
+    def _patch_sleep(self, monkeypatch):
+        """Don't actually sleep during retry tests."""
+        import core.pinned_media as pm
+        monkeypatch.setattr(pm.time, "sleep", lambda _: None)
+
+    def test_retries_on_timeout_then_succeeds(self, tracker, monkeypatch, caplog):
+        import requests
+        self._patch_sleep(monkeypatch)
+        movie = FakeMovie("Matrix", [FakeMedia("1080", "/plex/Matrix.mkv")])
+
+        calls = {"n": 0}
+
+        class FlakyServer:
+            def fetchItem(self, key):
+                calls["n"] += 1
+                if calls["n"] < 2:
+                    raise requests.Timeout("read timeout")
+                return movie
+
+        tracker.add_pin("100", "movie", "Matrix")
+        with caplog.at_level(logging.WARNING):
+            resolved, orphaned = resolve_pins_to_paths(FlakyServer(), tracker, "highest")
+
+        assert calls["n"] == 2
+        assert orphaned == []
+        assert len(resolved) == 1 and resolved[0][0] == "/plex/Matrix.mkv"
+        assert any("attempt 1/3" in r.message for r in caplog.records)
+        # No ERROR-level record should have been logged for this pin.
+        assert not any(r.levelno == logging.ERROR for r in caplog.records)
+
+    def test_retries_on_connection_error_then_succeeds(self, tracker, monkeypatch):
+        import requests
+        self._patch_sleep(monkeypatch)
+        movie = FakeMovie("Matrix", [FakeMedia("1080", "/plex/Matrix.mkv")])
+
+        calls = {"n": 0}
+
+        class FlakyServer:
+            def fetchItem(self, key):
+                calls["n"] += 1
+                if calls["n"] < 3:
+                    raise requests.ConnectionError("dns")
+                return movie
+
+        tracker.add_pin("100", "movie", "Matrix")
+        resolved, _ = resolve_pins_to_paths(FlakyServer(), tracker, "highest")
+        assert calls["n"] == 3
+        assert len(resolved) == 1
+
+    def test_gives_up_after_max_attempts_logs_error_keeps_pin(self, tracker, monkeypatch, caplog):
+        import requests
+        self._patch_sleep(monkeypatch)
+
+        calls = {"n": 0}
+
+        class BrokenServer:
+            def fetchItem(self, key):
+                calls["n"] += 1
+                raise requests.Timeout("always fails")
+
+        tracker.add_pin("100", "movie", "Matrix")
+        with caplog.at_level(logging.ERROR):
+            resolved, orphaned = resolve_pins_to_paths(BrokenServer(), tracker, "highest")
+
+        assert calls["n"] == 3  # _PIN_FETCH_MAX_ATTEMPTS
+        assert resolved == []
+        assert orphaned == []  # pin is NOT removed on transient failure
+        assert "100" in tracker._data
+        assert any("after 3 attempts" in r.message for r in caplog.records)
+
+    def test_notfound_still_removes_pin_without_retry(self, tracker, monkeypatch):
+        self._patch_sleep(monkeypatch)
+
+        calls = {"n": 0}
+
+        class ServerWithMissingItem:
+            def fetchItem(self, key):
+                calls["n"] += 1
+                raise FakeNotFound("gone")
+
+        tracker.add_pin("999", "movie", "DeletedMovie")
+        resolved, orphaned = resolve_pins_to_paths(ServerWithMissingItem(), tracker, "highest")
+
+        assert calls["n"] == 1  # no retry for NotFound
+        assert orphaned == ["999"]
+        assert resolved == []
+        assert "999" not in tracker._data
+
+    def test_non_retriable_exception_not_retried(self, tracker, monkeypatch):
+        """RuntimeError (or any non-network Exception) exits the retry loop after one attempt."""
+        self._patch_sleep(monkeypatch)
+
+        calls = {"n": 0}
+
+        class WeirdServer:
+            def fetchItem(self, key):
+                calls["n"] += 1
+                raise RuntimeError("unexpected")
+
+        tracker.add_pin("100", "movie", "Matrix")
+        resolved, _ = resolve_pins_to_paths(WeirdServer(), tracker, "highest")
+
+        # Only checking retry count here. Orphan-vs-keep depends on whether
+        # plexapi.exceptions.NotFound resolves to a specific class (production)
+        # or falls back to Exception (test env), which is orthogonal to the
+        # retry logic under test.
+        assert calls["n"] == 1
+        assert resolved == []

--- a/web/services/pinned_service.py
+++ b/web/services/pinned_service.py
@@ -66,7 +66,7 @@ class PinnedService:
             return None
         try:
             from plexapi.server import PlexServer
-            return PlexServer(plex_url, plex_token, timeout=10)
+            return PlexServer(plex_url, plex_token, timeout=30)
         except Exception as e:
             logger.warning(f"PinnedService: could not connect to Plex: {e}")
             return None


### PR DESCRIPTION
## Summary

Pin resolution runs inside the audit loop every ~5 min and calls `plex_server.fetchItem()` for every pin. A single `ReadTimeout` against the local Plex server would log an ERROR per pin per audit cycle, flooding the error notification channel when Plex is temporarily slow (library scan, metadata refresh, etc).

This is the same retry pattern as #154 (`plex.tv` watchlist) but on a different code path — local Plex fetches in `core/pinned_media.py`.

## Changes

- Retry up to 3 attempts on `requests.Timeout` / `requests.ConnectionError` with 2s between attempts.
- Raise per-fetch timeout from 10s → 30s on the `PlexServer` instances used for pinned operations.
- `NotFound` (item deleted) still removes the pin without retry.
- Non-network errors still exit immediately.

## Test plan

- [x] Pin a few items via the web UI; trigger a manual audit and confirm pins resolve normally.
- [x] Block local Plex traffic mid-audit (e.g. firewall rule, stop Plex container briefly) and confirm:
  - Logs show `WARNING` retry attempts instead of immediate `ERROR`.
  - If Plex returns within retries, the pin resolves cleanly.
  - If Plex stays down, the final failure is logged once (not per attempt).
- [x] Delete a pinned item from Plex; audit removes the pin from the tracker (no retry, since `NotFound`).