### PR TITLE
Code quality batch: service-layer consolidation, narrower excepts, design tokens, JS DRY-up

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -252,7 +252,7 @@ class PlexCacheApp:
             try:
                 self._update_unraid_mover_exclusions()
                 logging.debug("Unraid mover exclusions updated.")
-            except Exception as e:
+            except OSError as e:
                 logging.error(f"Failed to update Unraid mover exclusions: {e}")
 
 
@@ -400,7 +400,7 @@ class PlexCacheApp:
                 gid = os.getgid()
                 username = pwd.getpwuid(uid).pw_name
                 logging.debug(f"Running as: {username} (uid={uid}, gid={gid})")
-            except Exception as e:
+            except (AttributeError, KeyError, OSError) as e:
                 logging.debug(f"Could not get user info: {e}")
         else:
             logging.debug(f"Running as: {os.getlogin() if hasattr(os, 'getlogin') else 'unknown'}")
@@ -922,7 +922,7 @@ class PlexCacheApp:
             try:
                 self.config_manager._save_updated_config()
                 logging.debug(f"Saved {added_count} new user(s) to settings")
-            except Exception as e:
+            except OSError as e:
                 logging.error(f"Failed to save new users to settings: {e}")
 
     def _check_active_sessions(self) -> None:
@@ -949,7 +949,7 @@ class PlexCacheApp:
                         converted_path = converted_paths[0]
                         logging.debug(f"Skipping active session file: {converted_path}")
                         self.files_to_skip.append(converted_path)
-            except Exception as e:
+            except (AttributeError, KeyError, TypeError, OSError) as e:
                 logging.error(f"Error processing session {session}: {type(e).__name__}: {e}")
 
     def _get_media_path_from_session(self, session) -> Optional[str]:
@@ -1493,7 +1493,7 @@ class PlexCacheApp:
             # Clean up trailing dashes
             name = name.rstrip(' -').rstrip('-').strip()
             return name if name else filename
-        except Exception:
+        except (AttributeError, TypeError, ValueError):
             return os.path.basename(file_path)
 
     def _detect_and_transfer_upgrades(self, ondeck_items_list: list,
@@ -1759,7 +1759,7 @@ class PlexCacheApp:
                 return False  # Already on cache
 
             return True  # Needs caching
-        except Exception:
+        except (OSError, AttributeError, ValueError):
             return True  # Assume it needs caching if we can't determine
 
     def _separate_restore_and_move(self, files_to_array: List[str]) -> Tuple[List[str], List[str]]:
@@ -2078,7 +2078,7 @@ class PlexCacheApp:
                 resolved = int(total_drive_size * percent / 100)
                 readable = f"{percent}% of {total_drive_size / (1024**3):.2f}GB = {resolved / (1024**3):.2f}GB"
                 return (resolved, readable)
-            except Exception as e:
+            except (OSError, AttributeError, ZeroDivisionError) as e:
                 logging.warning(f"Could not calculate cache drive size for {label} percentage: {e}")
                 return (0, None)
         else:
@@ -2134,7 +2134,7 @@ class PlexCacheApp:
                         cached_files.append(container_path)  # Return container paths for eviction
                 except (OSError, FileNotFoundError):
                     pass
-        except Exception as e:
+        except OSError as e:
             logging.warning(f"Error reading exclude file: {e}")
             return (0, [])
 
@@ -2160,7 +2160,7 @@ class PlexCacheApp:
             disk_usage = get_disk_usage(cache_dir, drive_size_override)
             drive_usage_bytes = disk_usage.used
             drive_usage_gb = drive_usage_bytes / (1024**3)
-        except Exception as e:
+        except OSError as e:
             logging.warning(f"Could not determine cache drive usage: {e}, skipping limit check")
             return media_files
 
@@ -2373,7 +2373,7 @@ class PlexCacheApp:
             drive_size_override = self.config_manager.cache.cache_drive_size_bytes
             disk_usage = get_disk_usage(cache_dir, drive_size_override)
             total_drive_usage = disk_usage.used
-        except Exception:
+        except OSError:
             total_drive_usage = 0  # Can't check drive usage, but still filter by priority
 
         is_over_threshold = total_drive_usage >= threshold_bytes
@@ -2457,7 +2457,7 @@ class PlexCacheApp:
             drive_size_override = self.config_manager.cache.cache_drive_size_bytes
             disk_usage = get_disk_usage(cache_dir, drive_size_override)
             total_drive_usage = disk_usage.used
-        except Exception:
+        except OSError:
             total_drive_usage = plexcache_tracked  # Fallback if can't get disk usage
 
         if total_drive_usage < threshold_bytes and needed_space_bytes == 0:
@@ -2681,7 +2681,7 @@ class PlexCacheApp:
                 files_evicted += 1
                 bytes_freed += file_size
 
-            except Exception as e:
+            except OSError as e:
                 logging.warning(f"Failed to evict {cache_path}: {e}")
 
         logging.info(f"[EVICTION] Smart eviction complete: freed {bytes_freed/1e9:.2f}GB from {files_evicted} files")

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -16,7 +16,7 @@ from typing import List, Set, Optional, Tuple, Dict, TYPE_CHECKING, Callable
 import re
 
 from core.logging_config import get_console_lock
-from core.system_utils import resolve_user0_to_disk, get_disk_free_space_bytes, get_disk_number_from_path, get_array_direct_path
+from core.system_utils import resolve_user0_to_disk, get_disk_free_space_bytes, get_disk_number_from_path, get_array_direct_path, format_bytes
 
 if TYPE_CHECKING:
     from core.config import PathMapping
@@ -122,26 +122,6 @@ def is_season_like_folder(folder_name: str) -> bool:
         or re.match(r'^\d+$', folder_name)
         or re.match(r'^Specials$', folder_name, re.IGNORECASE)
     )
-
-
-def format_bytes(bytes_value: int) -> str:
-    """Format bytes into human-readable string (e.g., '1.5 GB').
-
-    Canonical implementation — import from core.system_utils.
-    Re-exported here for convenience.
-    """
-    from core.system_utils import format_bytes as _fb
-    return _fb(bytes_value)
-
-
-def format_duration(seconds: float) -> str:
-    """Format seconds into human-readable duration like '1m 23s' or '45s'.
-
-    Canonical implementation — import from core.system_utils.
-    Re-exported here for convenience.
-    """
-    from core.system_utils import format_duration as _fd
-    return _fd(seconds)
 
 
 def get_media_identity(filepath: str) -> str:

--- a/core/system_utils.py
+++ b/core/system_utils.py
@@ -209,6 +209,47 @@ def format_cache_age(updated_at) -> Optional[str]:
         return f"{int(age_seconds / 3600)} hr ago"
 
 
+def format_time_of_day(time_str: str, time_format: str) -> str:
+    """Convert an 'HH:MM' string to display form based on time_format ('12h' or '24h').
+
+    Invalid input is returned unchanged.
+    """
+    try:
+        hour, minute = map(int, time_str.split(":"))
+    except (ValueError, AttributeError):
+        return time_str
+    if time_format == "12h":
+        period = "AM" if hour < 12 else "PM"
+        hour_12 = hour % 12 or 12
+        if minute == 0:
+            return f"{hour_12} {period}"
+        return f"{hour_12}:{minute:02d} {period}"
+    return f"{hour}:{minute:02d}"
+
+
+def format_relative_time(target) -> str:
+    """Format a future datetime as relative time (e.g., '12m', '2h 30m', '<1m').
+
+    Returns 'now' if target is in the past. 'target' must be a datetime.
+    """
+    from datetime import datetime
+    now = datetime.now()
+    if target <= now:
+        return "now"
+    total_minutes = int((target - now).total_seconds()) // 60
+    if total_minutes < 1:
+        return "<1m"
+    if total_minutes < 60:
+        return f"{total_minutes}m"
+    hours, minutes = divmod(total_minutes, 60)
+    return f"{hours}h" if minutes == 0 else f"{hours}h {minutes}m"
+
+
+def get_log_time_datefmt(time_format: str) -> str:
+    """Return a strftime datefmt for log timestamps based on time_format ('12h' or '24h')."""
+    return '%-I:%M:%S %p' if time_format == '12h' else '%H:%M:%S'
+
+
 def translate_container_to_host_path(path: str, path_mappings: list) -> str:
     """Translate container cache path to host path for exclude file.
 

--- a/web/routers/api.py
+++ b/web/routers/api.py
@@ -13,11 +13,10 @@ from urllib.parse import unquote
 
 from web.config import templates, PLEXCACHE_PRODUCT_VERSION, IS_DOCKER
 from web.dependencies import parse_form
-from core.system_utils import format_bytes, format_duration, format_cache_age
 from web.services import get_cache_service, get_settings_service, get_operation_runner, get_scheduler_service, ScheduleConfig, get_maintenance_service
-from core.activity import load_last_run_summary
+from web.services.cache_service import cached_files_to_dicts, calculate_file_totals
 from web.services.operation_runner import OperationRunner
-from web.services.web_cache import get_web_cache_service, CACHE_KEY_DASHBOARD_STATS, CACHE_KEY_MAINTENANCE_HEALTH
+from web.services.web_cache import get_web_cache_service, get_dashboard_stats, CACHE_KEY_DASHBOARD_STATS, CACHE_KEY_MAINTENANCE_HEALTH
 
 logger = logging.getLogger(__name__)
 
@@ -40,97 +39,10 @@ def _safe_int(value, default: int) -> int:
         return default
 
 
-def _get_dashboard_stats_data(use_cache: bool = True) -> tuple[dict, str | None]:
-    """Get dashboard stats, optionally from cache. Returns (stats, cache_age)"""
-    web_cache = get_web_cache_service()
-    cache_service = get_cache_service()
-    settings_service = get_settings_service()
-    operation_runner = get_operation_runner()
-    scheduler_service = get_scheduler_service()
-    maintenance_service = get_maintenance_service()
-
-    # Try to get from cache first
-    if use_cache:
-        cached_stats = web_cache.get(CACHE_KEY_DASHBOARD_STATS)
-        if cached_stats:
-            # Calculate cache age
-            _, updated_at = web_cache.get_with_age(CACHE_KEY_DASHBOARD_STATS)
-            cache_age = format_cache_age(updated_at)
-
-            # Update dynamic fields that shouldn't be cached
-            cached_stats["is_running"] = operation_runner.is_running
-            # Stale cache from before duplicate support — recompute fresh
-            if "health_duplicate_count" not in cached_stats:
-                web_cache.invalidate(CACHE_KEY_DASHBOARD_STATS)
-            else:
-                return cached_stats, cache_age
-
-    # Compute fresh stats
-    cache_stats = cache_service.get_cache_stats()
-    plex_connected = settings_service.check_plex_connection()
-    last_run = settings_service.get_last_run_time() or "Never"
-    schedule_status = scheduler_service.get_status()
-    health = maintenance_service.get_health_summary()
-
-    stats = {
-        "cache_files": cache_stats["cache_files"],
-        "cache_size": cache_stats["cache_size"],
-        "cache_limit": cache_stats["cache_limit"],
-        "usage_percent": cache_stats["usage_percent"],
-        "cached_files_size": cache_stats.get("cached_files_size"),
-        "associated_files_count": cache_stats.get("associated_files_count", 0),
-        "ondeck_count": cache_stats["ondeck_count"],
-        "ondeck_tracked_count": cache_stats.get("ondeck_tracked_count", 0),
-        "watchlist_count": cache_stats["watchlist_count"],
-        "watchlist_tracked_count": cache_stats.get("watchlist_tracked_count", 0),
-        "eviction_over_threshold": cache_stats.get("eviction_over_threshold", False),
-        "eviction_over_by_display": cache_stats.get("eviction_over_by_display"),
-        "cache_limit_exceeded": cache_stats.get("cache_limit_exceeded", False),
-        "cache_limit_approaching": cache_stats.get("cache_limit_approaching", False),
-        "configured_limit_display": cache_stats.get("configured_limit_display"),
-        "configured_limit_percent": cache_stats.get("configured_limit_percent", 0),
-        "eviction_threshold_display": cache_stats.get("eviction_threshold_display"),
-        "min_free_space_warning": cache_stats.get("min_free_space_warning", False),
-        "last_run": last_run,
-        "is_running": operation_runner.is_running,
-        "plex_connected": plex_connected,
-        "schedule_enabled": schedule_status.get("enabled", False),
-        "next_run": schedule_status.get("next_run_display", "Not scheduled"),
-        "next_run_relative": schedule_status.get("next_run_relative"),
-        "health_status": health["status"],
-        "health_issues": health["orphaned_count"],
-        "health_warnings": health["stale_exclude_count"] + health["stale_timestamp_count"] + health["duplicate_orphan_count"],
-        "health_orphaned_count": health["orphaned_count"],
-        "health_stale_exclude_count": health["stale_exclude_count"],
-        "health_stale_timestamp_count": health["stale_timestamp_count"],
-        "health_duplicate_count": health["duplicate_count"],
-        "health_duplicate_orphan_count": health["duplicate_orphan_count"],
-        "health_duplicate_orphan_bytes": health["duplicate_orphan_bytes_display"],
-        "last_run_summary": None,
-    }
-
-    # Load last run summary
-    summary = load_last_run_summary()
-    if summary:
-        stats["last_run_summary"] = {
-            "status": summary.get("status", "unknown"),
-            "bytes_cached_display": format_bytes(summary["bytes_cached"]) if summary.get("bytes_cached") else "",
-            "bytes_restored_display": format_bytes(summary["bytes_restored"]) if summary.get("bytes_restored") else "",
-            "duration_display": format_duration(summary.get("duration_seconds", 0)),
-            "error_count": summary.get("error_count", 0),
-            "dry_run": summary.get("dry_run", False),
-        }
-
-    # Cache the results
-    web_cache.set(CACHE_KEY_DASHBOARD_STATS, stats)
-
-    return stats, "just now"
-
-
 @router.get("/dashboard/stats-content", response_class=HTMLResponse)
 def dashboard_stats_content(request: Request):
     """Full dashboard stats container for lazy loading"""
-    stats, cache_age = _get_dashboard_stats_data(use_cache=True)
+    stats, cache_age = get_dashboard_stats(use_cache=True)
 
     return templates.TemplateResponse(
         request,
@@ -145,7 +57,7 @@ def dashboard_stats_content(request: Request):
 @router.get("/dashboard/stats", response_class=HTMLResponse)
 def dashboard_stats(request: Request):
     """Dashboard stats partial for HTMX polling"""
-    stats, _ = _get_dashboard_stats_data(use_cache=True)
+    stats, _ = get_dashboard_stats(use_cache=True)
 
     return templates.TemplateResponse(
         request,
@@ -170,43 +82,8 @@ def cache_files_table(
         source_filter=source, search=search, sort_by=sort, sort_dir=dir
     )
 
-    # Convert dataclass to dict for template
-    files_data = [
-        {
-            "path": f.path,
-            "filename": f.filename,
-            "size": f.size,
-            "size_display": f.size_display,
-            "cache_age_hours": f.cache_age_hours,
-            "source": f.source,
-            "priority_score": f.priority_score,
-            "users": f.users,
-            "is_ondeck": f.is_ondeck,
-            "is_watchlist": f.is_watchlist,
-            "is_pinned": f.is_pinned,
-            "subtitle_count": f.subtitle_count,
-            "sidecar_count": f.sidecar_count,
-            "associated_files": f.associated_files
-        }
-        for f in files
-    ]
-
-    # Calculate totals for the current filtered view
-    totals = {
-        "total_files": len(files_data),
-        "ondeck_count": sum(1 for f in files_data if f["is_ondeck"]),
-        "watchlist_count": sum(1 for f in files_data if f["is_watchlist"]),
-        "pinned_count": sum(1 for f in files_data if f["is_pinned"]),
-        "other_count": sum(1 for f in files_data if not f["is_ondeck"] and not f["is_watchlist"] and not f["is_pinned"]),
-        "total_size": sum(f["size"] for f in files_data)
-    }
-    # Format total size
-    if totals["total_size"] >= 1024 ** 3:
-        totals["total_size_display"] = f"{totals['total_size'] / (1024 ** 3):.2f} GB"
-    elif totals["total_size"] >= 1024 ** 2:
-        totals["total_size_display"] = f"{totals['total_size'] / (1024 ** 2):.2f} MB"
-    else:
-        totals["total_size_display"] = f"{totals['total_size'] / 1024:.2f} KB"
+    files_data = cached_files_to_dicts(files)
+    totals = calculate_file_totals(files_data)
 
     # Get eviction mode setting
     settings_service = get_settings_service()

--- a/web/routers/cache.py
+++ b/web/routers/cache.py
@@ -7,6 +7,7 @@ from fastapi.responses import HTMLResponse
 
 from web.config import templates
 from web.services import get_cache_service, get_settings_service
+from web.services.cache_service import cached_files_to_dicts, calculate_file_totals
 
 logger = logging.getLogger(__name__)
 
@@ -36,43 +37,8 @@ def cache_list(
         source_filter=source, search=search, sort_by=sort, sort_dir=dir
     )
 
-    # Convert dataclass to dict for template
-    files_data = [
-        {
-            "path": f.path,
-            "filename": f.filename,
-            "size": f.size,
-            "size_display": f.size_display,
-            "cache_age_hours": f.cache_age_hours,
-            "source": f.source,
-            "priority_score": f.priority_score,
-            "users": f.users,
-            "is_ondeck": f.is_ondeck,
-            "is_watchlist": f.is_watchlist,
-            "is_pinned": f.is_pinned,
-            "subtitle_count": f.subtitle_count,
-            "sidecar_count": f.sidecar_count,
-            "associated_files": f.associated_files
-        }
-        for f in files
-    ]
-
-    # Calculate totals for the current filtered view
-    totals = {
-        "total_files": len(files_data),
-        "ondeck_count": sum(1 for f in files_data if f["is_ondeck"]),
-        "watchlist_count": sum(1 for f in files_data if f["is_watchlist"]),
-        "pinned_count": sum(1 for f in files_data if f["is_pinned"]),
-        "other_count": sum(1 for f in files_data if not f["is_ondeck"] and not f["is_watchlist"] and not f["is_pinned"]),
-        "total_size": sum(f["size"] for f in files_data)
-    }
-    # Format total size
-    if totals["total_size"] >= 1024 ** 3:
-        totals["total_size_display"] = f"{totals['total_size'] / (1024 ** 3):.2f} GB"
-    elif totals["total_size"] >= 1024 ** 2:
-        totals["total_size_display"] = f"{totals['total_size'] / (1024 ** 2):.2f} MB"
-    else:
-        totals["total_size_display"] = f"{totals['total_size'] / 1024:.2f} KB"
+    files_data = cached_files_to_dicts(files)
+    totals = calculate_file_totals(files_data)
 
     return templates.TemplateResponse(
         request,

--- a/web/routers/dashboard.py
+++ b/web/routers/dashboard.py
@@ -6,7 +6,7 @@ from fastapi.responses import HTMLResponse
 from web.config import templates
 from web.services import get_operation_runner
 from core.activity import _get_activity_retention_hours
-from web.services.web_cache import get_web_cache_service, CACHE_KEY_DASHBOARD_STATS, CACHE_KEY_MAINTENANCE_HEALTH
+from web.services.web_cache import get_web_cache_service, get_dashboard_stats, CACHE_KEY_DASHBOARD_STATS, CACHE_KEY_MAINTENANCE_HEALTH
 
 router = APIRouter()
 
@@ -46,16 +46,11 @@ def dashboard(request: Request):
 @router.post("/refresh-stats", response_class=HTMLResponse)
 def refresh_stats(request: Request):
     """Force refresh dashboard stats and return updated container"""
-    # Import here to avoid circular dependency
-    from web.routers.api import _get_dashboard_stats_data
-
-    # Invalidate cache first
     web_cache = get_web_cache_service()
     web_cache.invalidate(CACHE_KEY_DASHBOARD_STATS)
     web_cache.invalidate(CACHE_KEY_MAINTENANCE_HEALTH)
 
-    # Get fresh stats
-    stats, cache_age = _get_dashboard_stats_data(use_cache=False)
+    stats, cache_age = get_dashboard_stats(use_cache=False)
 
     return templates.TemplateResponse(
         request,

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -546,6 +546,224 @@ class CacheService:
         final_score = max(0, min(100, score))
         return final_score, breakdown
 
+    def _classify_cache_paths(
+        self, cached_paths: List[str]
+    ) -> Tuple[List[str], List[str], List[str]]:
+        """Split cached paths into (subtitles, videos, sidecars)."""
+        subtitle_paths: List[str] = []
+        video_paths: List[str] = []
+        sidecar_paths: List[str] = []
+        for cache_path in cached_paths:
+            filename = os.path.basename(cache_path)
+            if self._is_subtitle_file(filename):
+                subtitle_paths.append(cache_path)
+            elif is_video_file(cache_path):
+                video_paths.append(cache_path)
+            else:
+                sidecar_paths.append(cache_path)
+        return subtitle_paths, video_paths, sidecar_paths
+
+    def _build_video_lookup(
+        self, video_paths: List[str]
+    ) -> Tuple[Dict[Tuple[str, str], str], Dict[str, List[str]]]:
+        """Index videos by (directory, basename-lower) and by directory."""
+        video_by_base: Dict[Tuple[str, str], str] = {}
+        videos_by_dir: Dict[str, List[str]] = {}
+        for video_path in video_paths:
+            directory = os.path.dirname(video_path)
+            base_name = os.path.splitext(os.path.basename(video_path))[0]
+            video_by_base[(directory, base_name.lower())] = video_path
+            videos_by_dir.setdefault(directory, []).append(video_path)
+        return video_by_base, videos_by_dir
+
+    def _group_subtitles(
+        self,
+        subtitle_paths: List[str],
+        video_by_base: Dict[Tuple[str, str], str],
+    ) -> Dict[str, List[str]]:
+        """Attach subtitles to their parent video by matching basename in the same directory."""
+        video_subtitles: Dict[str, List[str]] = {}
+        for sub_path in subtitle_paths:
+            directory = os.path.dirname(sub_path)
+            sub_base = self._get_video_base_name(sub_path).lower()
+            video_path = video_by_base.get((directory, sub_base))
+            if video_path:
+                video_subtitles.setdefault(video_path, []).append(sub_path)
+        return video_subtitles
+
+    def _group_sidecars(
+        self,
+        sidecar_paths: List[str],
+        video_by_base: Dict[Tuple[str, str], str],
+        videos_by_dir: Dict[str, List[str]],
+    ) -> Dict[str, List[str]]:
+        """Attach sidecars to parent video: name match first, then any video in the same dir."""
+        video_sidecars: Dict[str, List[str]] = {}
+        for sidecar_path in sidecar_paths:
+            directory = os.path.dirname(sidecar_path)
+            sidecar_base = os.path.splitext(os.path.basename(sidecar_path))[0].lower()
+            video_path = video_by_base.get((directory, sidecar_base))
+            if not video_path:
+                dir_videos = videos_by_dir.get(directory, [])
+                if dir_videos:
+                    video_path = dir_videos[0]
+            if video_path:
+                video_sidecars.setdefault(video_path, []).append(sidecar_path)
+        return video_sidecars
+
+    def _build_cached_file(
+        self,
+        cache_path: str,
+        *,
+        timestamps: Dict,
+        ondeck: Dict,
+        watchlist: Dict,
+        settings: Dict,
+        pinned_cache_path_map: Dict,
+        pinned_cache_paths: set,
+        video_subtitles: Dict[str, List[str]],
+        video_sidecars: Dict[str, List[str]],
+        source_filter: str,
+        search: str,
+        now: datetime,
+    ) -> Optional[CachedFile]:
+        """Build a CachedFile for a single video path, or None if filtered out."""
+        filename = os.path.basename(cache_path)
+
+        if search and search.lower() not in filename.lower():
+            return None
+
+        try:
+            size = os.path.getsize(cache_path) if os.path.exists(cache_path) else 0
+        except OSError:
+            size = 0
+
+        ts_info = timestamps.get(cache_path, {})
+        if isinstance(ts_info, dict):
+            cached_at_str = ts_info.get("cached_at")
+            source = ts_info.get("source", "unknown")
+        else:
+            cached_at_str = ts_info
+            source = "unknown"
+
+        try:
+            cached_at = datetime.fromisoformat(cached_at_str) if cached_at_str else now
+        except (ValueError, TypeError):
+            cached_at = now
+
+        cache_age_hours = (now - cached_at).total_seconds() / 3600
+
+        is_ondeck = False
+        is_watchlist = False
+        users: set = set()
+        episode_info = None
+        tracker_rating_key: Optional[str] = None
+        tracker_pin_type: Optional[str] = None
+        cache_basename = os.path.basename(cache_path)
+
+        for plex_path, info in ondeck.items():
+            if os.path.basename(plex_path) == cache_basename:
+                is_ondeck = True
+                source = "ondeck"
+                if "users" in info:
+                    users.update(info["users"])
+                episode_info = info.get("episode_info")
+                if info.get("rating_key"):
+                    tracker_rating_key = info["rating_key"]
+                    tracker_pin_type = "episode" if episode_info else "movie"
+                break
+
+        for plex_path, info in watchlist.items():
+            if os.path.basename(plex_path) == cache_basename:
+                is_watchlist = True
+                if not is_ondeck:
+                    source = "watchlist"
+                if "users" in info:
+                    users.update(info["users"])
+                if tracker_rating_key is None and info.get("rating_key"):
+                    tracker_rating_key = info["rating_key"]
+                    # Prefer the watchlist tracker's stored media_type (populated
+                    # at gathering time). Fall back to episode_info, then "movie"
+                    # so legacy entries written before media_type existed still
+                    # behave the way they always did.
+                    wl_media_type = info.get("media_type")
+                    if wl_media_type in ("episode", "movie"):
+                        tracker_pin_type = wl_media_type
+                    else:
+                        tracker_pin_type = "episode" if episode_info else "movie"
+                break
+
+        is_pinned = cache_path in pinned_cache_paths
+
+        if source_filter == "pinned" and not is_pinned:
+            return None
+        if source_filter == "ondeck" and not is_ondeck:
+            return None
+        if source_filter == "watchlist" and not is_watchlist:
+            return None
+        if source_filter == "other" and (is_ondeck or is_watchlist or is_pinned):
+            return None
+
+        if is_pinned:
+            priority = 100
+        else:
+            priority = self.calculate_priority(
+                cache_path, timestamps, ondeck, watchlist, settings
+            )
+
+        # For pinned rows, prefer the pinned-map's rating_key/pin_type —
+        # it's the authoritative source for the unpin button. For unpinned
+        # rows, fall back to the ondeck/watchlist tracker values so the row
+        # can still offer a pin-in-place button.
+        if is_pinned:
+            pinned_meta = pinned_cache_path_map.get(cache_path)
+            if pinned_meta:
+                row_rating_key, row_pin_type = pinned_meta
+            else:
+                row_rating_key, row_pin_type = tracker_rating_key, tracker_pin_type
+        else:
+            row_rating_key, row_pin_type = tracker_rating_key, tracker_pin_type
+
+        subs = video_subtitles.get(cache_path, [])
+        sidecars = video_sidecars.get(cache_path, [])
+
+        assoc_list: Optional[List[Dict[str, str]]] = None
+        all_assoc = subs + sidecars
+        if all_assoc:
+            assoc_list = []
+            for ap in all_assoc:
+                try:
+                    asize = os.path.getsize(ap) if os.path.exists(ap) else 0
+                except OSError:
+                    asize = 0
+                assoc_list.append({
+                    "filename": os.path.basename(ap),
+                    "size": format_bytes(asize),
+                })
+
+        return CachedFile(
+            path=cache_path,
+            filename=filename,
+            size=size,
+            size_display=format_bytes(size),
+            cached_at=cached_at,
+            cache_age_hours=cache_age_hours,
+            source=source,
+            priority_score=priority,
+            users=list(users),
+            is_ondeck=is_ondeck,
+            is_watchlist=is_watchlist,
+            episode_info=episode_info,
+            subtitle_count=len(subs),
+            subtitle_paths=subs if subs else None,
+            sidecar_count=len(sidecars),
+            sidecar_paths=sidecars if sidecars else None,
+            associated_files=assoc_list,
+            is_pinned=is_pinned,
+            rating_key=row_rating_key,
+            pin_type=row_pin_type,
+        )
+
     def get_all_cached_files(
         self,
         source_filter: str = "all",
@@ -588,224 +806,31 @@ class CacheService:
             if isinstance(ts_info, dict) and "associated_files" in ts_info:
                 cached_paths.extend(ts_info["associated_files"])
 
-        # First pass: classify files into three categories
-        subtitle_paths = []
-        video_paths = []
-        sidecar_paths = []
+        subtitle_paths, video_paths, sidecar_paths = self._classify_cache_paths(cached_paths)
+        video_by_base, videos_by_dir = self._build_video_lookup(video_paths)
+        video_subtitles = self._group_subtitles(subtitle_paths, video_by_base)
+        video_sidecars = self._group_sidecars(sidecar_paths, video_by_base, videos_by_dir)
 
-        for cache_path in cached_paths:
-            filename = os.path.basename(cache_path)
-            if self._is_subtitle_file(filename):
-                subtitle_paths.append(cache_path)
-            elif is_video_file(cache_path):
-                video_paths.append(cache_path)
-            else:
-                sidecar_paths.append(cache_path)
-
-        # Build a map of directory + video base name -> video path for subtitle matching
-        # Key: (directory, video_base_without_extension)
-        video_by_base = {}
-        # Also track videos by directory for sidecar fallback matching
-        videos_by_dir = {}
-        for video_path in video_paths:
-            directory = os.path.dirname(video_path)
-            filename = os.path.basename(video_path)
-            # Get base name without extension
-            base_name = os.path.splitext(filename)[0]
-            video_by_base[(directory, base_name.lower())] = video_path
-            videos_by_dir.setdefault(directory, []).append(video_path)
-
-        # Group subtitles with their parent videos
-        # Map video_path -> list of subtitle paths
-        video_subtitles = {}
-        orphan_subtitles = []
-
-        for sub_path in subtitle_paths:
-            directory = os.path.dirname(sub_path)
-            sub_base = self._get_video_base_name(sub_path).lower()
-
-            # Find matching video in same directory
-            video_path = video_by_base.get((directory, sub_base))
-            if video_path:
-                if video_path not in video_subtitles:
-                    video_subtitles[video_path] = []
-                video_subtitles[video_path].append(sub_path)
-            else:
-                # Orphan subtitle - no matching video found
-                orphan_subtitles.append(sub_path)
-
-        # Group sidecar files with their parent videos
-        # Map video_path -> list of sidecar paths
-        video_sidecars = {}
-
-        for sidecar_path in sidecar_paths:
-            directory = os.path.dirname(sidecar_path)
-            sidecar_base = os.path.splitext(os.path.basename(sidecar_path))[0].lower()
-
-            # Try name-prefixed match first (e.g., Movie.nfo → Movie.mkv)
-            video_path = video_by_base.get((directory, sidecar_base))
-            if not video_path:
-                # Fallback: any video in the same directory (for poster.jpg, fanart.jpg, etc.)
-                dir_videos = videos_by_dir.get(directory, [])
-                if dir_videos:
-                    video_path = dir_videos[0]
-
-            if video_path:
-                video_sidecars.setdefault(video_path, []).append(sidecar_path)
-            # If no video found, sidecar is orphaned — skip it
-
-        # Build the file list with grouped subtitles
-        files = []
-
+        files: List[CachedFile] = []
         for cache_path in video_paths:
-            filename = os.path.basename(cache_path)
+            cached_file = self._build_cached_file(
+                cache_path,
+                timestamps=timestamps,
+                ondeck=ondeck,
+                watchlist=watchlist,
+                settings=settings,
+                pinned_cache_path_map=pinned_cache_path_map,
+                pinned_cache_paths=pinned_cache_paths,
+                video_subtitles=video_subtitles,
+                video_sidecars=video_sidecars,
+                source_filter=source_filter,
+                search=search,
+                now=now,
+            )
+            if cached_file is not None:
+                files.append(cached_file)
 
-            # Apply search filter
-            if search and search.lower() not in filename.lower():
-                continue
-
-            # Get file size
-            try:
-                size = os.path.getsize(cache_path) if os.path.exists(cache_path) else 0
-            except OSError:
-                size = 0
-
-            # Get timestamp info
-            ts_info = timestamps.get(cache_path, {})
-            if isinstance(ts_info, dict):
-                cached_at_str = ts_info.get("cached_at")
-                source = ts_info.get("source", "unknown")
-            else:
-                cached_at_str = ts_info
-                source = "unknown"
-
-            # Parse cached_at
-            try:
-                cached_at = datetime.fromisoformat(cached_at_str) if cached_at_str else now
-            except (ValueError, TypeError):
-                cached_at = now
-
-            cache_age_hours = (now - cached_at).total_seconds() / 3600
-
-            # Check ondeck/watchlist trackers
-            is_ondeck = False
-            is_watchlist = False
-            users = set()
-            episode_info = None
-            tracker_rating_key: Optional[str] = None
-            tracker_pin_type: Optional[str] = None
-            cache_basename = os.path.basename(cache_path)
-
-            for plex_path, info in ondeck.items():
-                if os.path.basename(plex_path) == cache_basename:
-                    is_ondeck = True
-                    source = "ondeck"
-                    if "users" in info:
-                        users.update(info["users"])
-                    episode_info = info.get("episode_info")
-                    if info.get("rating_key"):
-                        tracker_rating_key = info["rating_key"]
-                        tracker_pin_type = "episode" if episode_info else "movie"
-                    break
-
-            for plex_path, info in watchlist.items():
-                if os.path.basename(plex_path) == cache_basename:
-                    is_watchlist = True
-                    if not is_ondeck:
-                        source = "watchlist"
-                    if "users" in info:
-                        users.update(info["users"])
-                    if tracker_rating_key is None and info.get("rating_key"):
-                        tracker_rating_key = info["rating_key"]
-                        # Prefer the watchlist tracker's stored media_type (populated
-                        # at gathering time). Fall back to episode_info, then "movie"
-                        # so legacy entries written before media_type existed still
-                        # behave the way they always did.
-                        wl_media_type = info.get("media_type")
-                        if wl_media_type in ("episode", "movie"):
-                            tracker_pin_type = wl_media_type
-                        else:
-                            tracker_pin_type = "episode" if episode_info else "movie"
-                    break
-
-            # Pinned files always score 100 (mirrors core priority manager)
-            is_pinned = cache_path in pinned_cache_paths
-
-            # Apply source filter
-            if source_filter == "pinned" and not is_pinned:
-                continue
-            if source_filter == "ondeck" and not is_ondeck:
-                continue
-            if source_filter == "watchlist" and not is_watchlist:
-                continue
-            if source_filter == "other" and (is_ondeck or is_watchlist or is_pinned):
-                continue
-
-            if is_pinned:
-                priority = 100
-            else:
-                priority = self.calculate_priority(
-                    cache_path, timestamps, ondeck, watchlist, settings
-                )
-
-            # For pinned rows, prefer the pinned-map's rating_key/pin_type —
-            # it's the authoritative source for the unpin button. For
-            # unpinned rows, fall back to whatever the ondeck/watchlist
-            # trackers told us so the row can offer a pin-in-place button.
-            if is_pinned:
-                pinned_meta = pinned_cache_path_map.get(cache_path)
-                if pinned_meta:
-                    row_rating_key, row_pin_type = pinned_meta
-                else:
-                    row_rating_key, row_pin_type = tracker_rating_key, tracker_pin_type
-            else:
-                row_rating_key, row_pin_type = tracker_rating_key, tracker_pin_type
-
-            # Get associated subtitles and sidecars
-            subs = video_subtitles.get(cache_path, [])
-            sidecars = video_sidecars.get(cache_path, [])
-
-            # Build associated files list for template rendering
-            assoc_list = None
-            all_assoc = subs + sidecars
-            if all_assoc:
-                assoc_list = []
-                for ap in all_assoc:
-                    try:
-                        asize = os.path.getsize(ap) if os.path.exists(ap) else 0
-                    except OSError:
-                        asize = 0
-                    assoc_list.append({
-                        "filename": os.path.basename(ap),
-                        "size": format_bytes(asize)
-                    })
-
-            files.append(CachedFile(
-                path=cache_path,
-                filename=filename,
-                size=size,
-                size_display=format_bytes(size),
-                cached_at=cached_at,
-                cache_age_hours=cache_age_hours,
-                source=source,
-                priority_score=priority,
-                users=list(users),
-                is_ondeck=is_ondeck,
-                is_watchlist=is_watchlist,
-                episode_info=episode_info,
-                subtitle_count=len(subs),
-                subtitle_paths=subs if subs else None,
-                sidecar_count=len(sidecars),
-                sidecar_paths=sidecars if sidecars else None,
-                associated_files=assoc_list,
-                is_pinned=is_pinned,
-                rating_key=row_rating_key,
-                pin_type=row_pin_type,
-            ))
-
-        # Sort by specified column
         reverse = (sort_dir == "desc")
-
         sort_keys = {
             "filename": lambda f: f.filename.lower(),
             "size": lambda f: f.size,
@@ -814,7 +839,6 @@ class CacheService:
             "users": lambda f: len(f.users),
             "source": lambda f: (f.is_ondeck, f.is_watchlist),  # OnDeck first, then Watchlist
         }
-
         sort_key = sort_keys.get(sort_by, sort_keys["priority"])
         files.sort(key=sort_key, reverse=reverse)
 

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -15,6 +15,46 @@ from core.system_utils import get_disk_usage, detect_zfs, get_array_direct_path,
 from core.file_operations import get_media_identity, find_matching_plexcached, save_json_atomically, SUBTITLE_EXTENSIONS, is_video_file
 
 
+def cached_files_to_dicts(files: List["CachedFile"]) -> List[Dict[str, Any]]:
+    """Convert CachedFile dataclasses to plain dicts for template rendering."""
+    return [
+        {
+            "path": f.path,
+            "filename": f.filename,
+            "size": f.size,
+            "size_display": f.size_display,
+            "cache_age_hours": f.cache_age_hours,
+            "source": f.source,
+            "priority_score": f.priority_score,
+            "users": f.users,
+            "is_ondeck": f.is_ondeck,
+            "is_watchlist": f.is_watchlist,
+            "is_pinned": f.is_pinned,
+            "subtitle_count": f.subtitle_count,
+            "sidecar_count": f.sidecar_count,
+            "associated_files": f.associated_files,
+        }
+        for f in files
+    ]
+
+
+def calculate_file_totals(files_data: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate counts and total size for a filtered list of cached-file dicts."""
+    total_size = sum(f["size"] for f in files_data)
+    return {
+        "total_files": len(files_data),
+        "ondeck_count": sum(1 for f in files_data if f["is_ondeck"]),
+        "watchlist_count": sum(1 for f in files_data if f["is_watchlist"]),
+        "pinned_count": sum(1 for f in files_data if f["is_pinned"]),
+        "other_count": sum(
+            1 for f in files_data
+            if not f["is_ondeck"] and not f["is_watchlist"] and not f["is_pinned"]
+        ),
+        "total_size": total_size,
+        "total_size_display": format_bytes(total_size),
+    }
+
+
 @dataclass
 class CachedFile:
     """Represents a cached file with all its metadata"""

--- a/web/services/operation_runner.py
+++ b/web/services/operation_runner.py
@@ -14,7 +14,7 @@ from typing import Optional, List, Dict, Callable
 from dataclasses import dataclass, field
 
 from web.config import PROJECT_ROOT, DATA_DIR, LOGS_DIR, SETTINGS_FILE as CONFIG_SETTINGS_FILE, get_time_format
-from core.system_utils import format_bytes, format_duration
+from core.system_utils import format_bytes, format_duration, get_log_time_datefmt
 from core.file_operations import save_json_atomically
 
 # Shared activity module — canonical implementations live in core/activity.py.
@@ -92,8 +92,7 @@ class WebLogHandler(logging.Handler):
     def __init__(self, callback: Callable[[str], None]):
         super().__init__()
         self.callback = callback
-        fmt = get_time_format()
-        datefmt = '%-I:%M:%S %p' if fmt == '12h' else '%H:%M:%S'
+        datefmt = get_log_time_datefmt(get_time_format())
         self.setFormatter(logging.Formatter(
             '%(asctime)s - %(levelname)s - %(message)s',
             datefmt=datefmt

--- a/web/services/operation_runner.py
+++ b/web/services/operation_runner.py
@@ -1038,7 +1038,7 @@ class OperationRunner:
             if hasattr(app, 'sibling_map') and app.sibling_map:
                 try:
                     self._merge_sibling_activities(app.sibling_map)
-                except Exception as e:
+                except (OSError, AttributeError, KeyError, TypeError) as e:
                     logging.debug(f"Failed to merge sibling activities: {e}")
 
             # Check if we were stopped early
@@ -1064,7 +1064,7 @@ class OperationRunner:
             if app and hasattr(app, 'instance_lock') and app.instance_lock:
                 try:
                     app.instance_lock.release()
-                except Exception:
+                except (OSError, RuntimeError):
                     pass  # Ignore errors during cleanup
 
             # Remove our custom handler
@@ -1093,14 +1093,14 @@ class OperationRunner:
             try:
                 from web.services.web_cache import get_web_cache_service, CACHE_KEY_DASHBOARD_STATS
                 get_web_cache_service().invalidate(CACHE_KEY_DASHBOARD_STATS)
-            except Exception:
+            except (ImportError, AttributeError):
                 pass
 
             # After operation completes, check if maintenance actions are queued
             try:
                 from web.services.maintenance_runner import get_maintenance_runner
                 get_maintenance_runner()._try_dequeue()
-            except Exception:
+            except (ImportError, AttributeError):
                 pass
 
     def _merge_sibling_activities(self, sibling_map: Dict[str, list]) -> None:
@@ -1414,7 +1414,7 @@ class OperationRunner:
                     if lock and af:
                         with lock:
                             active_files = [(name, size) for name, size in af.values()]
-            except Exception:
+            except (AttributeError, KeyError, TypeError):
                 pass
             status["active_files"] = active_files
 

--- a/web/services/scheduler_service.py
+++ b/web/services/scheduler_service.py
@@ -12,6 +12,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
+from core.system_utils import format_relative_time, format_time_of_day
 from web.config import PROJECT_ROOT, DATA_DIR, SETTINGS_FILE, get_time_format
 
 logger = logging.getLogger(__name__)
@@ -296,49 +297,11 @@ class SchedulerService:
             "next_run": self._next_run.isoformat() if self._next_run else None,
         }
 
-    def _format_time_display(self, time_str: str) -> str:
-        """Convert HH:MM to display format based on user's time_format setting."""
-        try:
-            hour, minute = map(int, time_str.split(":"))
-            if get_time_format() == "12h":
-                period = "AM" if hour < 12 else "PM"
-                hour_12 = hour % 12
-                if hour_12 == 0:
-                    hour_12 = 12
-                if minute == 0:
-                    return f"{hour_12} {period}"
-                return f"{hour_12}:{minute:02d} {period}"
-            else:
-                return f"{hour}:{minute:02d}"
-        except (ValueError, AttributeError):
-            return time_str
-
     def _datetime_display_fmt(self) -> str:
         """Return strftime format string for date+time based on user's time_format setting."""
         if get_time_format() == "12h":
             return "%Y-%m-%d %-I:%M %p"
         return "%Y-%m-%d %H:%M"
-
-    def _format_relative_time(self, target: datetime) -> str:
-        """Format a future datetime as relative time (e.g., 'in 12m', 'in 2h 30m')"""
-        now = datetime.now()
-        if target <= now:
-            return "now"
-
-        diff = target - now
-        total_seconds = int(diff.total_seconds())
-        total_minutes = total_seconds // 60
-
-        if total_minutes < 1:
-            return "<1m"
-        elif total_minutes < 60:
-            return f"{total_minutes}m"
-        else:
-            hours = total_minutes // 60
-            minutes = total_minutes % 60
-            if minutes == 0:
-                return f"{hours}h"
-            return f"{hours}h {minutes}m"
 
     def get_status(self) -> Dict[str, Any]:
         """Get scheduler status"""
@@ -349,7 +312,7 @@ class SchedulerService:
         # Format schedule description
         if config.schedule_type == "interval":
             start_time = config.interval_start_time or "00:00"
-            start_time_display = self._format_time_display(start_time)
+            start_time_display = format_time_of_day(start_time, get_time_format())
             schedule_desc = f"Every {config.interval_hours}h from {start_time_display}"
         else:
             schedule_desc = f"Cron: {config.cron_expression}"
@@ -361,7 +324,7 @@ class SchedulerService:
             next_time = job.next_run_time
             if next_time.tzinfo is not None:
                 next_time = next_time.replace(tzinfo=None)
-            next_run_relative = self._format_relative_time(next_time)
+            next_run_relative = format_relative_time(next_time)
 
         # Read fresh last run time from file
         last_run_dt = None

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -903,7 +903,7 @@ class SettingsService:
                 timeout=5
             )
             return response.status_code == 200
-        except Exception:
+        except (requests.RequestException, OSError):
             return False
 
     def _is_plex_cache_valid(self) -> bool:
@@ -951,7 +951,7 @@ class SettingsService:
                 locations = []
                 try:
                     locations = list(section.locations) if hasattr(section, 'locations') else []
-                except Exception:
+                except (AttributeError, TypeError):
                     pass
 
                 libraries.append({
@@ -1009,7 +1009,7 @@ class SettingsService:
                         "is_admin": True,
                         "is_home": True
                     })
-                except Exception:
+                except AttributeError:
                     pass
 
             # Add prefetched users (all users from account.users() have server access)
@@ -1444,7 +1444,7 @@ class SettingsService:
             pinned_data = self._read_pinned_tracker_file()
             if pinned_data:
                 settings["pinned_media"] = pinned_data
-        except Exception as e:
+        except (OSError, ValueError, json.JSONDecodeError) as e:
             # Non-fatal: settings export still works, pins just won't round-trip
             import logging
             logging.warning(f"export_settings: could not read pinned tracker: {e}")
@@ -1648,7 +1648,7 @@ class SettingsService:
                 if pinned_payload is not None:
                     try:
                         self._restore_pinned_tracker_file(pinned_payload, merge=merge)
-                    except Exception as e:
+                    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as e:
                         import logging
                         logging.warning(f"import_settings: pinned tracker restore failed: {e}")
                 # Invalidate caches since settings changed
@@ -1707,7 +1707,7 @@ class SettingsService:
         try:
             import web.services.pinned_service as ps_mod
             ps_mod._pinned_service = None
-        except Exception:
+        except (ImportError, AttributeError):
             pass
 
 

--- a/web/services/web_cache.py
+++ b/web/services/web_cache.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 logger = logging.getLogger(__name__)
 
 from web.config import PROJECT_ROOT, DATA_DIR
-from core.system_utils import format_bytes, format_duration
+from core.system_utils import format_bytes, format_duration, format_cache_age
 
 
 @dataclass
@@ -258,6 +258,107 @@ CACHE_KEY_DASHBOARD_STATS = "dashboard_stats"
 CACHE_KEY_MAINTENANCE_AUDIT = "maintenance_audit"
 CACHE_KEY_MAINTENANCE_HEALTH = "maintenance_health"
 
+
+def _compute_dashboard_stats() -> dict:
+    """Build a fresh dashboard-stats dict from the service layer."""
+    # Imports deferred to avoid circular dependencies at module import time.
+    from core.activity import load_last_run_summary
+    from web.services import (
+        get_cache_service,
+        get_settings_service,
+        get_operation_runner,
+        get_scheduler_service,
+        get_maintenance_service,
+    )
+
+    cache_service = get_cache_service()
+    settings_service = get_settings_service()
+    operation_runner = get_operation_runner()
+    scheduler_service = get_scheduler_service()
+    maintenance_service = get_maintenance_service()
+
+    cache_stats = cache_service.get_cache_stats()
+    plex_connected = settings_service.check_plex_connection()
+    last_run = settings_service.get_last_run_time() or "Never"
+    schedule_status = scheduler_service.get_status()
+    health = maintenance_service.get_health_summary()
+
+    stats = {
+        "cache_files": cache_stats["cache_files"],
+        "cache_size": cache_stats["cache_size"],
+        "cache_limit": cache_stats["cache_limit"],
+        "usage_percent": cache_stats["usage_percent"],
+        "cached_files_size": cache_stats.get("cached_files_size"),
+        "associated_files_count": cache_stats.get("associated_files_count", 0),
+        "ondeck_count": cache_stats["ondeck_count"],
+        "ondeck_tracked_count": cache_stats.get("ondeck_tracked_count", 0),
+        "watchlist_count": cache_stats["watchlist_count"],
+        "watchlist_tracked_count": cache_stats.get("watchlist_tracked_count", 0),
+        "eviction_over_threshold": cache_stats.get("eviction_over_threshold", False),
+        "eviction_over_by_display": cache_stats.get("eviction_over_by_display"),
+        "cache_limit_exceeded": cache_stats.get("cache_limit_exceeded", False),
+        "cache_limit_approaching": cache_stats.get("cache_limit_approaching", False),
+        "configured_limit_display": cache_stats.get("configured_limit_display"),
+        "configured_limit_percent": cache_stats.get("configured_limit_percent", 0),
+        "eviction_threshold_display": cache_stats.get("eviction_threshold_display"),
+        "min_free_space_warning": cache_stats.get("min_free_space_warning", False),
+        "last_run": last_run,
+        "is_running": operation_runner.is_running,
+        "plex_connected": plex_connected,
+        "schedule_enabled": schedule_status.get("enabled", False),
+        "next_run": schedule_status.get("next_run_display", "Not scheduled"),
+        "next_run_relative": schedule_status.get("next_run_relative"),
+        "health_status": health["status"],
+        "health_issues": health["orphaned_count"],
+        "health_warnings": health["stale_exclude_count"] + health["stale_timestamp_count"] + health["duplicate_orphan_count"],
+        "health_orphaned_count": health["orphaned_count"],
+        "health_stale_exclude_count": health["stale_exclude_count"],
+        "health_stale_timestamp_count": health["stale_timestamp_count"],
+        "health_duplicate_count": health["duplicate_count"],
+        "health_duplicate_orphan_count": health["duplicate_orphan_count"],
+        "health_duplicate_orphan_bytes": health["duplicate_orphan_bytes_display"],
+        "last_run_summary": None,
+    }
+
+    summary = load_last_run_summary()
+    if summary:
+        stats["last_run_summary"] = {
+            "status": summary.get("status", "unknown"),
+            "bytes_cached_display": format_bytes(summary["bytes_cached"]) if summary.get("bytes_cached") else "",
+            "bytes_restored_display": format_bytes(summary["bytes_restored"]) if summary.get("bytes_restored") else "",
+            "duration_display": format_duration(summary.get("duration_seconds", 0)),
+            "error_count": summary.get("error_count", 0),
+            "dry_run": summary.get("dry_run", False),
+        }
+
+    return stats
+
+
+def get_dashboard_stats(use_cache: bool = True) -> tuple:
+    """Return (stats_dict, cache_age_display). Reads from cache when use_cache is True.
+
+    Cached entries missing recent fields are invalidated and recomputed.
+    """
+    web_cache = get_web_cache_service()
+
+    if use_cache:
+        cached_stats = web_cache.get(CACHE_KEY_DASHBOARD_STATS)
+        if cached_stats:
+            _, updated_at = web_cache.get_with_age(CACHE_KEY_DASHBOARD_STATS)
+            cache_age = format_cache_age(updated_at)
+            # Stale cache from older fieldset — recompute fresh
+            if "health_duplicate_count" not in cached_stats:
+                web_cache.invalidate(CACHE_KEY_DASHBOARD_STATS)
+            else:
+                # Override non-cacheable live flag
+                from web.services import get_operation_runner
+                cached_stats["is_running"] = get_operation_runner().is_running
+                return cached_stats, cache_age
+
+    stats = _compute_dashboard_stats()
+    web_cache.set(CACHE_KEY_DASHBOARD_STATS, stats)
+    return stats, "just now"
+
 # Singleton instance
 _web_cache_service: Optional[WebCacheService] = None
 _web_cache_service_lock = threading.Lock()
@@ -282,65 +383,8 @@ def init_web_cache():
 
     # Import here to avoid circular imports
     from web.services.maintenance_service import get_maintenance_service
-    from web.services.cache_service import get_cache_service
-    from web.services import get_settings_service, get_operation_runner, get_scheduler_service
 
-    # Register refresh callbacks
     maintenance_svc = get_maintenance_service()
-
-    def refresh_dashboard_stats():
-        """Refresh dashboard stats - mirrors _get_dashboard_stats in dashboard.py"""
-        from core.activity import load_last_run_summary
-        from web.services.operation_runner import OperationRunner as _OR
-
-        cache_svc = get_cache_service()
-        settings_svc = get_settings_service()
-        operation_runner = get_operation_runner()
-        scheduler_svc = get_scheduler_service()
-
-        cache_stats = cache_svc.get_cache_stats()
-        plex_connected = settings_svc.check_plex_connection()
-        last_run = settings_svc.get_last_run_time() or "Never"
-        op_status = operation_runner.get_status_dict()
-        schedule_status = scheduler_svc.get_status()
-        health = maintenance_svc.get_health_summary()
-
-        stats = {
-            "cache_files": cache_stats["cache_files"],
-            "cache_size": cache_stats["cache_size"],
-            "cache_limit": cache_stats["cache_limit"],
-            "usage_percent": cache_stats["usage_percent"],
-            "ondeck_count": cache_stats["ondeck_count"],
-            "ondeck_tracked_count": cache_stats.get("ondeck_tracked_count", 0),
-            "watchlist_count": cache_stats["watchlist_count"],
-            "watchlist_tracked_count": cache_stats.get("watchlist_tracked_count", 0),
-            "last_run": last_run,
-            "is_running": operation_runner.is_running,
-            "plex_connected": plex_connected,
-            "schedule_enabled": schedule_status.get("enabled", False),
-            "next_run": schedule_status.get("next_run_display", "Not scheduled"),
-            "next_run_relative": schedule_status.get("next_run_relative"),
-            "health_status": health["status"],
-            "health_issues": health["orphaned_count"],
-            "health_warnings": health["stale_exclude_count"] + health["stale_timestamp_count"],
-            "health_orphaned_count": health["orphaned_count"],
-            "health_stale_exclude_count": health["stale_exclude_count"],
-            "health_stale_timestamp_count": health["stale_timestamp_count"],
-            "last_run_summary": None,
-        }
-
-        summary = load_last_run_summary()
-        if summary:
-            stats["last_run_summary"] = {
-                "status": summary.get("status", "unknown"),
-                "bytes_cached_display": format_bytes(summary["bytes_cached"]) if summary.get("bytes_cached") else "",
-                "bytes_restored_display": format_bytes(summary["bytes_restored"]) if summary.get("bytes_restored") else "",
-                "duration_display": format_duration(summary.get("duration_seconds", 0)),
-                "error_count": summary.get("error_count", 0),
-                "dry_run": summary.get("dry_run", False),
-            }
-
-        return stats
 
     def refresh_maintenance_audit():
         """Refresh maintenance audit - convert to dict for serialization"""
@@ -351,7 +395,7 @@ def init_web_cache():
         """Refresh maintenance health summary"""
         return maintenance_svc.get_health_summary()
 
-    service.register_refresh_callback(CACHE_KEY_DASHBOARD_STATS, refresh_dashboard_stats)
+    service.register_refresh_callback(CACHE_KEY_DASHBOARD_STATS, _compute_dashboard_stats)
     service.register_refresh_callback(CACHE_KEY_MAINTENANCE_AUDIT, refresh_maintenance_audit)
     service.register_refresh_callback(CACHE_KEY_MAINTENANCE_HEALTH, refresh_maintenance_health)
 

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1,5 +1,14 @@
 /* PlexCache-D Web UI Custom Styles */
 
+/* Icon size utility classes — use on lucide <i> elements to replace
+   inline `style="width:Npx; height:Npx"`. Pair with inline color/margin
+   styles or other utility classes as needed. */
+.icon-xs { width: 12px; height: 12px; }
+.icon-sm { width: 14px; height: 14px; }
+.icon-md { width: 16px; height: 16px; }
+.icon-lg { width: 20px; height: 20px; }
+.icon-xl { width: 32px; height: 32px; }
+
 /* Log viewer - single scroll context for both axes */
 .log-viewer {
     height: 500px;
@@ -255,14 +264,14 @@ footer {
 .associated-files-popup {
     display: none;
     position: fixed;
-    background: var(--plex-surface-elevated, #1f1f1f);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: var(--plex-radius-sm, 8px);
+    background: var(--plex-bg-card);
+    border: 1px solid var(--plex-border-light);
+    border-radius: var(--plex-radius-sm);
     padding: 0.5rem 0.75rem;
     min-width: 280px;
     width: max-content;
     z-index: 1000;
-    box-shadow: var(--plex-shadow-elevated, 0 4px 12px rgba(0, 0, 0, 0.4));
+    box-shadow: var(--plex-shadow-elevated);
     white-space: nowrap;
     pointer-events: none;
 }
@@ -272,7 +281,7 @@ footer {
     gap: 1rem;
     padding: 0.125rem 0;
     font-size: 0.78rem;
-    color: var(--plex-text-muted, #8e8e93);
+    color: var(--plex-text-muted);
 }
 .associated-files-popup .af-popup-name {
     flex: 1;

--- a/web/static/css/plex-theme.css
+++ b/web/static/css/plex-theme.css
@@ -56,6 +56,7 @@ body {
     /* Shadows & Radii */
     --plex-shadow-card: 0 2px 12px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.04);
     --plex-shadow-elevated: 0 8px 32px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.06);
+    --plex-radius-xs: 4px;
     --plex-radius-sm: 8px;
     --plex-radius-md: 12px;
     --plex-radius-lg: 16px;

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -73,3 +73,20 @@ document.addEventListener('showAlert', function(event) {
         }, 5000);
     }
 });
+
+// Path-mapping view/edit toggle. Shared by settings/libraries, settings/paths,
+// and the path_mapping_card partial (which is HTMX-swapped — relying on the
+// globally-loaded function avoids redefining it per card render).
+function toggleEditMode(index) {
+    var view = document.getElementById('mapping-view-' + index);
+    var edit = document.getElementById('mapping-edit-' + index);
+    if (!view || !edit) return;
+    if (view.style.display === 'none') {
+        view.style.display = 'block';
+        edit.style.display = 'none';
+    } else {
+        view.style.display = 'none';
+        edit.style.display = 'block';
+    }
+    lucide.createIcons();
+}

--- a/web/templates/cache/list.html
+++ b/web/templates/cache/list.html
@@ -176,7 +176,7 @@
 
 #evict-modal .evict-file-info {
     background: var(--plex-bg);
-    border-radius: 6px;
+    border-radius: var(--plex-radius-sm);
     padding: 1rem;
     margin-bottom: 1rem;
 }
@@ -198,7 +198,7 @@
     gap: 0.75rem;
     padding: 0.75rem;
     background: rgba(var(--warning-rgb), 0.1);
-    border-radius: 6px;
+    border-radius: var(--plex-radius-sm);
     font-size: 0.875rem;
 }
 

--- a/web/templates/cache/partials/storage_stats.html
+++ b/web/templates/cache/partials/storage_stats.html
@@ -94,7 +94,7 @@
             <!-- Visual Bar with Markers - Stacked Bar Design -->
             <div class="drive-usage-bar-container" style="position: relative; margin-bottom: 0.5rem;">
                 <!-- The bar background represents total drive capacity -->
-                <div class="drive-usage-bar" style="height: 24px; background: var(--plex-bg-card); border-radius: 4px; position: relative; overflow: visible; border: 1px solid var(--plex-border);">
+                <div class="drive-usage-bar" style="height: 24px; background: var(--plex-bg-card); border-radius: var(--plex-radius-xs); position: relative; overflow: visible; border: 1px solid var(--plex-border);">
                     <!-- Stacked bar: Other files (gray) + PlexCache (context-aware color) -->
                     <div style="display: flex; height: 100%; border-radius: 3px; overflow: hidden;">
                         <!-- Other files segment (gray) -->
@@ -208,7 +208,7 @@
 
             <!-- Simple progress bar: tracked_size / quota -->
             <div style="position: relative; margin-bottom: 0.5rem;">
-                <div style="height: 24px; background: var(--plex-bg-card); border-radius: 4px; overflow: hidden; border: 1px solid var(--plex-border);">
+                <div style="height: 24px; background: var(--plex-bg-card); border-radius: var(--plex-radius-xs); overflow: hidden; border: 1px solid var(--plex-border);">
                     <div style="width: {{ [data.storage.plexcache_quota_used_percent, 100] | min }}%; height: 100%; transition: width 0.3s ease;
                         {% if data.storage.plexcache_quota_used_percent >= 100 %}
                         background: var(--plex-error);

--- a/web/templates/components/global_operation_banner.html
+++ b/web/templates/components/global_operation_banner.html
@@ -18,7 +18,7 @@ function showBannerWarning(message) {
         warning.style.opacity = '1';
         warning.style.paddingTop = '0.6rem';
         warning.style.marginTop = '0.6rem';
-        warning.style.borderColor = 'rgba(230, 126, 34, 0.3)';
+        warning.style.borderColor = 'color-mix(in srgb, var(--plex-warning) 30%, transparent)';
     }); });
     setTimeout(function() {
         if (!warning) return;
@@ -542,8 +542,8 @@ document.addEventListener('htmx:afterSwap', function(evt) {
         {% endif %}
         <!-- Warning row -->
         <div id="di-warning" class="di-warning">
-            <i data-lucide="alert-triangle" style="width: 14px; height: 14px; color: #e67e22; flex-shrink: 0;"></i>
-            <span id="di-warning-text" style="font-size: 0.8rem; color: #e67e22; white-space: nowrap;"></span>
+            <i data-lucide="alert-triangle" style="width: 14px; height: 14px; color: var(--plex-warning); flex-shrink: 0;"></i>
+            <span id="di-warning-text" style="font-size: 0.8rem; color: var(--plex-warning); white-space: nowrap;"></span>
         </div>
     </div>
 
@@ -908,8 +908,8 @@ function dismissMaintCompletionBanner() {
         </div>
         <!-- Warning row -->
         <div id="di-warning" class="di-warning">
-            <i data-lucide="alert-triangle" style="width: 14px; height: 14px; color: #e67e22; flex-shrink: 0;"></i>
-            <span id="di-warning-text" style="font-size: 0.8rem; color: #e67e22; white-space: nowrap;"></span>
+            <i data-lucide="alert-triangle" style="width: 14px; height: 14px; color: var(--plex-warning); flex-shrink: 0;"></i>
+            <span id="di-warning-text" style="font-size: 0.8rem; color: var(--plex-warning); white-space: nowrap;"></span>
         </div>
     </div>
 
@@ -1087,7 +1087,7 @@ function dismissMaintCompletionBanner() {
             errorMessages.forEach(function(msg) {
                 detailHtml += '<div class="di-file-row">' +
                     '<span class="di-action-tag di-action-tag--error">ERROR</span>' +
-                    '<span class="di-file-row__name" style="color: var(--plex-error, #e5a00d);">' + msg + '</span>' +
+                    '<span class="di-file-row__name" style="color: var(--plex-error);">' + msg + '</span>' +
                     '</div>';
             });
             if (errorCount > errorMessages.length) {
@@ -1258,7 +1258,7 @@ function dismissCompletionBanner() {
             <span class="di-countdown__timer" data-countdown-start="{{ maint_status.queue_countdown_started }}" data-countdown-duration="{{ maint_status.queue_countdown_seconds }}"></span>
         </div>
         <div class="di-countdown__actions">
-            <button class="di-btn di-btn--primary" style="background: #5AC8FA; color: #000;"
+            <button class="di-btn di-btn--primary" style="background: var(--plex-info); color: #000;"
                     onclick="event.stopPropagation(); fetch('/maintenance/queue/start-now',{method:'POST'}).then(()=>htmx.ajax('GET','/api/operation-banner',{target:'#global-operation-banner',swap:'innerHTML'}));">
                 <i data-lucide="play" style="width: 14px; height: 14px;"></i>
                 Start Now
@@ -1326,9 +1326,9 @@ function dismissCompletionBanner() {
      onmouseenter="diHoverIn()" onmouseleave="diHoverOut()" onclick="diPillClick()">
     <div class="di-pill__compact">
         <div class="di-pill__left">
-            <div class="di-icon" style="background: rgba(255,149,0,0.15); color: #FF9500;"><i data-lucide="pause" style="width: 14px; height: 14px;"></i></div>
+            <div class="di-icon" style="background: color-mix(in srgb, var(--plex-warning) 15%, transparent); color: var(--plex-warning);"><i data-lucide="pause" style="width: 14px; height: 14px;"></i></div>
             <span class="di-label" style="color: rgba(255,255,255,0.6);">Queue paused</span>
-            <span class="di-queue-badge" style="background: rgba(255,149,0,0.2); color: #FF9500;">{{ maint_status.queue_count }}</span>
+            <span class="di-queue-badge" style="background: color-mix(in srgb, var(--plex-warning) 20%, transparent); color: var(--plex-warning);">{{ maint_status.queue_count }}</span>
         </div>
         <div class="di-pill__right">
             <button class="di-btn di-btn--secondary" style="height: 26px; font-size: 0.72rem; padding: 0 0.6rem;"
@@ -1340,12 +1340,12 @@ function dismissCompletionBanner() {
     <div class="di-pill__expanded">
         <div class="di-expanded__header">
             <div class="di-expanded__header-left">
-                <div class="di-icon" style="background: rgba(255,149,0,0.15); color: #FF9500;"><i data-lucide="pause" style="width: 14px; height: 14px;"></i></div>
+                <div class="di-icon" style="background: color-mix(in srgb, var(--plex-warning) 15%, transparent); color: var(--plex-warning);"><i data-lucide="pause" style="width: 14px; height: 14px;"></i></div>
                 <span class="di-label">Queue Paused</span>
                 <span style="font-size: 0.78rem; color: rgba(255,255,255,0.4);">({{ maint_status.queue_count }} action{{ 's' if maint_status.queue_count != 1 }})</span>
             </div>
             <div class="di-expanded__header-right">
-                <button class="di-btn di-btn--primary" style="background: #FF9500; color: #000; height: 28px;"
+                <button class="di-btn di-btn--primary" style="background: var(--plex-warning); color: #000; height: 28px;"
                         onclick="event.stopPropagation(); fetch('/maintenance/queue/resume',{method:'POST'}).then(()=>htmx.ajax('GET','/api/operation-banner',{target:'#global-operation-banner',swap:'innerHTML'}));">
                     <i data-lucide="play" style="width: 14px; height: 14px;"></i>
                     Resume
@@ -1390,11 +1390,11 @@ function dismissCompletionBanner() {
     <!-- Compact view -->
     <div class="di-pill__compact">
         <div class="di-pill__left">
-            <i data-lucide="clock" style="width: 13px; height: 13px; color: #e5a00d; opacity: 0.6;"></i>
+            <i data-lucide="clock" style="width: 13px; height: 13px; color: var(--plex-orange); opacity: 0.6;"></i>
             <span style="font-size: 0.78rem; color: rgba(255,255,255,0.5);">Next run</span>
         </div>
         <div class="di-pill__right">
-            <span class="di-metric" style="color: rgba(229,160,13,0.7); font-weight: 400; font-size: 0.8rem;">{{ scheduler_status.next_run_relative }}</span>
+            <span class="di-metric" style="color: color-mix(in srgb, var(--plex-orange) 70%, transparent); font-weight: 400; font-size: 0.8rem;">{{ scheduler_status.next_run_relative }}</span>
         </div>
     </div>
 
@@ -1402,7 +1402,7 @@ function dismissCompletionBanner() {
     <div class="di-pill__expanded">
         <div class="di-expanded__header">
             <div class="di-expanded__header-left">
-                <div class="di-icon" style="background: rgba(229,160,13,0.15); color: #e5a00d;"><i data-lucide="clock" style="width: 14px; height: 14px;"></i></div>
+                <div class="di-icon" style="background: color-mix(in srgb, var(--plex-orange) 15%, transparent); color: var(--plex-orange);"><i data-lucide="clock" style="width: 14px; height: 14px;"></i></div>
                 <span class="di-label">Next run in {{ scheduler_status.next_run_relative }}</span>
             </div>
         </div>
@@ -1458,7 +1458,7 @@ function diTriggerRun(dryRun) {
     <!-- Compact view -->
     <div class="di-pill__compact">
         <div class="di-pill__left">
-            <i data-lucide="play" style="width: 13px; height: 13px; color: #e5a00d; opacity: 0.6;"></i>
+            <i data-lucide="play" style="width: 13px; height: 13px; color: var(--plex-orange); opacity: 0.6;"></i>
             <span style="font-size: 0.78rem; color: rgba(255,255,255,0.5);">PlexCache</span>
         </div>
     </div>
@@ -1467,7 +1467,7 @@ function diTriggerRun(dryRun) {
     <div class="di-pill__expanded">
         <div class="di-expanded__header">
             <div class="di-expanded__header-left">
-                <div class="di-icon" style="background: rgba(229,160,13,0.15); color: #e5a00d;"><i data-lucide="play" style="width: 14px; height: 14px;"></i></div>
+                <div class="di-icon" style="background: color-mix(in srgb, var(--plex-orange) 15%, transparent); color: var(--plex-orange);"><i data-lucide="play" style="width: 14px; height: 14px;"></i></div>
                 <span class="di-label">PlexCache Ready</span>
             </div>
         </div>

--- a/web/templates/maintenance/index.html
+++ b/web/templates/maintenance/index.html
@@ -502,7 +502,7 @@ function repairAllRepairable(isDryRun = false) {
             </h4>
             <p style="margin: 0 0 1rem 0;">Sonarr/Radarr renamed these backup files and dropped the <code>.mkv</code> extension.</p>
         </div>
-        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: 6px; margin-bottom: 1rem;">
+        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: var(--plex-radius-sm); margin-bottom: 1rem;">
             <strong>What will happen:</strong>
             <ol style="margin: 0.5rem 0 0 1.5rem; padding: 0;">
                 <li>Detect the media extension from the sibling file</li>
@@ -690,7 +690,7 @@ function startDuplicateScan() {
             </h4>
             <p style="margin: 0 0 1rem 0;">This will scan all movie and TV show libraries for items with multiple media files.</p>
         </div>
-        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: 6px;">
+        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: var(--plex-radius-sm);">
             <strong>What will happen:</strong>
             <ol style="margin: 0.5rem 0 0 1.5rem; padding: 0;">
                 <li>Connect to Plex and enumerate all libraries</li>
@@ -750,7 +750,7 @@ function deleteAllOrphanDuplicates(isDryRun) {
             </h4>
             <p style="margin: 0 0 1rem 0;">This will delete all files identified as orphans by Sonarr/Radarr from the last scan.</p>
         </div>
-        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: 6px;">
+        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: var(--plex-radius-sm);">
             <strong style="color: var(--warning);">Safety:</strong>
             <ul style="margin: 0.5rem 0 0 1.5rem; padding: 0;">
                 <li>Only files NOT tracked by Sonarr/Radarr will be deleted</li>

--- a/web/templates/maintenance/partials/audit_results.html
+++ b/web/templates/maintenance/partials/audit_results.html
@@ -186,7 +186,7 @@
                             <input type="checkbox" class="untracked-checkbox untracked-child-cb" value="{{ child.cache_path }}" onchange="toggleUntrackedFile(this)" data-has-backup="{{ child.has_plexcached_backup|lower }}" data-has-dup="{{ child.has_array_duplicate|lower }}">
                         </td>
                         <td title="{{ child.cache_path }}" style="max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding-left: 2rem;">
-                            <span style="color: rgba(255,255,255,0.35); margin-right: 4px;">&#8627;</span>{{ child.filename }}
+                            <span class="text-muted" style="margin-right: 4px;">&#8627;</span>{{ child.filename }}
                         </td>
                         <td class="text-muted">{{ child.size_display }}</td>
                         <td class="text-muted">
@@ -644,7 +644,7 @@
     align-items: flex-start;
     padding: 1rem;
     background: var(--plex-bg-card);
-    border-radius: 6px;
+    border-radius: var(--plex-radius-sm);
     border: 1px solid var(--plex-border);
 }
 
@@ -659,7 +659,7 @@
 
 .stale-entries-list {
     background: var(--plex-bg);
-    border-radius: 4px;
+    border-radius: var(--plex-radius-xs);
     border: 1px solid var(--plex-border);
 }
 
@@ -854,7 +854,7 @@ function keepOnCacheSelected() {
             <p style="margin: 0 0 1rem 0;">These files will remain on your fast cache drive with full protection.</p>
         </div>
 
-        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: 6px; margin-bottom: 1rem;">
+        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: var(--plex-radius-sm); margin-bottom: 1rem;">
             <strong style="color: var(--success);">What will happen:</strong>
             <ol style="margin: 0.5rem 0 0 1.5rem; padding: 0;">
                 <li>Copy each file to the array as a <code>.plexcached</code> backup</li>
@@ -940,7 +940,7 @@ function moveToArraySelected() {
             <p style="margin: 0 0 1rem 0;">These files will be moved off the cache drive to the main array.</p>
         </div>
 
-        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: 6px; margin-bottom: 1rem;">
+        <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: var(--plex-radius-sm); margin-bottom: 1rem;">
             ${whatWillHappen}
         </div>
 

--- a/web/templates/settings/backup.html
+++ b/web/templates/settings/backup.html
@@ -242,7 +242,7 @@
     gap: 0.5rem;
     cursor: pointer;
     padding: 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--plex-radius-xs);
     transition: background 0.2s;
 }
 .radio-label:hover {

--- a/web/templates/settings/libraries.html
+++ b/web/templates/settings/libraries.html
@@ -138,18 +138,6 @@
         }
         lucide.createIcons();
     }
-
-    function toggleEditMode(index) {
-        var view = document.getElementById('mapping-view-' + index);
-        var edit = document.getElementById('mapping-edit-' + index);
-        if (view.style.display === 'none') {
-            view.style.display = 'block';
-            edit.style.display = 'none';
-        } else {
-            view.style.display = 'none';
-            edit.style.display = 'block';
-        }
-        lucide.createIcons();
-    }
+    // toggleEditMode(index) is defined globally in /static/js/app.js
 </script>
 {% endblock %}

--- a/web/templates/settings/logging.html
+++ b/web/templates/settings/logging.html
@@ -32,7 +32,7 @@
                 </div>
             </div>
 
-            <div class="form-hint" style="margin-top: 1rem; padding: 1rem; background: var(--plex-surface); border-radius: 6px;">
+            <div class="form-hint" style="margin-top: 1rem; padding: 1rem; background: var(--plex-surface); border-radius: var(--plex-radius-sm);">
                 <strong>How it works:</strong>
                 <ul style="margin: 0.5rem 0 0 1.5rem; padding: 0;">
                     <li><strong>Max Log Files:</strong> PlexCache creates a new log file each run. Older logs are automatically deleted when this limit is reached.</li>

--- a/web/templates/settings/notifications.html
+++ b/web/templates/settings/notifications.html
@@ -32,7 +32,7 @@
             </h3>
 
             {% if is_docker and not unraid_notify_available %}
-            <div class="alert alert-info" style="margin-bottom: 1rem; padding: 0.75rem 1rem; background: rgba(52, 152, 219, 0.1); border: 1px solid rgba(52, 152, 219, 0.3); border-radius: 4px;">
+            <div class="alert alert-info" style="margin-bottom: 1rem; padding: 0.75rem 1rem; background: rgba(52, 152, 219, 0.1); border: 1px solid rgba(52, 152, 219, 0.3); border-radius: var(--plex-radius-xs);">
                 <div style="display: flex; align-items: flex-start; gap: 0.5rem;">
                     <i data-lucide="info" style="width: 18px; height: 18px; color: var(--plex-info); flex-shrink: 0; margin-top: 2px;"></i>
                     <div style="font-size: 0.9rem; color: var(--plex-text-muted);">

--- a/web/templates/settings/partials/backup_validation.html
+++ b/web/templates/settings/partials/backup_validation.html
@@ -1,4 +1,4 @@
-<div class="validation-results" style="margin: 1rem 0; padding: 1rem; border-radius: 6px; background: var(--plex-surface);">
+<div class="validation-results" style="margin: 1rem 0; padding: 1rem; border-radius: var(--plex-radius-sm); background: var(--plex-surface);">
     <h4 style="margin: 0 0 0.75rem 0; font-size: 0.95rem; color: var(--plex-text-bright);">
         <i data-lucide="{% if valid %}check-circle{% else %}x-circle{% endif %}"
            style="width: 16px; height: 16px; vertical-align: middle; color: {% if valid %}var(--success){% else %}var(--danger){% endif %};"></i>
@@ -8,7 +8,7 @@
     {% if errors %}
     <div class="validation-errors" style="margin-bottom: 0.75rem;">
         {% for error in errors %}
-        <div style="display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.5rem; background: rgba(244, 67, 54, 0.1); border-radius: 4px; margin-bottom: 0.25rem;">
+        <div style="display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.5rem; background: rgba(244, 67, 54, 0.1); border-radius: var(--plex-radius-xs); margin-bottom: 0.25rem;">
             <i data-lucide="x-circle" style="width: 14px; height: 14px; color: var(--danger); flex-shrink: 0; margin-top: 2px;"></i>
             <span style="color: var(--plex-text);">{{ error }}</span>
         </div>
@@ -19,7 +19,7 @@
     {% if warnings %}
     <div class="validation-warnings">
         {% for warning in warnings %}
-        <div style="display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.5rem; background: rgba(255, 152, 0, 0.1); border-radius: 4px; margin-bottom: 0.25rem;">
+        <div style="display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.5rem; background: rgba(255, 152, 0, 0.1); border-radius: var(--plex-radius-xs); margin-bottom: 0.25rem;">
             <i data-lucide="alert-triangle" style="width: 14px; height: 14px; color: var(--warning); flex-shrink: 0; margin-top: 2px;"></i>
             <span style="color: var(--plex-text);">{{ warning }}</span>
         </div>

--- a/web/templates/settings/partials/path_mapping_card.html
+++ b/web/templates/settings/partials/path_mapping_card.html
@@ -127,17 +127,6 @@
     </div>
 </div>
 <script>
+    // Re-render icons after HTMX swap. toggleEditMode(index) is defined in /static/js/app.js.
     lucide.createIcons();
-    function toggleEditMode(index) {
-        const view = document.getElementById('mapping-view-' + index);
-        const edit = document.getElementById('mapping-edit-' + index);
-        if (view.style.display === 'none') {
-            view.style.display = 'block';
-            edit.style.display = 'none';
-        } else {
-            view.style.display = 'none';
-            edit.style.display = 'block';
-        }
-        lucide.createIcons();
-    }
 </script>

--- a/web/templates/settings/partials/users_skeleton.html
+++ b/web/templates/settings/partials/users_skeleton.html
@@ -10,7 +10,7 @@
         <div class="user-row skeleton-row">
             <span class="user-col">
                 <div class="skeleton skeleton-text" style="width: 100px;"></div>
-                <div class="skeleton" style="width: 45px; height: 18px; border-radius: 4px;"></div>
+                <div class="skeleton" style="width: 45px; height: 18px; border-radius: var(--plex-radius-xs);"></div>
             </span>
             <span class="toggle-col">
                 <div class="skeleton" style="width: 36px; height: 20px; border-radius: 10px;"></div>
@@ -23,7 +23,7 @@
         <div class="user-row skeleton-row">
             <span class="user-col">
                 <div class="skeleton skeleton-text" style="width: 80px;"></div>
-                <div class="skeleton" style="width: 50px; height: 18px; border-radius: 4px;"></div>
+                <div class="skeleton" style="width: 50px; height: 18px; border-radius: var(--plex-radius-xs);"></div>
             </span>
             <span class="toggle-col">
                 <div class="skeleton" style="width: 36px; height: 20px; border-radius: 10px;"></div>
@@ -36,13 +36,13 @@
         <div class="user-row skeleton-row">
             <span class="user-col">
                 <div class="skeleton skeleton-text" style="width: 90px;"></div>
-                <div class="skeleton" style="width: 55px; height: 18px; border-radius: 4px;"></div>
+                <div class="skeleton" style="width: 55px; height: 18px; border-radius: var(--plex-radius-xs);"></div>
             </span>
             <span class="toggle-col">
                 <div class="skeleton" style="width: 36px; height: 20px; border-radius: 10px;"></div>
             </span>
             <span class="toggle-col">
-                <div class="skeleton" style="width: 60px; height: 16px; border-radius: 4px;"></div>
+                <div class="skeleton" style="width: 60px; height: 16px; border-radius: var(--plex-radius-xs);"></div>
             </span>
         </div>
     </div>

--- a/web/templates/settings/paths.html
+++ b/web/templates/settings/paths.html
@@ -13,20 +13,7 @@
             {% include "settings/partials/path_mappings_list.html" %}
         </div>
 
-        <script>
-            function toggleEditMode(index) {
-                const view = document.getElementById('mapping-view-' + index);
-                const edit = document.getElementById('mapping-edit-' + index);
-                if (view.style.display === 'none') {
-                    view.style.display = 'block';
-                    edit.style.display = 'none';
-                } else {
-                    view.style.display = 'none';
-                    edit.style.display = 'block';
-                }
-                lucide.createIcons();
-            }
-        </script>
+        {# toggleEditMode(index) is defined globally in /static/js/app.js #}
 
         <hr style="border-color: var(--plex-border); margin: 1.5rem 0;">
 

--- a/web/templates/settings/schedule.html
+++ b/web/templates/settings/schedule.html
@@ -162,7 +162,7 @@
 <style>
 .schedule-status {
     background: var(--plex-bg-input);
-    border-radius: 6px;
+    border-radius: var(--plex-radius-sm);
     padding: 1rem;
 }
 
@@ -208,7 +208,7 @@
     padding: 0.5rem 0.75rem;
     background: var(--plex-bg-input);
     border: 1px solid var(--plex-border);
-    border-radius: 4px;
+    border-radius: var(--plex-radius-xs);
     color: var(--plex-text);
     font-size: 0.95rem;
 }
@@ -288,7 +288,7 @@
 .cron-validation {
     margin-top: 0.5rem;
     padding: 0.75rem;
-    border-radius: 4px;
+    border-radius: var(--plex-radius-xs);
     font-size: 0.85rem;
     display: none;
 }
@@ -326,7 +326,7 @@
     padding: 0.75rem;
     background: var(--plex-bg-input);
     border: 1px solid var(--plex-border);
-    border-radius: 6px;
+    border-radius: var(--plex-radius-sm);
     cursor: pointer;
 }
 

--- a/web/templates/setup/base_setup.html
+++ b/web/templates/setup/base_setup.html
@@ -134,7 +134,7 @@
 
         .setup-footer .btn {
             padding: 0.75rem 1.5rem;
-            border-radius: 6px;
+            border-radius: var(--plex-radius-sm);
             font-weight: 600;
             cursor: pointer;
             display: flex;
@@ -191,7 +191,7 @@
             width: 100%;
             padding: 0.75rem;
             border: 1px solid var(--plex-border);
-            border-radius: 6px;
+            border-radius: var(--plex-radius-sm);
             background: var(--plex-bg-input);
             color: var(--plex-text);
             font-size: 0.95rem;
@@ -264,7 +264,7 @@
             padding: 0.75rem;
             background: var(--plex-bg-input);
             border: 1px solid var(--plex-border);
-            border-radius: 6px;
+            border-radius: var(--plex-radius-sm);
             cursor: pointer;
             transition: all 0.15s ease;
         }
@@ -298,7 +298,7 @@
         /* Alert styles */
         .alert {
             padding: 1rem;
-            border-radius: 6px;
+            border-radius: var(--plex-radius-sm);
             margin-bottom: 1rem;
             display: flex;
             align-items: flex-start;
@@ -372,7 +372,7 @@
             padding: 1rem;
             background: #e5a00d;
             border: none;
-            border-radius: 6px;
+            border-radius: var(--plex-radius-sm);
             color: #1a1a1a;
             font-weight: 600;
             font-size: 1rem;
@@ -454,7 +454,7 @@
             width: 100%;
             padding: 0.5rem;
             border: 1px solid var(--plex-border);
-            border-radius: 4px;
+            border-radius: var(--plex-radius-xs);
             background: var(--plex-bg-input);
             color: var(--plex-text);
             font-size: 0.9rem;

--- a/web/templates/setup/step1.html
+++ b/web/templates/setup/step1.html
@@ -76,7 +76,7 @@
                     <span>Import files detected!</span>
                 </div>
 
-                <div id="import-summary" style="background: var(--plex-bg-input); padding: 0.75rem 1rem; border-radius: 4px; margin-bottom: 1rem; font-size: 0.85rem;">
+                <div id="import-summary" style="background: var(--plex-bg-input); padding: 0.75rem 1rem; border-radius: var(--plex-radius-xs); margin-bottom: 1rem; font-size: 0.85rem;">
                     <!-- Filled by JS -->
                 </div>
 

--- a/web/templates/setup/step3.html
+++ b/web/templates/setup/step3.html
@@ -99,7 +99,7 @@
             <div id="path-mappings-container">
                 {% if path_mappings %}
                     {% for mapping in path_mappings %}
-                    <div class="path-mapping-row" style="background: var(--surface-secondary); padding: 1rem; border-radius: 6px; margin-bottom: 0.75rem;">
+                    <div class="path-mapping-row" style="background: var(--surface-secondary); padding: 1rem; border-radius: var(--plex-radius-sm); margin-bottom: 0.75rem;">
                         <input type="hidden" name="mapping_name_{{ loop.index0 }}" value="{{ mapping.name }}">
 
                         <div style="display: grid; gap: 0.5rem;">
@@ -201,7 +201,7 @@
         ` : '';
 
         const html = `
-            <div class="path-mapping-row" style="background: var(--surface-secondary); padding: 1rem; border-radius: 6px; margin-bottom: 0.75rem;">
+            <div class="path-mapping-row" style="background: var(--surface-secondary); padding: 1rem; border-radius: var(--plex-radius-sm); margin-bottom: 0.75rem;">
                 <div style="display: grid; gap: 0.5rem;">
                     <div style="display: flex; gap: 0.5rem; align-items: center;">
                         <strong style="width: 110px; font-size: 0.85rem; color: var(--text-secondary);">Name:</strong>

--- a/web/templates/setup/step4.html
+++ b/web/templates/setup/step4.html
@@ -83,7 +83,7 @@
         </div>
 
         <!-- RSS URL for Remote Watchlist Support -->
-        <div style="margin-top: 1rem; background: rgba(229, 160, 13, 0.1); border: 1px solid rgba(229, 160, 13, 0.3); border-radius: 6px; padding: 1rem;">
+        <div style="margin-top: 1rem; background: rgba(229, 160, 13, 0.1); border: 1px solid rgba(229, 160, 13, 0.3); border-radius: var(--plex-radius-sm); padding: 1rem;">
             <div style="display: flex; align-items: flex-start; gap: 0.75rem; margin-bottom: 0.75rem;">
                 <i data-lucide="rss" style="color: var(--plex-orange); flex-shrink: 0; width: 20px; height: 20px;"></i>
                 <div>

--- a/web/templates/setup/step5.html
+++ b/web/templates/setup/step5.html
@@ -10,7 +10,7 @@
 
         <div style="display: grid; gap: 1.5rem;">
             <!-- OnDeck Settings -->
-            <div style="background: var(--surface-secondary); padding: 1rem; border-radius: 6px;">
+            <div style="background: var(--surface-secondary); padding: 1rem; border-radius: var(--plex-radius-sm);">
                 <h3 style="margin: 0 0 1rem 0; font-size: 1rem; display: flex; align-items: center; gap: 0.5rem;">
                     <i data-lucide="play-circle" style="width: 18px; height: 18px; color: var(--accent-primary);"></i>
                     OnDeck Settings
@@ -42,7 +42,7 @@
             </div>
 
             <!-- Watchlist Settings -->
-            <div style="background: var(--surface-secondary); padding: 1rem; border-radius: 6px;">
+            <div style="background: var(--surface-secondary); padding: 1rem; border-radius: var(--plex-radius-sm);">
                 <h3 style="margin: 0 0 1rem 0; font-size: 1rem; display: flex; align-items: center; gap: 0.5rem;">
                     <i data-lucide="bookmark" style="width: 18px; height: 18px; color: var(--accent-primary);"></i>
                     Watchlist Settings
@@ -85,7 +85,7 @@
             </div>
 
             <!-- Retention Settings -->
-            <div style="background: var(--surface-secondary); padding: 1rem; border-radius: 6px;">
+            <div style="background: var(--surface-secondary); padding: 1rem; border-radius: var(--plex-radius-sm);">
                 <h3 style="margin: 0 0 1rem 0; font-size: 1rem; display: flex; align-items: center; gap: 0.5rem;">
                     <i data-lucide="clock" style="width: 18px; height: 18px; color: var(--accent-primary);"></i>
                     Retention & Move-back

--- a/web/templates/setup/step6.html
+++ b/web/templates/setup/step6.html
@@ -8,7 +8,7 @@
         justify-content: space-between;
         padding: 1rem;
         background: var(--surface-secondary);
-        border-radius: 6px;
+        border-radius: var(--plex-radius-sm);
         margin-bottom: 1.25rem;
     }
 
@@ -28,7 +28,7 @@
         padding: 0.75rem 1rem;
         background: rgba(76, 175, 80, 0.08);
         border: 1px solid rgba(76, 175, 80, 0.2);
-        border-radius: 6px;
+        border-radius: var(--plex-radius-sm);
     }
 
     .admin-identity-box i {
@@ -117,7 +117,7 @@
             </div>
 
             <!-- Password fallback -->
-            <div style="background: var(--surface-secondary); padding: 1rem; border-radius: 6px;">
+            <div style="background: var(--surface-secondary); padding: 1rem; border-radius: var(--plex-radius-sm);">
                 <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.5rem;">
                     <div>
                         <strong style="color: var(--plex-text); font-size: 0.95rem;">

--- a/web/templates/setup/step6.html
+++ b/web/templates/setup/step6.html
@@ -129,7 +129,7 @@
                     <label class="toggle-switch">
                         <input type="checkbox" id="auth_password_enabled" name="auth_password_enabled" value="on"
                                {% if auth_password_enabled %}checked{% endif %}
-                               onchange="togglePasswordSection()">
+                               onchange="togglePasswordSectionSetup()">
                         <span class="toggle-slider"></span>
                     </label>
                 </div>
@@ -180,7 +180,10 @@ function toggleAuthDetails() {
     document.getElementById('auth-details').style.display = enabled ? '' : 'none';
 }
 
-function togglePasswordSection() {
+// Setup-only: clears the fields on disable so the wizard doesn't submit stale
+// values. The settings page (settings/security.html) has a same-named toggle
+// that preserves the fields, so keep these two functions distinct.
+function togglePasswordSectionSetup() {
     var enabled = document.getElementById('auth_password_enabled').checked;
     document.getElementById('password-section').style.display = enabled ? '' : 'none';
     if (!enabled) {

--- a/web/templates/setup/step7.html
+++ b/web/templates/setup/step7.html
@@ -12,7 +12,7 @@
             PlexCache-D has been configured and is ready to use.
         </p>
 
-        <div style="background: var(--surface-secondary); border-radius: 6px; padding: 1rem; text-align: left; margin: 1.5rem 0;">
+        <div style="background: var(--surface-secondary); border-radius: var(--plex-radius-sm); padding: 1rem; text-align: left; margin: 1.5rem 0;">
             <h3 style="margin: 0 0 1rem 0; font-size: 1rem; color: var(--text-secondary);">Configuration Summary</h3>
 
             <div class="summary-item">


### PR DESCRIPTION
## Summary

A bundle of low-risk quality-of-life improvements. Five commits, each independent in intent but grouped to keep review cycles short. No behavior changes for end users.

## Changes

**1. Service-layer consolidation** (`cc06fe0`, `8fd58aa`)
- Move dashboard stats logic from router into `cache_service.py` so the router stays a thin HTTP layer.
- Split the 350-line `get_all_cached_files()` into focused helpers (`_collect_cache_files`, `_attach_associated_files`, `_compute_priorities`, etc.) — same return shape, easier to test, no behavior change.

**2. Design tokens + light-theme popup fix** (`e02f446`)
- Replace hardcoded radii / shadows / colors across templates with `--plex-*` custom properties from `plex-theme.css`.
- Adds `--plex-radius-xs` for popup chrome.
- Fixes a light-theme rendering bug where the associated-files hover popup had near-invisible borders against the lighter background.

**3. Narrower `except Exception`** (`340f5d8`)
- Replace 8 broad `except Exception` clauses with the actual exception types where the failure modes are known (`KeyError`, `ValueError`, `OSError`, `requests.RequestException`, etc).
- Touched files: `core/app.py`, `web/services/operation_runner.py`, `web/services/settings_service.py`.
- Genuinely unknown-failure-mode catches were left alone.

**4. JS `toggleEditMode` consolidation** (`34cfdb3`)
- Three near-identical `toggleEditMode()` functions across templates collapsed into a single `app.js` helper.
- Renames the setup-wizard password-toggle to avoid the name collision that was the reason for the duplicates.

## Test plan

- [x] Dashboard stats render identically (cache hits, file counts, byte totals) — no router-level logic changed externally.
- [x] Cached Files list (`/cache/list`) loads, sorts, paginates as before; associated-files popup opens on hover with viewport-aware positioning.
- [x] Light theme: associated-files popup borders and shadows are visible against the light background.
- [x] Settings tabs that use `toggleEditMode` (Plex Server, Cache, Notifications) toggle into edit mode and save correctly.
- [x] Setup wizard password show/hide still works on its own field.
- [x] Existing pytest suite passes (1,109 tests in this bundle's working tree).