### PR TITLE
Group Recent Activity by run on the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ python3 plexcache.py --web --port 8080     # Custom port
 - **Logs** - Real-time log viewer with search, filters, and live streaming
 - **Stop Button** - Abort running operations gracefully (stops after current file completes)
 - **Operations** - Run Now with real-time progress banner, ETA, and stop button
-- **Activity Feed** - Recent file operations with persistent history
+- **Activity Feed** - Recent file operations grouped by run, with TV episodes collapsed by show and persistent history
 - **Maintenance History** - Persistent log of past maintenance actions
 - **Authentication** - Optional Plex OAuth login with password fallback and session management
 

--- a/core/activity.py
+++ b/core/activity.py
@@ -1,13 +1,13 @@
-"""Shared activity writer — CLI and Web UI both write here.
+"""Shared activity writer — CLI, Web UI, and Maintenance all write here.
 
 Provides file activity recording, last-run timestamps, and run summaries
 that the Web UI dashboard reads. This module has NO web framework imports
 so it can be used from core/app.py (CLI path) as well as from the web layer.
 
-Both CLI runs and web-triggered runs write to the same files:
+All run paths write to the same files:
   - data/recent_activity.json   (per-file activity feed)
   - data/last_run.txt           (last run timestamp)
-  - data/last_run_summary.json  (run statistics)
+  - data/run_summaries.json     (run statistics keyed by run_id)
 """
 
 import json
@@ -56,14 +56,21 @@ SETTINGS_FILE = _get_settings_file()
 # File paths
 ACTIVITY_FILE = DATA_DIR / "recent_activity.json"
 LAST_RUN_FILE = DATA_DIR / "last_run.txt"
-LAST_RUN_SUMMARY_FILE = DATA_DIR / "last_run_summary.json"
+RUN_SUMMARIES_FILE = DATA_DIR / "run_summaries.json"
+# Legacy single-dict file; migrated into RUN_SUMMARIES_FILE on first load.
+_LEGACY_RUN_SUMMARY_FILE = DATA_DIR / "last_run_summary.json"
 
 # Defaults
 DEFAULT_ACTIVITY_RETENTION_HOURS = 24
 MAX_RECENT_ACTIVITY = 500
 
-# Thread lock for concurrent access to activity file
+# Run sources excluded from load_last_run_summary() so the dashboard's
+# "PlexCache last run" widget reflects caching runs, not maintenance.
+_LAST_RUN_DEFAULT_SOURCES = ("cli", "web", "scheduled")
+
+# Thread locks
 _activity_file_lock = threading.Lock()
+_run_summaries_lock = threading.Lock()
 
 logger = logging.getLogger(__name__)
 
@@ -385,24 +392,124 @@ def save_last_run_time() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Run summary
+# Run summaries (keyed by run_id, pruned by activity_retention_hours)
 # ---------------------------------------------------------------------------
 
-def load_last_run_summary() -> Optional[dict]:
-    """Load the last run summary from disk."""
+def _migrate_legacy_run_summary_unlocked(summaries: dict) -> dict:
+    """One-shot migration: fold old single-dict last_run_summary.json into the
+    new keyed-dict file. Idempotent — only runs when the legacy file exists
+    and the new file is empty/missing the same entry. Caller must hold
+    _run_summaries_lock.
+    """
+    if not _LEGACY_RUN_SUMMARY_FILE.exists():
+        return summaries
     try:
-        if LAST_RUN_SUMMARY_FILE.exists():
-            with open(LAST_RUN_SUMMARY_FILE, 'r', encoding='utf-8') as f:
-                return json.load(f)
+        with open(_LEGACY_RUN_SUMMARY_FILE, 'r', encoding='utf-8') as f:
+            old = json.load(f)
+        if not isinstance(old, dict):
+            _LEGACY_RUN_SUMMARY_FILE.unlink(missing_ok=True)
+            return summaries
+        run_id = old.get("run_id") or f"legacy-{old.get('timestamp', datetime.now().isoformat())}"
+        if run_id not in summaries:
+            entry = dict(old)
+            entry.setdefault("run_id", run_id)
+            entry.setdefault("run_source", "legacy")
+            # Old shape stored the completion timestamp as "timestamp"; map
+            # it to completed_at so downstream consumers see a uniform schema.
+            if "completed_at" not in entry and "timestamp" in entry:
+                entry["completed_at"] = entry["timestamp"]
+            entry.setdefault("started_at", entry.get("completed_at", datetime.now().isoformat()))
+            summaries[run_id] = entry
+        _LEGACY_RUN_SUMMARY_FILE.unlink(missing_ok=True)
+        logger.info("Migrated legacy last_run_summary.json into run_summaries.json")
+    except (json.JSONDecodeError, IOError, OSError) as e:
+        logger.debug(f"Legacy run-summary migration skipped: {e}")
+    return summaries
+
+
+def _prune_summaries(summaries: dict) -> dict:
+    """Drop entries older than activity_retention_hours, keyed by started_at."""
+    cutoff = datetime.now() - timedelta(hours=_get_activity_retention_hours())
+    pruned = {}
+    for run_id, entry in summaries.items():
+        ts_str = entry.get("started_at") or entry.get("completed_at")
+        if not ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except ValueError:
+            continue
+        if ts > cutoff:
+            pruned[run_id] = entry
+    return pruned
+
+
+def _load_run_summaries_unlocked() -> dict:
+    """Load run summaries dict from disk, migrate legacy file, prune. Caller
+    must hold _run_summaries_lock.
+    """
+    summaries: dict = {}
+    try:
+        if RUN_SUMMARIES_FILE.exists():
+            with open(RUN_SUMMARIES_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    summaries = data
     except (json.JSONDecodeError, IOError):
-        pass
-    return None
+        summaries = {}
+    summaries = _migrate_legacy_run_summary_unlocked(summaries)
+    return _prune_summaries(summaries)
 
 
-def save_run_summary(summary: dict) -> None:
-    """Save a run summary to disk atomically."""
+def load_run_summaries() -> dict:
+    """All run summaries keyed by run_id, pruned by retention setting."""
+    with _run_summaries_lock:
+        return _load_run_summaries_unlocked()
+
+
+def load_run_summary(run_id: str) -> Optional[dict]:
+    """One run summary by id, or None if not found / pruned."""
+    return load_run_summaries().get(run_id)
+
+
+def save_run_summary(run_id: str, summary: dict) -> None:
+    """Persist a run summary keyed by run_id. Load-merge-save under a lock so
+    concurrent writers (CLI, web/scheduled, maintenance) don't clobber.
+    """
+    if not run_id:
+        logger.debug("save_run_summary called with empty run_id; ignoring")
+        return
     try:
-        LAST_RUN_SUMMARY_FILE.parent.mkdir(parents=True, exist_ok=True)
-        save_json_atomically(str(LAST_RUN_SUMMARY_FILE), summary, label="last run summary")
+        with _run_summaries_lock:
+            summaries = _load_run_summaries_unlocked()
+            entry = dict(summary)
+            entry["run_id"] = run_id
+            summaries[run_id] = entry
+            summaries = _prune_summaries(summaries)
+            RUN_SUMMARIES_FILE.parent.mkdir(parents=True, exist_ok=True)
+            save_json_atomically(str(RUN_SUMMARIES_FILE), summaries, label="run summaries")
     except IOError:
         pass
+
+
+def load_last_run_summary(run_sources: Optional[tuple] = None) -> Optional[dict]:
+    """Most-recent run summary by started_at. Backward-compat wrapper for the
+    dashboard's "Last Run Summary" widget — defaults to caching runs only
+    (cli/web/scheduled), excluding maintenance so the widget keeps its
+    semantic meaning.
+    """
+    sources = run_sources if run_sources is not None else _LAST_RUN_DEFAULT_SOURCES
+    summaries = load_run_summaries()
+    if not summaries:
+        return None
+    candidates = [
+        entry for entry in summaries.values()
+        if not sources or entry.get("run_source") in sources
+    ]
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda e: e.get("started_at") or e.get("completed_at") or "",
+        reverse=True,
+    )
+    return candidates[0]

--- a/core/activity.py
+++ b/core/activity.py
@@ -13,6 +13,7 @@ Both CLI runs and web-triggered runs write to the same files:
 import json
 import logging
 import os
+import re
 import threading
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -110,6 +111,11 @@ class FileActivity:
     size_bytes: int = 0
     users: List[str] = field(default_factory=list)
     associated_files: List[dict] = field(default_factory=list)
+    # Run grouping metadata (added 2026-04 for run-grouped Recent Activity view).
+    # Pre-existing entries on disk lack these fields; loader defaults run_id=None
+    # (treated as legacy, bucketed by 15-min time windows by activity_grouping).
+    run_id: Optional[str] = None
+    run_source: str = "legacy"  # "scheduled" | "web" | "cli" | "maintenance" | "legacy"
 
     def to_dict(self) -> dict:
         fmt = get_time_format()
@@ -136,7 +142,10 @@ class FileActivity:
             "action": self.action,
             "filename": self.filename,
             "size": self._format_size(self.size_bytes),
+            "size_bytes": self.size_bytes,
             "users": self.users,
+            "run_id": self.run_id,
+            "run_source": self.run_source,
         }
         if self.associated_files:
             result["associated_files"] = self.associated_files
@@ -176,7 +185,9 @@ def _load_activity_unlocked() -> List[FileActivity]:
                         filename=item['filename'],
                         size_bytes=item.get('size_bytes', 0),
                         users=item.get('users', []),
-                        associated_files=item.get('associated_files', [])
+                        associated_files=item.get('associated_files', []),
+                        run_id=item.get('run_id'),
+                        run_source=item.get('run_source', 'legacy'),
                     ))
             except (KeyError, ValueError):
                 continue  # Skip malformed entries
@@ -211,6 +222,10 @@ def _save_activity_unlocked(activities: List[FileActivity]) -> None:
                 }
                 if activity.associated_files:
                     entry['associated_files'] = activity.associated_files
+                if activity.run_id:
+                    entry['run_id'] = activity.run_id
+                if activity.run_source and activity.run_source != "legacy":
+                    entry['run_source'] = activity.run_source
                 data.append(entry)
 
         save_json_atomically(str(ACTIVITY_FILE), data, label="activity")
@@ -241,6 +256,8 @@ def record_file_activity(
     size_bytes: int = 0,
     users: Optional[List[str]] = None,
     associated_files: Optional[List[dict]] = None,
+    run_id: Optional[str] = None,
+    run_source: str = "legacy",
 ) -> None:
     """Record a single file activity entry using load-merge-save pattern.
 
@@ -254,12 +271,103 @@ def record_file_activity(
         size_bytes=size_bytes,
         users=users or [],
         associated_files=associated_files or [],
+        run_id=run_id,
+        run_source=run_source,
     )
     with _activity_file_lock:
         activities = _load_activity_unlocked()
         activities.insert(0, entry)
         activities = activities[:MAX_RECENT_ACTIVITY]
         _save_activity_unlocked(activities)
+
+
+# ---------------------------------------------------------------------------
+# Show-episode grouping (shared by completion banner + dashboard)
+# ---------------------------------------------------------------------------
+
+# Matches "<show> - S##E##" — the Sonarr/Plex TV naming convention.
+# Non-TV files (movies, specials without episode numbering) don't match
+# and pass through as singletons.
+_SHOW_EPISODE_PATTERN = re.compile(r'^(.+?) - S\d+E\d+', re.IGNORECASE)
+
+
+def group_episodes_by_show(files: List[dict]) -> List[dict]:
+    """Collapse multi-episode TV runs into a single parent row per show.
+
+    Movies and shows with only one episode in the payload stay as
+    individual rows (grouping a single entry offers no compression).
+    Preserves first-seen order so re-renders don't reshuffle.
+
+    Used by both the completion banner (`OperationRunner`) and the
+    Recent Activity grouping service (`web/services/activity_grouping.py`).
+    """
+    groups: dict = {}
+    order: list = []
+
+    for idx, f in enumerate(files):
+        match = _SHOW_EPISODE_PATTERN.match(f.get("filename", ""))
+        if match:
+            show_name = match.group(1).strip()
+            key = (f.get("action", ""), show_name)
+            if key not in groups:
+                groups[key] = {
+                    "action": f.get("action", ""),
+                    "show_name": show_name,
+                    "episodes": [],
+                    "total_bytes": 0,
+                }
+                order.append(key)
+            # Preserve per-episode metadata the dashboard renders (time, users)
+            # in addition to the fields the completion banner consumes.
+            groups[key]["episodes"].append({
+                "filename": f.get("filename", ""),
+                "size": f.get("size", ""),
+                "size_bytes": f.get("size_bytes", 0),
+                "associated_files": f.get("associated_files", []),
+                "timestamp": f.get("timestamp", ""),
+                "time_display": f.get("time_display", ""),
+                "users": f.get("users", []),
+            })
+            groups[key]["total_bytes"] += f.get("size_bytes", 0)
+        else:
+            key = ("__singleton__", idx)
+            groups[key] = f
+            order.append(key)
+
+    result: List[dict] = []
+    for key in order:
+        entry = groups[key]
+        if key[0] == "__singleton__":
+            result.append(entry)
+        elif len(entry["episodes"]) == 1:
+            ep = entry["episodes"][0]
+            result.append({
+                "action": entry["action"],
+                "filename": ep["filename"],
+                "size": ep.get("size", ""),
+                "size_bytes": ep.get("size_bytes", 0),
+                "associated_files": ep.get("associated_files", []),
+                "timestamp": ep.get("timestamp", ""),
+                "time_display": ep.get("time_display", ""),
+                "users": ep.get("users", []),
+            })
+        else:
+            # Use the newest episode's time as the group's representative time
+            # (episodes arrive newest-first when called from the dashboard path).
+            head_ep = entry["episodes"][0]
+            result.append({
+                "action": entry["action"],
+                "is_group": True,
+                "show_name": entry["show_name"],
+                "episode_count": len(entry["episodes"]),
+                "episodes": entry["episodes"],
+                "size_bytes": entry["total_bytes"],
+                "size": format_bytes(entry["total_bytes"]) if entry["total_bytes"] > 0 else "",
+                "time_display": head_ep.get("time_display", ""),
+                "users": head_ep.get("users", []),
+            })
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/core/app.py
+++ b/core/app.py
@@ -11,6 +11,7 @@ import logging
 import re
 import shutil
 import subprocess
+import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Set, Optional, Tuple
@@ -92,6 +93,9 @@ class PlexCacheApp:
         self._stop_requested = False
         # Docker mount validation result (False = unsafe, blocks file moves)
         self._mount_paths_safe = True
+        # Run ID — minted at run start, written into the log header so
+        # `_parse_external_log` can recover it for the dashboard's run-grouped view.
+        self._run_id: Optional[str] = None
 
     def _record_file_activity(self, action: str, filename: str, size_bytes: int) -> None:
         """Record a file operation to the shared activity feed (CLI runs only).
@@ -101,7 +105,13 @@ class PlexCacheApp:
         handles activity recording via log parsing instead).
         """
         from core.activity import record_file_activity
-        record_file_activity(action=action, filename=filename, size_bytes=size_bytes)
+        record_file_activity(
+            action=action,
+            filename=filename,
+            size_bytes=size_bytes,
+            run_id=self._run_id,
+            run_source="cli",
+        )
 
     def request_stop(self) -> None:
         """Request the operation to stop gracefully after current file."""
@@ -362,9 +372,13 @@ class PlexCacheApp:
         )
         self.logging_manager.setup_logging()
         logging.info("")
+        # Mint a stable run_id and write it into the header so the web
+        # dashboard's external-log parser can attach it to per-file entries
+        # for the run-grouped Recent Activity view.
+        self._run_id = uuid.uuid4().hex
         # Log version and build info for debugging
         build_commit = os.environ.get('GIT_COMMIT', 'dev')
-        logging.info(f"=== PlexCache-D v{__version__} (build: {build_commit}) ===")
+        logging.info(f"=== PlexCache-D v{__version__} (build: {build_commit}) run_id={self._run_id} ===")
         # Log file ownership configuration (PUID/PGID)
         self.file_utils.log_ownership_config()
 

--- a/core/app.py
+++ b/core/app.py
@@ -2926,17 +2926,19 @@ class PlexCacheApp:
         # Save last run time and summary to shared activity files
         # so the Web UI dashboard reflects CLI-triggered runs too.
         # Skip in dry-run mode (no real files were moved).
-        if not self.dry_run and self._record_activity:
+        if not self.dry_run and self._record_activity and self._run_id:
             from core.activity import save_last_run_time, save_run_summary
             save_last_run_time()
-            save_run_summary({
+            save_run_summary(self._run_id, {
+                "run_source": "cli",
                 "status": "completed",
-                "timestamp": datetime.now().isoformat(),
+                "started_at": datetime.fromtimestamp(self.start_time).isoformat(),
+                "completed_at": datetime.now().isoformat(),
+                "duration_seconds": round(execution_time_seconds, 1),
                 "files_cached": cached_count,
                 "files_restored": restored_count,
                 "bytes_cached": cached_bytes,
                 "bytes_restored": restored_bytes,
-                "duration_seconds": round(execution_time_seconds, 1),
                 "error_count": 0,
                 "dry_run": False,
             })

--- a/tests/test_activity_feed.py
+++ b/tests/test_activity_feed.py
@@ -97,7 +97,11 @@ class TestFileActivity:
             )
             d = fa.to_dict()
 
-        required_keys = {'timestamp', 'time_display', 'date_key', 'date_display', 'action', 'filename', 'size', 'users'}
+        required_keys = {
+            'timestamp', 'time_display', 'date_key', 'date_display',
+            'action', 'filename', 'size', 'size_bytes', 'users',
+            'run_id', 'run_source',
+        }
         assert required_keys == set(d.keys())
 
 

--- a/tests/test_activity_feed.py
+++ b/tests/test_activity_feed.py
@@ -443,12 +443,16 @@ class TestLastRunSummaryAtomicWrite:
             OperationRunner, OperationResult, OperationState,
         )
 
-        summary_file = tmp_path / "last_run_summary.json"
+        summary_file = tmp_path / "run_summaries.json"
+        legacy_file = tmp_path / "last_run_summary.json"
 
         with patch('core.activity.load_activity', return_value=[]), \
-             patch('core.activity.LAST_RUN_SUMMARY_FILE', summary_file), \
+             patch('core.activity.RUN_SUMMARIES_FILE', summary_file), \
+             patch('core.activity._LEGACY_RUN_SUMMARY_FILE', legacy_file), \
              patch('core.activity.save_json_atomically') as mock_atomic:
             runner = OperationRunner()
+            runner._run_id = "test-run-id"
+            runner._run_source = "web"
             runner._current_result = OperationResult(
                 state=OperationState.COMPLETED,
                 started_at=datetime.now(),
@@ -460,10 +464,10 @@ class TestLastRunSummaryAtomicWrite:
             )
             runner._save_last_run_summary()
 
-        assert mock_atomic.called, "save_json_atomically was not called for last run summary"
+        assert mock_atomic.called, "save_json_atomically was not called for run summaries"
         call_args = mock_atomic.call_args
         # Check positional or keyword label arg
         positional = call_args[0]
         keyword = call_args[1]
         label = keyword.get("label") if "label" in keyword else (positional[2] if len(positional) > 2 else None)
-        assert label == "last run summary", f"Expected label 'last run summary', got {label!r}"
+        assert label == "run summaries", f"Expected label 'run summaries', got {label!r}"

--- a/tests/test_activity_grouping.py
+++ b/tests/test_activity_grouping.py
@@ -45,6 +45,13 @@ def _stub_time_format():
         yield
 
 
+# Default to no run summaries; individual tests override when needed.
+@pytest.fixture(autouse=True)
+def _stub_run_summaries():
+    with patch("web.services.activity_grouping.load_run_summaries", return_value={}):
+        yield
+
+
 class TestEmpty:
     def test_empty_input_returns_empty(self):
         assert group_activity_into_runs([]) == []
@@ -193,6 +200,61 @@ class TestAggregates:
         runs = group_activity_into_runs(activities)
         assert runs[0]["files_restored"] == 1
         assert runs[0]["files_cached"] == 0
+
+
+class TestRunSummaryOverride:
+    """When a run_summary exists for a bucket's run_id, its started_at /
+    completed_at win over the first/last FileActivity timestamp — captures
+    the pre-/post-file-move tail (Plex API + scanning + audit).
+    """
+
+    def test_summary_started_at_overrides_first_file_timestamp(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        # Files moved at 10:01 and 10:02, but the actual run started at 10:00
+        # (Plex API + scanning took 60s before the first file).
+        activities = [
+            _entry(now + timedelta(seconds=120), "Cached", "b.mkv", run_id="r1", run_source="web"),
+            _entry(now + timedelta(seconds=60), "Cached", "a.mkv", run_id="r1", run_source="web"),
+        ]
+        summaries = {
+            "r1": {
+                "run_id": "r1",
+                "run_source": "web",
+                "started_at": now.isoformat(),
+                "completed_at": (now + timedelta(seconds=180)).isoformat(),
+            }
+        }
+        with patch("web.services.activity_grouping.load_run_summaries", return_value=summaries):
+            runs = group_activity_into_runs(activities)
+
+        # Without the override the bucket would be 60s; with summary it's 180s.
+        assert runs[0]["duration_seconds"] == 180
+        assert runs[0]["started_at"] == now.isoformat()
+        assert runs[0]["completed_at"] == (now + timedelta(seconds=180)).isoformat()
+
+    def test_missing_summary_falls_back_to_bucket_timestamps(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=60), "Cached", "b.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "a.mkv", run_id="r1", run_source="web"),
+        ]
+        # No summary for r1
+        runs = group_activity_into_runs(activities)
+        assert runs[0]["duration_seconds"] == 60
+
+    def test_malformed_summary_timestamps_ignored(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=60), "Cached", "b.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "a.mkv", run_id="r1", run_source="web"),
+        ]
+        summaries = {
+            "r1": {"started_at": "not-a-date", "completed_at": "also-bad"}
+        }
+        with patch("web.services.activity_grouping.load_run_summaries", return_value=summaries):
+            runs = group_activity_into_runs(activities)
+        # Falls back to bucket timestamps without raising.
+        assert runs[0]["duration_seconds"] == 60
 
 
 class TestOrdering:

--- a/tests/test_activity_grouping.py
+++ b/tests/test_activity_grouping.py
@@ -1,0 +1,233 @@
+"""Tests for the run-grouped Recent Activity transformation."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from web.services.activity_grouping import (
+    group_activity_into_runs,
+    LEGACY_RUN_WINDOW,
+    SOURCE_LABELS,
+)
+
+
+def _entry(
+    timestamp: datetime,
+    action: str,
+    filename: str,
+    *,
+    size_bytes: int = 1000,
+    run_id: str = None,
+    run_source: str = "legacy",
+    users=None,
+) -> dict:
+    """Build a FileActivity-shaped dict for tests."""
+    return {
+        "timestamp": timestamp.isoformat(),
+        "time_display": timestamp.strftime("%H:%M:%S"),
+        "date_key": timestamp.date().isoformat(),
+        "date_display": "Today",
+        "action": action,
+        "filename": filename,
+        "size": f"{size_bytes} B",
+        "size_bytes": size_bytes,
+        "users": users or [],
+        "run_id": run_id,
+        "run_source": run_source,
+    }
+
+
+# Patch get_time_format to avoid touching settings.json during tests.
+@pytest.fixture(autouse=True)
+def _stub_time_format():
+    with patch("web.services.activity_grouping.get_time_format", return_value="24h"):
+        yield
+
+
+class TestEmpty:
+    def test_empty_input_returns_empty(self):
+        assert group_activity_into_runs([]) == []
+
+
+class TestRunIdBucketing:
+    def test_same_run_id_groups_together(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(minutes=2), "Cached", "b.mkv", run_id="abc", run_source="web"),
+            _entry(now + timedelta(minutes=1), "Cached", "a.mkv", run_id="abc", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert len(runs) == 1
+        assert runs[0]["run_id"] == "abc"
+        assert runs[0]["run_source"] == "web"
+        assert runs[0]["files_cached"] == 2
+
+    def test_different_run_ids_split(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(minutes=10), "Cached", "b.mkv", run_id="run2", run_source="web"),
+            _entry(now, "Cached", "a.mkv", run_id="run1", run_source="scheduled"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert len(runs) == 2
+        # Newest run first
+        assert runs[0]["run_id"] == "run2"
+        assert runs[1]["run_id"] == "run1"
+
+    def test_different_run_ids_within_legacy_window_still_split(self):
+        """Real runs separated by less than LEGACY_RUN_WINDOW must NOT merge."""
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(minutes=2), "Cached", "b.mkv", run_id="run2", run_source="web"),
+            _entry(now, "Cached", "a.mkv", run_id="run1", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert len(runs) == 2
+
+    def test_run_label_from_source(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now, "Cached", "a.mkv", run_id="r1", run_source="scheduled"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert runs[0]["label"] == SOURCE_LABELS["scheduled"]
+
+
+class TestLegacyBucketing:
+    def test_close_legacy_entries_cluster(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(minutes=5), "Cached", "b.mkv"),
+            _entry(now, "Cached", "a.mkv"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert len(runs) == 1
+        assert runs[0]["run_source"] == "legacy"
+        assert runs[0]["label"] == SOURCE_LABELS["legacy"]
+        assert runs[0]["files_cached"] == 2
+
+    def test_legacy_gap_beyond_window_splits(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + LEGACY_RUN_WINDOW + timedelta(minutes=1), "Cached", "b.mkv"),
+            _entry(now, "Cached", "a.mkv"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert len(runs) == 2
+
+    def test_legacy_run_id_stable_within_bucket(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(minutes=5), "Cached", "b.mkv"),
+            _entry(now, "Cached", "a.mkv"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert runs[0]["run_id"].startswith("legacy-")
+
+
+class TestShowGrouping:
+    def test_same_show_episodes_collapse(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=2), "Cached", "Entourage - S01E03 - Test.mkv", run_id="r1", run_source="web"),
+            _entry(now + timedelta(seconds=1), "Cached", "Entourage - S01E02 - Test.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "Entourage - S01E01 - Test.mkv", run_id="r1", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert len(runs) == 1
+        assert len(runs[0]["entries"]) == 1
+        group = runs[0]["entries"][0]
+        assert group.get("is_group") is True
+        assert group["show_name"] == "Entourage"
+        assert group["episode_count"] == 3
+
+    def test_movie_stays_singleton(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now, "Cached", "The Bourne Identity (2002).mkv", run_id="r1", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert runs[0]["entries"][0].get("is_group") is None
+        assert runs[0]["entries"][0]["filename"] == "The Bourne Identity (2002).mkv"
+
+    def test_single_episode_does_not_group(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now, "Cached", "Outlander - S08E07 - Evidence.mkv", run_id="r1", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        # Single episode passes through as a singleton, not a group of 1
+        assert runs[0]["entries"][0].get("is_group") is None
+
+
+class TestAggregates:
+    def test_byte_totals_per_action(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=2), "Restored", "r.mkv", size_bytes=2000, run_id="r1", run_source="web"),
+            _entry(now + timedelta(seconds=1), "Cached", "c2.mkv", size_bytes=500, run_id="r1", run_source="web"),
+            _entry(now, "Cached", "c1.mkv", size_bytes=1000, run_id="r1", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert runs[0]["files_cached"] == 2
+        assert runs[0]["files_restored"] == 1
+        assert runs[0]["bytes_cached"] == 1500
+        assert runs[0]["bytes_restored"] == 2000
+        assert runs[0]["bytes_total"] == 3500
+
+    def test_duration_seconds_from_start_to_completed(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=125), "Cached", "b.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "a.mkv", run_id="r1", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert runs[0]["duration_seconds"] == 125
+
+    def test_moved_to_array_counts_as_restored(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now, "Moved to Array", "a.mkv", run_id="r1", run_source="scheduled"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert runs[0]["files_restored"] == 1
+        assert runs[0]["files_cached"] == 0
+
+
+class TestOrdering:
+    def test_runs_returned_newest_first(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(hours=2), "Cached", "c.mkv", run_id="r3", run_source="web"),
+            _entry(now + timedelta(hours=1), "Cached", "b.mkv", run_id="r2", run_source="web"),
+            _entry(now, "Cached", "a.mkv", run_id="r1", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        assert [r["run_id"] for r in runs] == ["r3", "r2", "r1"]
+
+    def test_entries_within_run_newest_first(self):
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=10), "Cached", "newest.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "oldest.mkv", run_id="r1", run_source="web"),
+        ]
+        runs = group_activity_into_runs(activities)
+        # First entry should be the newer one
+        assert runs[0]["entries"][0]["filename"] == "newest.mkv"
+
+
+class TestMixedRunIdAndLegacy:
+    def test_real_run_breaks_legacy_window(self):
+        """A run_id-bearing entry between two legacy entries should split them."""
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(minutes=10), "Cached", "after.mkv"),  # legacy
+            _entry(now + timedelta(minutes=5), "Cached", "real.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "before.mkv"),  # legacy
+        ]
+        runs = group_activity_into_runs(activities)
+        # 3 buckets: legacy(after), real(r1), legacy(before)
+        assert len(runs) == 3
+        sources = [r["run_source"] for r in runs]
+        assert sources == ["legacy", "web", "legacy"]

--- a/tests/test_core_activity.py
+++ b/tests/test_core_activity.py
@@ -115,7 +115,11 @@ class TestFileActivity:
             )
             d = fa.to_dict()
 
-        required_keys = {'timestamp', 'time_display', 'date_key', 'date_display', 'action', 'filename', 'size', 'users'}
+        required_keys = {
+            'timestamp', 'time_display', 'date_key', 'date_display',
+            'action', 'filename', 'size', 'size_bytes', 'users',
+            'run_id', 'run_source',
+        }
         assert required_keys == set(d.keys())
 
 

--- a/tests/test_core_activity.py
+++ b/tests/test_core_activity.py
@@ -23,11 +23,13 @@ from core.activity import (
     record_file_activity,
     save_last_run_time,
     load_last_run_summary,
+    load_run_summaries,
+    load_run_summary,
     save_run_summary,
     MAX_RECENT_ACTIVITY,
     ACTIVITY_FILE,
     LAST_RUN_FILE,
-    LAST_RUN_SUMMARY_FILE,
+    RUN_SUMMARIES_FILE,
     _get_activity_retention_hours,
 )
 
@@ -395,48 +397,154 @@ class TestLastRunTime:
 # ============================================================================
 
 class TestRunSummary:
-    """Tests for save_run_summary() and load_last_run_summary()."""
+    """Tests for save_run_summary() / load_run_summaries() / load_last_run_summary()."""
 
-    def test_round_trip(self, tmp_path):
-        f = tmp_path / "last_run_summary.json"
+    @staticmethod
+    def _patch_files(tmp_path):
+        """Patch both the run-summaries file and the legacy migration file."""
+        return patch.multiple(
+            'core.activity',
+            RUN_SUMMARIES_FILE=tmp_path / "run_summaries.json",
+            _LEGACY_RUN_SUMMARY_FILE=tmp_path / "last_run_summary.json",
+        )
 
-        summary = {
+    def _summary(self, **overrides):
+        base = {
+            "run_source": "cli",
             "status": "completed",
-            "timestamp": datetime.now().isoformat(),
+            "started_at": datetime.now().isoformat(),
+            "completed_at": datetime.now().isoformat(),
+            "duration_seconds": 10.5,
             "files_cached": 3,
             "files_restored": 1,
             "bytes_cached": 1000,
             "bytes_restored": 500,
-            "duration_seconds": 10.5,
             "error_count": 0,
             "dry_run": False,
         }
+        base.update(overrides)
+        return base
 
-        with patch('core.activity.LAST_RUN_SUMMARY_FILE', f):
-            save_run_summary(summary)
+    def test_round_trip(self, tmp_path):
+        with self._patch_files(tmp_path):
+            save_run_summary("run-1", self._summary())
             loaded = load_last_run_summary()
 
         assert loaded is not None
+        assert loaded["run_id"] == "run-1"
         assert loaded["files_cached"] == 3
-        assert loaded["files_restored"] == 1
         assert loaded["status"] == "completed"
 
+    def test_save_run_summary_requires_run_id(self, tmp_path):
+        with self._patch_files(tmp_path):
+            save_run_summary("", self._summary())
+            assert load_last_run_summary() is None
+
+    def test_multiple_runs_keyed_by_id(self, tmp_path):
+        now = datetime.now()
+        with self._patch_files(tmp_path):
+            save_run_summary("run-1", self._summary(
+                started_at=(now - timedelta(minutes=10)).isoformat(),
+                files_cached=1,
+            ))
+            save_run_summary("run-2", self._summary(
+                started_at=now.isoformat(),
+                files_cached=5,
+            ))
+            summaries = load_run_summaries()
+
+        assert set(summaries.keys()) == {"run-1", "run-2"}
+        assert summaries["run-1"]["files_cached"] == 1
+        assert summaries["run-2"]["files_cached"] == 5
+
+    def test_load_run_summary_by_id(self, tmp_path):
+        with self._patch_files(tmp_path):
+            save_run_summary("run-1", self._summary())
+            assert load_run_summary("run-1") is not None
+            assert load_run_summary("missing") is None
+
+    def test_load_last_run_summary_excludes_maintenance_by_default(self, tmp_path):
+        now = datetime.now()
+        with self._patch_files(tmp_path):
+            # Older caching run, newer maintenance run
+            save_run_summary("cli-1", self._summary(
+                run_source="cli",
+                started_at=(now - timedelta(minutes=10)).isoformat(),
+            ))
+            save_run_summary("maint-1", self._summary(
+                run_source="maintenance",
+                started_at=now.isoformat(),
+            ))
+            loaded = load_last_run_summary()
+
+        # Even though maintenance is newer, the dashboard widget should
+        # surface the most recent caching run.
+        assert loaded is not None
+        assert loaded["run_id"] == "cli-1"
+
+    def test_load_last_run_summary_can_include_all_sources(self, tmp_path):
+        now = datetime.now()
+        with self._patch_files(tmp_path):
+            save_run_summary("cli-1", self._summary(
+                run_source="cli",
+                started_at=(now - timedelta(minutes=10)).isoformat(),
+            ))
+            save_run_summary("maint-1", self._summary(
+                run_source="maintenance",
+                started_at=now.isoformat(),
+            ))
+            loaded = load_last_run_summary(run_sources=())
+
+        assert loaded["run_id"] == "maint-1"
+
+    def test_retention_prunes_old_summaries(self, tmp_path):
+        old = datetime.now() - timedelta(hours=48)
+        with self._patch_files(tmp_path):
+            save_run_summary("ancient", self._summary(
+                started_at=old.isoformat(),
+                completed_at=old.isoformat(),
+            ))
+            save_run_summary("fresh", self._summary())
+            with patch('core.activity._get_activity_retention_hours', return_value=24):
+                summaries = load_run_summaries()
+
+        assert "ancient" not in summaries
+        assert "fresh" in summaries
+
+    def test_legacy_migration(self, tmp_path):
+        legacy_file = tmp_path / "last_run_summary.json"
+        new_file = tmp_path / "run_summaries.json"
+        legacy_payload = {
+            "status": "completed",
+            "timestamp": datetime.now().isoformat(),
+            "files_cached": 7,
+            "duration_seconds": 42.0,
+        }
+        legacy_file.write_text(json.dumps(legacy_payload, indent=2))
+
+        with patch.multiple(
+            'core.activity',
+            RUN_SUMMARIES_FILE=new_file,
+            _LEGACY_RUN_SUMMARY_FILE=legacy_file,
+        ):
+            summaries = load_run_summaries()
+
+        assert len(summaries) == 1
+        only_entry = next(iter(summaries.values()))
+        assert only_entry["files_cached"] == 7
+        assert only_entry["run_source"] == "legacy"
+        # Legacy file removed after migration
+        assert not legacy_file.exists()
+
     def test_missing_file_returns_none(self, tmp_path):
-        f = tmp_path / "nope.json"
-
-        with patch('core.activity.LAST_RUN_SUMMARY_FILE', f):
-            result = load_last_run_summary()
-
-        assert result is None
+        with self._patch_files(tmp_path):
+            assert load_last_run_summary() is None
 
     def test_malformed_json_returns_none(self, tmp_path):
-        f = tmp_path / "summary.json"
+        f = tmp_path / "run_summaries.json"
         f.write_text("{ not valid }")
-
-        with patch('core.activity.LAST_RUN_SUMMARY_FILE', f):
-            result = load_last_run_summary()
-
-        assert result is None
+        with self._patch_files(tmp_path):
+            assert load_last_run_summary() is None
 
 
 # ============================================================================

--- a/tests/test_maintenance_runner.py
+++ b/tests/test_maintenance_runner.py
@@ -403,3 +403,103 @@ class TestOperationRunnerMutualExclusion:
                 # Clean up state
                 with runner._lock:
                     runner._state = runner._state.__class__("idle")
+
+
+# ============================================================================
+# MaintenanceRunner - merge_into_queued
+# ============================================================================
+
+class TestMergeIntoQueued:
+    """Coalesce paths into a queued action of the same name.
+
+    Used by rapid-unpin path so 7+ × clicks don't overflow the queue.
+    """
+
+    def _enqueue(self, runner, action_name, paths):
+        """Helper: enqueue an action with a path list as method_args[0]."""
+        return runner.enqueue_action(
+            action_name=action_name,
+            service_method=lambda **kwargs: ActionResult(success=True),
+            method_args=(list(paths),),
+            method_kwargs={"dry_run": False},
+            file_count=len(paths),
+        )
+
+    def test_returns_false_when_queue_empty(self):
+        runner = MaintenanceRunner()
+        assert runner.merge_into_queued("evict-files", ["/a", "/b"]) is False
+
+    def test_returns_false_when_no_matching_action_in_queue(self):
+        runner = MaintenanceRunner()
+        self._enqueue(runner, "sync-to-array", ["/x"])
+        assert runner.merge_into_queued("evict-files", ["/a"]) is False
+        # Queue unchanged
+        assert runner.queue_count == 1
+        assert runner._queue[0].action_name == "sync-to-array"
+
+    def test_merges_into_matching_tail_item(self):
+        runner = MaintenanceRunner()
+        self._enqueue(runner, "evict-files", ["/a", "/b"])
+
+        merged = runner.merge_into_queued("evict-files", ["/c", "/d"])
+        assert merged is True
+        assert runner.queue_count == 1
+
+        item = runner._queue[0]
+        assert item.method_args[0] == ["/a", "/b", "/c", "/d"]
+        assert item.file_count == 4
+
+    def test_merges_into_tail_when_multiple_actions_queued(self):
+        """Merge target is the tail-most matching item, not the first."""
+        runner = MaintenanceRunner()
+        self._enqueue(runner, "evict-files", ["/a"])
+        self._enqueue(runner, "sync-to-array", ["/x"])
+        self._enqueue(runner, "evict-files", ["/b"])
+
+        merged = runner.merge_into_queued("evict-files", ["/c"])
+        assert merged is True
+
+        # First evict-files entry untouched
+        assert runner._queue[0].method_args[0] == ["/a"]
+        # Tail evict-files absorbed the new path
+        assert runner._queue[2].method_args[0] == ["/b", "/c"]
+        assert runner._queue[2].file_count == 2
+
+    def test_dedupes_paths_already_in_queue(self):
+        runner = MaintenanceRunner()
+        self._enqueue(runner, "evict-files", ["/a", "/b"])
+
+        merged = runner.merge_into_queued("evict-files", ["/b", "/c"])
+        assert merged is True
+
+        item = runner._queue[0]
+        assert item.method_args[0] == ["/a", "/b", "/c"]  # /b not duplicated
+        assert item.file_count == 3
+
+    def test_returns_true_when_all_paths_already_queued(self):
+        """Caller treats this as success — no fallback enqueue needed."""
+        runner = MaintenanceRunner()
+        self._enqueue(runner, "evict-files", ["/a", "/b"])
+
+        merged = runner.merge_into_queued("evict-files", ["/a", "/b"])
+        assert merged is True
+        assert runner._queue[0].file_count == 2  # unchanged
+
+    def test_returns_false_when_paths_empty(self):
+        runner = MaintenanceRunner()
+        self._enqueue(runner, "evict-files", ["/a"])
+        assert runner.merge_into_queued("evict-files", []) is False
+        assert runner._queue[0].file_count == 1
+
+    def test_does_not_merge_when_method_args_lacks_path_list(self):
+        """Defensive: skip items whose first arg isn't a list."""
+        runner = MaintenanceRunner()
+        # Manually queue an item with a non-list first arg
+        runner.enqueue_action(
+            action_name="evict-files",
+            service_method=lambda **kwargs: ActionResult(success=True),
+            method_args=("not-a-list",),
+            method_kwargs={},
+            file_count=0,
+        )
+        assert runner.merge_into_queued("evict-files", ["/a"]) is False

--- a/tests/test_operations_activity_route.py
+++ b/tests/test_operations_activity_route.py
@@ -1,0 +1,213 @@
+"""Route test for GET /operations/activity (run-grouped Recent Activity).
+
+Verifies the endpoint returns the HTMX partial with run headers, member rows,
+and proper data attributes for the dashboard's run-grouped view.
+
+Test isolation: earlier tests sometimes replace ``web.config`` in
+``sys.modules`` with a MagicMock. Force-reload affected modules so route
+tests run against the real Jinja2Templates instance.
+"""
+
+import sys
+import importlib
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _force_real_modules():
+    mocked_names = [
+        "web.config",
+        "web.routers",
+        "web.routers.operations",
+        "web.services",
+        "web.services.activity_grouping",
+        "web",
+    ]
+    for name in mocked_names:
+        mod = sys.modules.get(name)
+        if isinstance(mod, MagicMock):
+            del sys.modules[name]
+    import web  # noqa: F401
+    import web.config  # noqa: F401
+    import web.routers.operations  # noqa: F401
+    import web.services.activity_grouping  # noqa: F401
+
+
+_force_real_modules()
+
+
+def _activity_dict(timestamp, action, filename, *, size_bytes=1000, run_id=None, run_source="legacy"):
+    return {
+        "timestamp": timestamp.isoformat(),
+        "time_display": timestamp.strftime("%H:%M:%S"),
+        "date_key": timestamp.date().isoformat(),
+        "date_display": "Today",
+        "action": action,
+        "filename": filename,
+        "size": f"{size_bytes} B",
+        "size_bytes": size_bytes,
+        "users": [],
+        "run_id": run_id,
+        "run_source": run_source,
+        "associated_files": [],
+    }
+
+
+@pytest.fixture
+def client():
+    """Mount only the operations router on a minimal FastAPI app."""
+    from web.routers import operations as operations_router
+
+    app = FastAPI()
+    app.include_router(operations_router.router, prefix="/operations")
+    return TestClient(app)
+
+
+class TestActivityEndpoint:
+    def test_empty_activity_renders_empty_state(self, client):
+        # Patch both the runner's recent_activity property and the auxiliary services
+        fake_runner = MagicMock()
+        fake_runner.recent_activity = []
+        fake_settings = MagicMock()
+        fake_settings.check_plex_connection.return_value = True
+        fake_settings.get_last_run_time.return_value = None
+        fake_cache = MagicMock()
+        fake_cache.get_user_types.return_value = {}
+
+        with patch("web.routers.operations.get_operation_runner", return_value=fake_runner), \
+             patch("web.services.get_settings_service", return_value=fake_settings), \
+             patch("web.services.get_cache_service", return_value=fake_cache):
+            r = client.get("/operations/activity", headers={"HX-Request": "true"})
+
+        assert r.status_code == 200
+        # Empty state renders one of the three contextual messages
+        assert any(msg in r.text for msg in ["No recent activity", "Ready to go", "Set up your Plex"])
+
+    def test_grouped_run_renders_header_and_members(self, client):
+        now = datetime.now()
+        activities = [
+            _activity_dict(now + timedelta(seconds=2), "Cached", "Show - S01E02 - Test.mkv",
+                           run_id="abc", run_source="web"),
+            _activity_dict(now + timedelta(seconds=1), "Cached", "Show - S01E01 - Test.mkv",
+                           run_id="abc", run_source="web"),
+            _activity_dict(now, "Cached", "Movie.mkv", run_id="abc", run_source="web"),
+        ]
+        fake_runner = MagicMock()
+        fake_runner.recent_activity = activities
+        fake_cache = MagicMock()
+        fake_cache.get_user_types.return_value = {}
+
+        with patch("web.routers.operations.get_operation_runner", return_value=fake_runner), \
+             patch("web.services.get_cache_service", return_value=fake_cache):
+            r = client.get("/operations/activity", headers={"HX-Request": "true"})
+
+        assert r.status_code == 200
+        # Run header is present with the right run_id and source
+        assert 'data-run-id="abc"' in r.text
+        assert 'data-run-source="web"' in r.text
+        assert "Web UI Run" in r.text
+        # Show grouping collapsed two episodes — group badge "2 eps" appears
+        assert "2 eps" in r.text
+        # Movie singleton is rendered too
+        assert "Movie.mkv" in r.text
+        # Stat pill for cached files (3 cached total)
+        assert "3 cached" in r.text
+
+    def test_separate_runs_get_separate_headers(self, client):
+        now = datetime.now()
+        activities = [
+            _activity_dict(now + timedelta(minutes=10), "Cached", "later.mkv",
+                           run_id="run-2", run_source="scheduled"),
+            _activity_dict(now, "Restored", "earlier.mkv",
+                           run_id="run-1", run_source="cli"),
+        ]
+        fake_runner = MagicMock()
+        fake_runner.recent_activity = activities
+        fake_cache = MagicMock()
+        fake_cache.get_user_types.return_value = {}
+
+        with patch("web.routers.operations.get_operation_runner", return_value=fake_runner), \
+             patch("web.services.get_cache_service", return_value=fake_cache):
+            r = client.get("/operations/activity", headers={"HX-Request": "true"})
+
+        assert r.status_code == 200
+        assert 'data-run-id="run-2"' in r.text
+        assert 'data-run-id="run-1"' in r.text
+        assert "Scheduled Run" in r.text
+        assert "CLI Run" in r.text
+
+    def test_newest_run_starts_open(self, client):
+        now = datetime.now()
+        activities = [
+            _activity_dict(now + timedelta(minutes=5), "Cached", "a.mkv",
+                           run_id="newer", run_source="web"),
+            _activity_dict(now, "Cached", "b.mkv",
+                           run_id="older", run_source="web"),
+        ]
+        fake_runner = MagicMock()
+        fake_runner.recent_activity = activities
+        fake_cache = MagicMock()
+        fake_cache.get_user_types.return_value = {}
+
+        with patch("web.routers.operations.get_operation_runner", return_value=fake_runner), \
+             patch("web.services.get_cache_service", return_value=fake_cache):
+            r = client.get("/operations/activity", headers={"HX-Request": "true"})
+
+        # The newer run header has class "is-open"; older does not
+        # (Look for the opening segment of each run header)
+        newer_idx = r.text.find('data-run-id="newer"')
+        older_idx = r.text.find('data-run-id="older"')
+        assert newer_idx != -1 and older_idx != -1
+        # Backtrack to find the class on the <tr> opening for "newer"
+        newer_tr_start = r.text.rfind("<tr", 0, newer_idx)
+        newer_tr = r.text[newer_tr_start:newer_idx]
+        assert "is-open" in newer_tr
+
+        older_tr_start = r.text.rfind("<tr", 0, older_idx)
+        older_tr = r.text[older_tr_start:older_idx]
+        assert "is-open" not in older_tr
+
+    def test_legacy_entries_bucket_into_previous_activity(self, client):
+        """Entries without run_id should appear under a 'Previous Activity' bucket."""
+        now = datetime.now()
+        activities = [
+            _activity_dict(now, "Cached", "old.mkv"),  # no run_id, run_source=legacy
+        ]
+        fake_runner = MagicMock()
+        fake_runner.recent_activity = activities
+        fake_cache = MagicMock()
+        fake_cache.get_user_types.return_value = {}
+
+        with patch("web.routers.operations.get_operation_runner", return_value=fake_runner), \
+             patch("web.services.get_cache_service", return_value=fake_cache):
+            r = client.get("/operations/activity", headers={"HX-Request": "true"})
+
+        assert r.status_code == 200
+        assert "Previous Activity" in r.text
+
+    def test_json_response_when_not_htmx(self, client):
+        """Non-HTMX requests get JSON with both raw activity and grouped runs."""
+        now = datetime.now()
+        activities = [
+            _activity_dict(now, "Cached", "a.mkv", run_id="r1", run_source="web"),
+        ]
+        fake_runner = MagicMock()
+        fake_runner.recent_activity = activities
+        fake_cache = MagicMock()
+        fake_cache.get_user_types.return_value = {}
+
+        with patch("web.routers.operations.get_operation_runner", return_value=fake_runner), \
+             patch("web.services.get_cache_service", return_value=fake_cache):
+            r = client.get("/operations/activity")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert "activity" in body
+        assert "runs" in body
+        assert len(body["runs"]) == 1
+        assert body["runs"][0]["run_id"] == "r1"
+        assert body["runs"][0]["files_cached"] == 1

--- a/tests/test_pinned_service.py
+++ b/tests/test_pinned_service.py
@@ -535,9 +535,42 @@ class TestUnpinMany:
         svc._tracker.add_pin("100", "movie", "Matrix")
         before = svc.resolve_all_to_cache_paths()
         assert "/mnt/cache/media/Movies/Matrix.mkv" in before
-        result = svc.unpin_many(["100"])
+        # evict_paths now filters to paths actually on cache, so pretend the
+        # diff hit exists on disk for this test.
+        with patch(
+            "web.services.pinned_service.os.path.exists",
+            lambda p: p == "/mnt/cache/media/Movies/Matrix.mkv",
+        ):
+            result = svc.unpin_many(["100"])
         # Freshly-released cache path must appear in evict_paths
         assert "/mnt/cache/media/Movies/Matrix.mkv" in result["evict_paths"]
+
+    def test_evict_paths_filters_paths_not_on_cache(self, service_with_plex):
+        # Pinning items but never running "Cache Pinned Now", then unpinning,
+        # used to hand the maintenance runner a non-empty evict list and spin
+        # up an empty eviction. evict_paths must now be empty when nothing is
+        # actually on cache.
+        svc = service_with_plex
+        svc._tracker.add_pin("100", "movie", "Matrix")
+        with patch(
+            "web.services.pinned_service.os.path.exists",
+            lambda p: False,
+        ):
+            result = svc.unpin_many(["100"])
+        assert result["removed"] == 1
+        assert result["evict_paths"] == []
+
+    def test_toggle_unpin_filters_paths_not_on_cache(self, service_with_plex):
+        # Same guarantee as above, via the single-pin toggle path.
+        svc = service_with_plex
+        svc._tracker.add_pin("100", "movie", "Matrix")
+        with patch(
+            "web.services.pinned_service.os.path.exists",
+            lambda p: False,
+        ):
+            result = svc.toggle_pin("100", "movie", "Matrix")
+        assert result["is_pinned"] is False
+        assert result["evict_paths"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/web/routers/operations.py
+++ b/web/routers/operations.py
@@ -169,18 +169,21 @@ def get_status(request: Request):
 
 @router.get("/activity")
 def get_recent_activity(request: Request):
-    """Get recent file activity from operations"""
+    """Get recent file activity from operations, bucketed by run."""
     from web.services import get_settings_service
+    from web.services.activity_grouping import group_activity_into_runs
 
     runner = get_operation_runner()
     activity = runner.recent_activity
+    runs = group_activity_into_runs(activity)
 
     is_htmx = request.headers.get("HX-Request") == "true"
 
     if is_htmx:
         from web.services import get_cache_service
         context = {
-            "activity": activity,
+            "runs": runs,
+            "activity": activity,  # kept for empty-state branches
             "user_types": get_cache_service().get_user_types(),
         }
         # Pass extra context when activity is empty for contextual empty states
@@ -195,4 +198,4 @@ def get_recent_activity(request: Request):
             context
         )
 
-    return JSONResponse({"activity": activity})
+    return JSONResponse({"activity": activity, "runs": runs})

--- a/web/routers/pinned.py
+++ b/web/routers/pinned.py
@@ -118,8 +118,12 @@ def pinned_toggle(
 def _record_pin_activity(cache_paths: list) -> None:
     """Record a Cached activity entry for each pinned path that exists on cache."""
     import os
+    import uuid
     try:
         from core.activity import record_file_activity
+        # One run_id per pin batch so the dashboard groups all paths from a
+        # single pin operation together.
+        pin_run_id = uuid.uuid4().hex
         for path in cache_paths:
             try:
                 if not os.path.exists(path):
@@ -131,6 +135,8 @@ def _record_pin_activity(cache_paths: list) -> None:
                 action="Cached",
                 filename=os.path.basename(path),
                 size_bytes=size_bytes,
+                run_id=pin_run_id,
+                run_source="web",
             )
     except Exception as e:
         logger.warning("Pin activity could not be recorded: %s", e)

--- a/web/routers/pinned.py
+++ b/web/routers/pinned.py
@@ -165,7 +165,13 @@ def _start_unpin_eviction(cache_paths: list) -> bool:
         )
         if started:
             return True
-        # Runner is busy; queue if there's room, otherwise give up quietly.
+        # Runner is busy. Try to merge into an existing queued evict-files
+        # first so rapid unpin clicks coalesce into one batch instead of
+        # filling the queue with sibling jobs (and getting silently dropped
+        # at queue overflow).
+        if runner.merge_into_queued("evict-files", cache_paths):
+            return True
+        # No compatible tail item — enqueue normally if there's room.
         if runner.queue_count < runner._max_queue_size:
             item_id = runner.enqueue_action(
                 action_name="evict-files",

--- a/web/services/activity_grouping.py
+++ b/web/services/activity_grouping.py
@@ -1,0 +1,186 @@
+"""Run-grouped Recent Activity transformation.
+
+Pure render-layer two-pass transformation over the per-file activity feed:
+
+  1. Bucket entries by ``run_id`` (entries without one — pre-upgrade or
+     manually-recorded — fall back to 15-minute time-window clusters so the
+     dashboard still has a coherent grouping during the retention overlap).
+  2. Within each bucket, apply ``group_episodes_by_show()`` so multi-episode
+     TV runs collapse under a single parent row.
+
+The on-disk activity file shape is unchanged; this transformation runs on
+each ``GET /operations/activity`` request.
+"""
+
+from datetime import datetime, timedelta
+from typing import List, Dict, Optional
+
+from core.activity import group_episodes_by_show, get_time_format
+from core.system_utils import format_bytes, format_duration
+
+
+# Time gap that splits adjacent legacy entries into separate buckets.
+# Picked to match the typical scheduled cadence (hourly) without merging
+# distinct manual runs that happen to land minutes apart.
+LEGACY_RUN_WINDOW = timedelta(minutes=15)
+
+# Actions that count toward the "restored" pill on the run header.
+RESTORE_ACTIONS = {"Restored", "Moved", "Moved to Array", "Restored Backup"}
+
+SOURCE_LABELS = {
+    "scheduled": "Scheduled Run",
+    "web": "Web UI Run",
+    "cli": "CLI Run",
+    "maintenance": "Maintenance Run",
+    "legacy": "Previous Activity",
+}
+
+
+def _format_time(dt: datetime, time_format: str) -> str:
+    """Portable time-of-day formatter (no strftime %-I, which fails on Windows)."""
+    if time_format == "12h":
+        hour = dt.hour % 12 or 12
+        suffix = "AM" if dt.hour < 12 else "PM"
+        return f"{hour}:{dt.minute:02d} {suffix}"
+    return dt.strftime("%H:%M")
+
+
+def _format_time_range(started: datetime, completed: datetime, time_format: str) -> str:
+    start_str = _format_time(started, time_format)
+    end_str = _format_time(completed, time_format)
+    if start_str == end_str:
+        return start_str
+    return f"{start_str} – {end_str}"
+
+
+def _format_date_display(dt: datetime) -> str:
+    today = datetime.now().date()
+    entry_date = dt.date()
+    if entry_date == today:
+        return "Today"
+    if entry_date == today - timedelta(days=1):
+        return "Yesterday"
+    return dt.strftime("%a, %b ") + str(dt.day)
+
+
+def group_activity_into_runs(
+    activities: List[dict],
+    legacy_window: timedelta = LEGACY_RUN_WINDOW,
+) -> List[dict]:
+    """Two-pass: bucket by run_id (legacy → time window), then per-bucket show grouping.
+
+    Args:
+        activities: List of ``FileActivity.to_dict()`` outputs, sorted newest-first.
+        legacy_window: Time gap that splits adjacent legacy entries into
+                       separate buckets (default 15 minutes).
+
+    Returns:
+        List of run-group dicts ordered newest-first, each shaped like::
+
+            {
+                "run_id": str,
+                "run_source": "scheduled" | "web" | "cli" | "maintenance" | "legacy",
+                "label": str,                # e.g. "Scheduled Run"
+                "started_at": isoformat,
+                "completed_at": isoformat,
+                "duration_seconds": float,
+                "duration_display": str,
+                "files_cached": int,
+                "files_restored": int,
+                "files_total": int,
+                "bytes_cached": int,
+                "bytes_restored": int,
+                "bytes_total": int,
+                "bytes_total_display": str,
+                "time_range": str,           # "10:24 – 10:27"
+                "date_key": "YYYY-MM-DD",
+                "date_display": str,         # "Today" / "Yesterday" / "Mon, Apr 23"
+                "entries": List[dict],       # show-grouped per-file entries
+            }
+    """
+    if not activities:
+        return []
+
+    time_format = get_time_format()
+
+    # Pass 1: bucket entries (iterate chronologically so legacy windows cluster correctly)
+    buckets: List[Dict] = []
+    current_bucket: Optional[Dict] = None
+    last_legacy_timestamp: Optional[datetime] = None
+    legacy_counter = 0
+
+    for entry in reversed(activities):
+        run_id = entry.get("run_id")
+        run_source = entry.get("run_source", "legacy") or "legacy"
+        timestamp = datetime.fromisoformat(entry["timestamp"])
+
+        if run_id:
+            key = ("run", run_id)
+            last_legacy_timestamp = None
+        else:
+            if last_legacy_timestamp is None or (timestamp - last_legacy_timestamp) > legacy_window:
+                legacy_counter += 1
+            last_legacy_timestamp = timestamp
+            key = ("legacy", legacy_counter)
+
+        if current_bucket is None or current_bucket["key"] != key:
+            current_bucket = {
+                "key": key,
+                "run_id": run_id or f"legacy-{legacy_counter}",
+                "run_source": run_source,
+                "entries": [entry],
+                "started_at": timestamp,
+                "completed_at": timestamp,
+            }
+            buckets.append(current_bucket)
+        else:
+            current_bucket["entries"].append(entry)
+            if timestamp < current_bucket["started_at"]:
+                current_bucket["started_at"] = timestamp
+            if timestamp > current_bucket["completed_at"]:
+                current_bucket["completed_at"] = timestamp
+
+    # Pass 2: per-bucket show grouping + run-level aggregates
+    result: List[dict] = []
+    for bucket in buckets:
+        # Sort bucket entries newest-first for the rendered view
+        sorted_entries = sorted(
+            bucket["entries"],
+            key=lambda e: datetime.fromisoformat(e["timestamp"]),
+            reverse=True,
+        )
+        grouped_entries = group_episodes_by_show(sorted_entries)
+
+        # Aggregates from raw entries (each file counts once, not per group)
+        files_cached = sum(1 for e in bucket["entries"] if e.get("action") == "Cached")
+        files_restored = sum(1 for e in bucket["entries"] if e.get("action") in RESTORE_ACTIONS)
+        bytes_cached = sum(e.get("size_bytes", 0) for e in bucket["entries"] if e.get("action") == "Cached")
+        bytes_restored = sum(e.get("size_bytes", 0) for e in bucket["entries"] if e.get("action") in RESTORE_ACTIONS)
+        total_bytes = sum(e.get("size_bytes", 0) for e in bucket["entries"])
+
+        duration = (bucket["completed_at"] - bucket["started_at"]).total_seconds()
+
+        result.append({
+            "run_id": bucket["run_id"],
+            "run_source": bucket["run_source"],
+            "label": SOURCE_LABELS.get(bucket["run_source"], "Activity"),
+            "started_at": bucket["started_at"].isoformat(),
+            "completed_at": bucket["completed_at"].isoformat(),
+            "duration_seconds": duration,
+            "duration_display": format_duration(duration) if duration > 0 else "",
+            "files_cached": files_cached,
+            "files_restored": files_restored,
+            "files_total": len(bucket["entries"]),
+            "bytes_cached": bytes_cached,
+            "bytes_restored": bytes_restored,
+            "bytes_total": total_bytes,
+            "bytes_total_display": format_bytes(total_bytes) if total_bytes > 0 else "",
+            "time_range": _format_time_range(bucket["started_at"], bucket["completed_at"], time_format),
+            "date_key": bucket["started_at"].date().isoformat(),
+            "date_display": _format_date_display(bucket["started_at"]),
+            "entries": grouped_entries,
+        })
+
+    # Newest run first (we built buckets chronologically)
+    result.reverse()
+    return result

--- a/web/services/activity_grouping.py
+++ b/web/services/activity_grouping.py
@@ -15,7 +15,7 @@ each ``GET /operations/activity`` request.
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 
-from core.activity import group_episodes_by_show, get_time_format
+from core.activity import group_episodes_by_show, get_time_format, load_run_summaries
 from core.system_utils import format_bytes, format_duration
 
 
@@ -102,6 +102,11 @@ def group_activity_into_runs(
         return []
 
     time_format = get_time_format()
+    # Run summaries (keyed by run_id) carry the *real* run start/end times —
+    # the period the script actually spent on Plex API + scanning + file
+    # moves. Without them we'd fall back to first/last FileActivity timestamp,
+    # which only covers the file-move window and misses the pre-/post-tail.
+    run_summaries = load_run_summaries()
 
     # Pass 1: bucket entries (iterate chronologically so legacy windows cluster correctly)
     buckets: List[Dict] = []
@@ -158,14 +163,28 @@ def group_activity_into_runs(
         bytes_restored = sum(e.get("size_bytes", 0) for e in bucket["entries"] if e.get("action") in RESTORE_ACTIONS)
         total_bytes = sum(e.get("size_bytes", 0) for e in bucket["entries"])
 
-        duration = (bucket["completed_at"] - bucket["started_at"]).total_seconds()
+        # Prefer summary-recorded times when available — they cover the full
+        # run, not just the first-to-last-file window.
+        summary = run_summaries.get(bucket["run_id"])
+        run_started_at = bucket["started_at"]
+        run_completed_at = bucket["completed_at"]
+        if summary:
+            try:
+                if summary.get("started_at"):
+                    run_started_at = datetime.fromisoformat(summary["started_at"])
+                if summary.get("completed_at"):
+                    run_completed_at = datetime.fromisoformat(summary["completed_at"])
+            except ValueError:
+                pass
+
+        duration = (run_completed_at - run_started_at).total_seconds()
 
         result.append({
             "run_id": bucket["run_id"],
             "run_source": bucket["run_source"],
             "label": SOURCE_LABELS.get(bucket["run_source"], "Activity"),
-            "started_at": bucket["started_at"].isoformat(),
-            "completed_at": bucket["completed_at"].isoformat(),
+            "started_at": run_started_at.isoformat(),
+            "completed_at": run_completed_at.isoformat(),
             "duration_seconds": duration,
             "duration_display": format_duration(duration) if duration > 0 else "",
             "files_cached": files_cached,
@@ -175,9 +194,9 @@ def group_activity_into_runs(
             "bytes_restored": bytes_restored,
             "bytes_total": total_bytes,
             "bytes_total_display": format_bytes(total_bytes) if total_bytes > 0 else "",
-            "time_range": _format_time_range(bucket["started_at"], bucket["completed_at"], time_format),
-            "date_key": bucket["started_at"].date().isoformat(),
-            "date_display": _format_date_display(bucket["started_at"]),
+            "time_range": _format_time_range(run_started_at, run_completed_at, time_format),
+            "date_key": run_started_at.date().isoformat(),
+            "date_display": _format_date_display(run_started_at),
             "entries": grouped_entries,
         })
 

--- a/web/services/maintenance_runner.py
+++ b/web/services/maintenance_runner.py
@@ -761,6 +761,39 @@ class MaintenanceRunner:
                 run_source="maintenance",
             )
 
+    def _save_run_summary(self, action_name: str, action_result: Optional[ActionResult]):
+        """Persist a run summary so the dashboard's Recent Activity grouping
+        can display real start/end times for maintenance runs alongside
+        cache and restore runs."""
+        if not self._run_id or not self._result:
+            return
+
+        from core.activity import save_run_summary
+
+        result = self._result
+        if result.error_message:
+            status = "failed"
+        elif self._stop_requested:
+            status = "stopped"
+        else:
+            status = "completed"
+
+        affected_count = action_result.affected_count if action_result else 0
+        error_count = len(action_result.errors) if action_result else 0
+
+        save_run_summary(self._run_id, {
+            "run_source": "maintenance",
+            "status": status,
+            "started_at": result.started_at.isoformat() if result.started_at else datetime.now().isoformat(),
+            "completed_at": result.completed_at.isoformat() if result.completed_at else datetime.now().isoformat(),
+            "duration_seconds": round(result.duration_seconds, 1),
+            "action_name": action_name,
+            "action_display": ACTION_HISTORY_LABELS.get(action_name, action_name),
+            "affected_count": affected_count,
+            "error_count": error_count,
+            "dry_run": False,
+        })
+
     def _record_history(self, action_name: str, action_result: Optional[ActionResult]):
         """Record this action to the persistent maintenance history."""
         try:
@@ -864,6 +897,12 @@ class MaintenanceRunner:
 
             # Record to persistent history
             self._record_history(action_name, action_result)
+
+            # Persist run summary for the dashboard's Recent Activity grouping
+            try:
+                self._save_run_summary(action_name, action_result)
+            except Exception as e:
+                logger.error(f"Failed to save maintenance run summary: {e}")
 
             # Call on_complete callback (e.g., cache invalidation)
             if on_complete:

--- a/web/services/maintenance_runner.py
+++ b/web/services/maintenance_runner.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Optional, Callable, Any, List
+from typing import Optional, Callable, Any, Dict, List
 from dataclasses import dataclass, field
 
 from web.services.maintenance_service import ActionResult
@@ -307,6 +307,11 @@ class MaintenanceRunner:
         # Run grouping: minted at start_action(), attached to every FileActivity
         # so the dashboard's run-grouped Recent Activity view can bucket entries.
         self._run_id: Optional[str] = None
+        # Pre-action size snapshot: many maintenance actions delete/move the
+        # affected files, so post-action `os.path.getsize` returns 0. Capture
+        # sizes up front (input paths always exist at start) so the activity
+        # feed shows real sizes for "Restored", "Moved to Array", etc.
+        self._path_sizes: Dict[str, int] = {}
 
     @property
     def state(self) -> MaintenanceState:
@@ -370,6 +375,7 @@ class MaintenanceRunner:
             self._state = MaintenanceState.RUNNING
             self._stop_requested = False
             self._run_id = uuid.uuid4().hex
+            self._path_sizes = self._snapshot_path_sizes(method_args, method_kwargs)
 
             display = ACTION_DISPLAY.get(action_name, "Running maintenance action...")
             display = display.format(count=file_count)
@@ -639,6 +645,51 @@ class MaintenanceRunner:
         "cache-pinned": "Cached",
     }
 
+    @staticmethod
+    def _snapshot_path_sizes(method_args: tuple, method_kwargs: dict) -> Dict[str, int]:
+        """Record sizes of input file paths before the action runs.
+
+        Most maintenance actions take the path list as the first positional
+        arg or a `paths`/`cache_paths` kwarg; the files always exist at
+        start (else the action couldn't operate on them). Sampling here
+        gives us authoritative sizes for the activity feed even after the
+        files are deleted, renamed, or moved by the action.
+        """
+        candidates = []
+        if method_args and isinstance(method_args[0], list):
+            candidates = method_args[0]
+        else:
+            for key in ("paths", "cache_paths"):
+                value = (method_kwargs or {}).get(key)
+                if isinstance(value, list):
+                    candidates = value
+                    break
+
+        sizes: Dict[str, int] = {}
+        for path in candidates:
+            if not isinstance(path, str):
+                continue
+            try:
+                sizes[path] = os.path.getsize(path)
+            except OSError:
+                pass
+        return sizes
+
+    def _resolve_size_for_activity(self, path: str) -> int:
+        """Look up the file's size, preferring the pre-action snapshot.
+
+        Falls back to a live `os.path.getsize` for actions that don't pass
+        the path list as an arg (e.g. `cache-pinned` resolves its own
+        targets internally — the cache file exists post-action there).
+        """
+        size = self._path_sizes.get(path, 0)
+        if size:
+            return size
+        try:
+            return os.path.getsize(path)
+        except OSError:
+            return 0
+
     def _record_maintenance_activity(self, action_name: str, action_result: ActionResult):
         """Record maintenance file operations to the shared activity feed."""
         if not action_result or not action_result.affected_paths:
@@ -652,11 +703,7 @@ class MaintenanceRunner:
 
         for path in action_result.affected_paths:
             filename = os.path.basename(path)
-            # Try to get file size (file may be gone after delete/move)
-            try:
-                size_bytes = os.path.getsize(path)
-            except OSError:
-                size_bytes = 0
+            size_bytes = self._resolve_size_for_activity(path)
 
             record_file_activity(
                 action=label,

--- a/web/services/maintenance_runner.py
+++ b/web/services/maintenance_runner.py
@@ -304,6 +304,9 @@ class MaintenanceRunner:
         self._queue_paused = False
         self._dequeue_timer: Optional[threading.Timer] = None
         self._countdown_started_at: Optional[datetime] = None
+        # Run grouping: minted at start_action(), attached to every FileActivity
+        # so the dashboard's run-grouped Recent Activity view can bucket entries.
+        self._run_id: Optional[str] = None
 
     @property
     def state(self) -> MaintenanceState:
@@ -366,6 +369,7 @@ class MaintenanceRunner:
 
             self._state = MaintenanceState.RUNNING
             self._stop_requested = False
+            self._run_id = uuid.uuid4().hex
 
             display = ACTION_DISPLAY.get(action_name, "Running maintenance action...")
             display = display.format(count=file_count)
@@ -658,6 +662,8 @@ class MaintenanceRunner:
                 action=label,
                 filename=filename,
                 size_bytes=size_bytes,
+                run_id=self._run_id,
+                run_source="maintenance",
             )
 
     def _record_history(self, action_name: str, action_result: Optional[ActionResult]):

--- a/web/services/maintenance_runner.py
+++ b/web/services/maintenance_runner.py
@@ -526,6 +526,54 @@ class MaintenanceRunner:
             logger.info(f"Queued maintenance action: {display_name} (#{len(self._queue)})")
             return item_id
 
+    def merge_into_queued(self, action_name: str, additional_paths: List[str]) -> bool:
+        """Append paths to the tail-most queued action of the same name.
+
+        Used when a caller would otherwise create a near-duplicate queue
+        entry (e.g. rapid unpin clicks each spawning their own evict-files
+        job). Merging keeps the queue from filling up with sibling jobs
+        and removes the 10-second countdown gap between each.
+
+        Only merges into queued items, never the currently running action
+        (its path list is being iterated by the service). The merged
+        action keeps the original `max_workers` / `on_complete` /
+        `method_kwargs` — only the path list and `file_count` change.
+
+        Returns True if merged, False if no compatible queue tail item
+        exists (caller should fall back to `enqueue_action`).
+        """
+        if not additional_paths:
+            return False
+
+        with self._lock:
+            for item in reversed(self._queue):
+                if item.action_name != action_name:
+                    continue
+                if not item.method_args or not isinstance(item.method_args[0], list):
+                    continue
+
+                existing = list(item.method_args[0])
+                existing_set = set(existing)
+                added = 0
+                for p in additional_paths:
+                    if p not in existing_set:
+                        existing.append(p)
+                        existing_set.add(p)
+                        added += 1
+
+                if added == 0:
+                    return True  # All paths already in queue — caller can stop
+
+                item.method_args = (existing,) + item.method_args[1:]
+                item.file_count = len(existing)
+                logger.info(
+                    f"Merged {added} path(s) into queued action: {item.display_name} "
+                    f"(now {item.file_count} file(s))"
+                )
+                return True
+
+            return False
+
     def remove_from_queue(self, item_id: str) -> bool:
         """Remove an item from the queue by ID."""
         with self._lock:

--- a/web/services/operation_runner.py
+++ b/web/services/operation_runner.py
@@ -32,7 +32,7 @@ from core.activity import (
     MAX_RECENT_ACTIVITY,
     ACTIVITY_FILE,
     LAST_RUN_FILE,
-    LAST_RUN_SUMMARY_FILE,
+    RUN_SUMMARIES_FILE,
     _activity_file_lock,
     _load_activity_unlocked,
     _save_activity_unlocked,
@@ -631,20 +631,22 @@ class OperationRunner:
     def _save_last_run_summary(self):
         """Save a summary of the completed operation to disk."""
         result = self._current_result
-        if not result:
+        if not result or not self._run_id:
             return
         summary = {
+            "run_source": self._run_source,
             "status": result.state.value,
-            "timestamp": datetime.now().isoformat(),
+            "started_at": result.started_at.isoformat() if result.started_at else datetime.now().isoformat(),
+            "completed_at": result.completed_at.isoformat() if result.completed_at else datetime.now().isoformat(),
+            "duration_seconds": round(result.duration_seconds, 1),
             "files_cached": result.files_cached,
             "files_restored": result.files_restored,
             "bytes_cached": result.bytes_cached,
             "bytes_restored": result.bytes_restored,
-            "duration_seconds": round(result.duration_seconds, 1),
             "error_count": result.error_count,
             "dry_run": result.dry_run,
         }
-        save_run_summary(summary)
+        save_run_summary(self._run_id, summary)
 
     @property
     def state(self) -> OperationState:

--- a/web/services/operation_runner.py
+++ b/web/services/operation_runner.py
@@ -7,6 +7,7 @@ import os
 import re
 import threading
 import time
+import uuid
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
@@ -27,6 +28,7 @@ from core.activity import (
     load_last_run_summary,
     save_run_summary,
     record_file_activity,
+    group_episodes_by_show,
     MAX_RECENT_ACTIVITY,
     ACTIVITY_FILE,
     LAST_RUN_FILE,
@@ -122,6 +124,10 @@ class OperationRunner:
         self._stop_requested = False  # Flag to signal operation should stop
         self._app_instance: Optional["PlexCacheApp"] = None  # Reference to running app
         self._current_run_files: List[dict] = []  # Files processed in current run only
+        # Run grouping: minted at start_operation(), attached to every FileActivity
+        # so the dashboard's run-grouped Recent Activity view can bucket entries.
+        self._run_id: Optional[str] = None
+        self._run_source: str = "web"  # "web" | "scheduled"
         # Track current operation type based on headers
         self._current_operation: Optional[str] = None
         # Patterns to match file operation headers and content
@@ -528,7 +534,7 @@ class OperationRunner:
             "error_count": log_state["error_count"],
             "error_messages": log_state["error_messages"][:5],
             "was_stopped": False,
-            "recent_files": self._group_episodes_by_show(log_state["recent_files"])[:15],
+            "recent_files": group_episodes_by_show(log_state["recent_files"])[:15],
             "message": message,
         }
 
@@ -818,7 +824,9 @@ class OperationRunner:
                 action=action,
                 filename=filename,
                 size_bytes=size_bytes,
-                users=users
+                users=users,
+                run_id=self._run_id,
+                run_source=self._run_source,
             )
             with self._lock:
                 self._recent_activity.insert(0, activity)
@@ -880,13 +888,16 @@ class OperationRunner:
             if queue in self._subscribers:
                 self._subscribers.remove(queue)
 
-    def start_operation(self, dry_run: bool = False, verbose: bool = False) -> bool:
+    def start_operation(self, dry_run: bool = False, verbose: bool = False, source: str = "web") -> bool:
         """
         Start a PlexCache operation in a background thread.
 
         Args:
             dry_run: If True, simulate without moving files
             verbose: If True, enable DEBUG level logging
+            source: Trigger origin for run grouping — "web" (manual UI button) or
+                    "scheduled" (APScheduler). Stored on every FileActivity for
+                    the dashboard's run-grouped Recent Activity view.
 
         Returns:
             True if operation started, False if already running or maintenance is running
@@ -912,6 +923,10 @@ class OperationRunner:
             self._stop_requested = False  # Reset stop flag for new operation
             self._app_instance = None  # Clear previous app reference
             self._current_run_files = []  # Reset per-run file list
+            # Mint a run_id for this operation; every FileActivity emitted from
+            # the log-parser path will carry it so the dashboard can group them.
+            self._run_id = uuid.uuid4().hex
+            self._run_source = source
             # Activity stacks across runs (not cleared) - capped at _max_recent_activity
             self._current_operation = None
             self._current_result = OperationResult(
@@ -1218,72 +1233,9 @@ class OperationRunner:
         if merged_indices:
             self._current_run_files = [f for i, f in enumerate(self._current_run_files) if i not in merged_indices]
 
-    # Matches "<show> - S##E##" — the Sonarr/Plex TV naming convention.
-    # Non-TV files (movies, specials without episode numbering) don't match
-    # and pass through as singletons.
-    _SHOW_EPISODE_PATTERN = re.compile(r'^(.+?) - S\d+E\d+', re.IGNORECASE)
-
-    def _group_episodes_by_show(self, files: List[dict]) -> List[dict]:
-        """Collapse multi-episode TV runs into a single parent row per show.
-
-        Movies and shows with only one episode in the payload stay as
-        individual rows (grouping a single entry offers no compression).
-        Preserves first-seen order so the banner doesn't reshuffle on re-render.
-        """
-        groups: Dict[tuple, dict] = {}
-        order: List[tuple] = []
-
-        for idx, f in enumerate(files):
-            match = self._SHOW_EPISODE_PATTERN.match(f.get("filename", ""))
-            if match:
-                show_name = match.group(1).strip()
-                key = (f.get("action", ""), show_name)
-                if key not in groups:
-                    groups[key] = {
-                        "action": f.get("action", ""),
-                        "show_name": show_name,
-                        "episodes": [],
-                        "total_bytes": 0,
-                    }
-                    order.append(key)
-                groups[key]["episodes"].append({
-                    "filename": f.get("filename", ""),
-                    "size": f.get("size", ""),
-                    "size_bytes": f.get("size_bytes", 0),
-                    "associated_files": f.get("associated_files", []),
-                })
-                groups[key]["total_bytes"] += f.get("size_bytes", 0)
-            else:
-                key = ("__singleton__", idx)
-                groups[key] = f
-                order.append(key)
-
-        result: List[dict] = []
-        for key in order:
-            entry = groups[key]
-            if key[0] == "__singleton__":
-                result.append(entry)
-            elif len(entry["episodes"]) == 1:
-                ep = entry["episodes"][0]
-                result.append({
-                    "action": entry["action"],
-                    "filename": ep["filename"],
-                    "size": ep.get("size", ""),
-                    "size_bytes": ep.get("size_bytes", 0),
-                    "associated_files": ep.get("associated_files", []),
-                })
-            else:
-                result.append({
-                    "action": entry["action"],
-                    "is_group": True,
-                    "show_name": entry["show_name"],
-                    "episode_count": len(entry["episodes"]),
-                    "episodes": entry["episodes"],
-                    "size_bytes": entry["total_bytes"],
-                    "size": self._format_bytes(entry["total_bytes"]) if entry["total_bytes"] > 0 else "",
-                })
-
-        return result
+    # Show-episode grouping helper lives in core.activity (shared with the
+    # Recent Activity dashboard grouping service). Imported as
+    # `group_episodes_by_show` at the top of this module.
 
     def get_status_dict(self) -> dict:
         """Get status as a dictionary for API responses"""
@@ -1432,7 +1384,7 @@ class OperationRunner:
             # Files processed in this run, grouped by show to compress TV runs.
             # Cap at 15 groups so long runs stay readable; overflow links to Recent Activity.
             with self._lock:
-                grouped = self._group_episodes_by_show(list(self._current_run_files))
+                grouped = group_episodes_by_show(list(self._current_run_files))
                 status["recent_files"] = grouped[:15]
 
             if self._stop_requested:

--- a/web/services/pinned_service.py
+++ b/web/services/pinned_service.py
@@ -17,6 +17,7 @@ does the grouping), so this service only exposes video cache paths.
 """
 
 import logging
+import os
 import threading
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -356,11 +357,15 @@ class PinnedService:
             self._tracker.remove_pin(rating_key)
             after_paths = self.resolve_all_to_cache_paths()
             freshly_unpinned = sorted(before_paths - after_paths)
+            # Only hand the runner paths that actually exist on cache —
+            # otherwise pinning items without clicking "Cache Pinned Now"
+            # and then unpinning them spins up an empty eviction.
+            evict_paths = [p for p in freshly_unpinned if os.path.exists(p)]
             return {
                 "is_pinned": False,
                 "error": None,
                 "budget": self.budget_check(),
-                "evict_paths": freshly_unpinned,
+                "evict_paths": evict_paths,
                 "pinned_paths": [],
             }
 
@@ -547,9 +552,13 @@ class PinnedService:
                 removed += 1
         after_paths = self.resolve_all_to_cache_paths()
         freshly_unpinned = sorted(before_paths - after_paths)
+        # Only hand the runner paths that actually exist on cache — otherwise
+        # batch-unpinning items that were never cached spins up an empty
+        # eviction.
+        evict_paths = [p for p in freshly_unpinned if os.path.exists(p)]
         return {
             "removed": removed,
-            "evict_paths": freshly_unpinned,
+            "evict_paths": evict_paths,
             "budget": self.budget_check(),
         }
 

--- a/web/services/scheduler_service.py
+++ b/web/services/scheduler_service.py
@@ -220,7 +220,7 @@ class SchedulerService:
         dry_run = self._config.dry_run if self._config else False
         verbose = self._config.verbose if self._config else False
 
-        runner.start_operation(dry_run=dry_run, verbose=verbose)
+        runner.start_operation(dry_run=dry_run, verbose=verbose, source="scheduled")
         # Note: last_run.txt is updated by operation_runner when operation completes
 
     def _apply_schedule(self):

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -201,6 +201,18 @@ footer {
 }
 
 /* Activity table column tweaks */
+/* Fixed layout pins column widths via <colgroup> so expanding a run-row
+   doesn't shift column boundaries based on the newly visible filenames. */
+.recent-activity-table {
+    table-layout: fixed;
+    width: 100%;
+}
+.activity-col-time   { width: 130px; }
+.activity-col-action { width: 130px; }
+.activity-col-file   { width: auto; }
+.activity-col-users  { width: 130px; }
+.activity-col-size   { width: 110px; }
+
 .activity-file-col {
     word-break: break-word;
     white-space: normal;

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1259,3 +1259,122 @@ footer {
 [data-theme="light"] .activity-filter-pill.active {
     color: #000;
 }
+
+/* ─────────────────────────────────────────────────────────────────────
+   Recent Activity — run-grouped view (Option D)
+   Run header is clickable; member rows hide unless `.is-visible`.
+   Show-group children hide unless `.is-visible`. Movie sidecars keep
+   the existing `.af-parent` / `.af-visible` pattern.
+   ───────────────────────────────────────────────────────────────────── */
+.run-expandable-header {
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.run-expandable-header:hover td {
+    background: color-mix(in srgb, var(--plex-purple) 8%, transparent);
+}
+.run-expandable-header td {
+    padding: 0.7rem 0.75rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--plex-purple) 18%, transparent);
+}
+.run-expandable-inner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+.run-expandable-chev {
+    color: color-mix(in srgb, var(--plex-purple) 75%, transparent);
+    font-size: 1rem;
+    line-height: 1;
+    width: 1rem;
+    text-align: center;
+    transition: transform 0.15s;
+}
+.run-expandable-chev.open { transform: rotate(90deg); }
+.run-expandable-title {
+    color: color-mix(in srgb, var(--plex-purple) 95%, transparent);
+    font-weight: 500;
+    font-size: 0.85rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.run-source-ic {
+    width: 14px;
+    height: 14px;
+    stroke-width: 2;
+}
+.run-expandable-meta {
+    color: var(--plex-text-light);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+}
+.run-expandable-stats {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+/* Run-header stat pills */
+.run-stat-pill {
+    padding: 0.18rem 0.55rem;
+    border-radius: var(--plex-radius-xs);
+    font-size: 0.7rem;
+    font-weight: 500;
+    transition: opacity 0.15s;
+}
+.run-stat-pill--cached {
+    background: color-mix(in srgb, var(--plex-success) 15%, transparent);
+    color: var(--plex-success);
+}
+.run-stat-pill--restored {
+    background: color-mix(in srgb, var(--plex-info) 15%, transparent);
+    color: var(--plex-info);
+}
+.run-stat-pill--size {
+    background: var(--plex-bg-hover);
+    color: var(--plex-text-light);
+    font-variant-numeric: tabular-nums;
+}
+/* Dim a stat pill when its action is filtered out (set by JS) */
+.run-stat-pill.is-dimmed {
+    opacity: 0.4;
+}
+
+/* Run member rows — hidden until parent header is open */
+.run-row { display: none; }
+.run-row.is-visible { display: table-row; }
+
+/* Show-group children — separately collapsible, hidden by default */
+.run-show-child { display: none; }
+.run-show-child.is-visible { display: table-row; }
+.run-show-parent {
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.run-show-parent:hover td {
+    background: color-mix(in srgb, var(--plex-text) 4%, transparent);
+}
+.run-show-parent .chev {
+    display: inline-block;
+    margin-right: 0.3rem;
+    color: var(--plex-text-muted);
+    font-size: 0.85rem;
+    transition: transform 0.15s;
+}
+.run-show-parent.is-open .chev { transform: rotate(90deg); }
+
+/* Show-group "N eps" badge */
+.badge-group {
+    background: color-mix(in srgb, var(--plex-purple) 18%, transparent);
+    color: var(--plex-purple);
+}
+
+/* Light theme: lower-contrast hover backgrounds */
+[data-theme="light"] .run-expandable-header:hover td {
+    background: color-mix(in srgb, var(--plex-purple) 6%, transparent);
+}
+[data-theme="light"] .run-show-parent:hover td {
+    background: rgba(0, 0, 0, 0.025);
+}

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1390,3 +1390,14 @@ footer {
 [data-theme="light"] .run-show-parent:hover td {
     background: rgba(0, 0, 0, 0.025);
 }
+
+/* Pinned chip — pending unpin (debounce window) */
+.pinned-row-pending-unpin {
+    opacity: 0.45;
+    text-decoration: line-through;
+    text-decoration-color: var(--plex-text-muted);
+    transition: opacity 150ms ease;
+}
+.pinned-row-pending-unpin .pinned-unpin-btn {
+    cursor: default;
+}

--- a/web/static/css/plex-theme.css
+++ b/web/static/css/plex-theme.css
@@ -25,6 +25,7 @@ body {
     --plex-warning: #ff9800;
     --plex-error: #FF453A;
     --plex-info: #0A84FF;
+    --plex-purple: #a78bfa;
     --plex-user-admin: var(--plex-orange);
     --plex-user-home: var(--plex-info);
     --plex-user-shared: var(--plex-success);
@@ -79,6 +80,7 @@ body {
     --plex-error: #d70015;
     --plex-warning: #c77c02;
     --plex-info: #0066cc;
+    --plex-purple: #6d4cd8;
     --plex-shadow-card: 0 1px 3px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.05);
     --plex-shadow-elevated: 0 4px 12px rgba(0,0,0,0.10), 0 0 0 1px rgba(0,0,0,0.07);
 }

--- a/web/templates/components/recent_activity.html
+++ b/web/templates/components/recent_activity.html
@@ -1,54 +1,138 @@
-<!-- Recent Activity component - HTMX partial (grouped by date) -->
+<!-- Recent Activity component - HTMX partial (run-grouped Option D layout) -->
 {% from "macros/associated_files.html" import af_expand_badge, af_expand_rows, af_expand_onclick %}
 {% from "macros/user_badge.html" import user_badge %}
-{% if activity %}
-{% for group in activity|groupby('date_key')|reverse %}
-<tr class="date-group-header" data-date-group="{{ group.grouper }}">
+
+{% macro action_badge(action) -%}
+{%- if action in ('Cached', 'Protected', 'Fixed') -%}
+<span class="badge badge-success">{{ action }}</span>
+{%- elif action in ('Restored', 'Moved to Array', 'Restored Backup') -%}
+<span class="badge badge-info">{{ action }}</span>
+{%- elif action == 'Deleted Backup' -%}
+<span class="badge badge-warning">{{ action }}</span>
+{%- else -%}
+<span class="badge badge-muted">{{ action }}</span>
+{%- endif -%}
+{%- endmacro %}
+
+{% macro source_icon(source) -%}
+{%- if source == 'scheduled' -%}<i data-lucide="clock" class="run-source-ic"></i>
+{%- elif source == 'web' -%}<i data-lucide="monitor" class="run-source-ic"></i>
+{%- elif source == 'cli' -%}<i data-lucide="terminal" class="run-source-ic"></i>
+{%- elif source == 'maintenance' -%}<i data-lucide="wrench" class="run-source-ic"></i>
+{%- else -%}<i data-lucide="history" class="run-source-ic"></i>
+{%- endif -%}
+{%- endmacro %}
+
+{% if runs %}
+{% set ns = namespace(last_date_key=None) %}
+{% for run in runs %}
+{% set is_newest = loop.first %}
+
+{% if run.date_key != ns.last_date_key %}
+<tr class="date-group-header" data-date-group="{{ run.date_key }}">
     <td colspan="5">
         <div class="date-group-inner">
             <span class="date-group-label">
                 <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                {{ group.list[0].date_display }}
+                {{ run.date_display }}
             </span>
-            <span class="date-group-count">{{ group.list|length }} action{{ 's' if group.list|length != 1 else '' }}</span>
             <span class="date-group-line"></span>
         </div>
     </td>
 </tr>
-{% for item in group.list %}
-<tr data-action="{{ item.action }}" data-date-group="{{ item.date_key }}"{% if item.associated_files %} class="af-parent" {{ af_expand_onclick() }}{% endif %}>
-    <td>{{ item.time_display }}</td>
-    <td>
-        {% if item.action in ('Cached', 'Protected', 'Fixed') %}
-        <span class="badge badge-success">{{ item.action }}</span>
-        {% elif item.action in ('Restored', 'Moved to Array', 'Restored Backup') %}
-        <span class="badge badge-info">{{ item.action }}</span>
-        {% elif item.action == 'Deleted Backup' %}
-        <span class="badge badge-warning">{{ item.action }}</span>
+{% set ns.last_date_key = run.date_key %}
+{% endif %}
+
+<tr class="run-expandable-header{% if is_newest %} is-open{% endif %}"
+    data-run-id="{{ run.run_id }}"
+    data-run-source="{{ run.run_source }}"
+    data-files-cached="{{ run.files_cached }}"
+    data-files-restored="{{ run.files_restored }}"
+    onclick="ActivityRuns.toggleRun(this)">
+    <td colspan="5">
+        <div class="run-expandable-inner">
+            <span class="run-expandable-chev{% if is_newest %} open{% endif %}">&#8250;</span>
+            <span class="run-expandable-title">
+                {{ source_icon(run.run_source) }}
+                {{ run.label }}
+            </span>
+            <span class="run-expandable-meta">{{ run.time_range }}{% if run.duration_display %} &middot; {{ run.duration_display }}{% endif %}</span>
+            <span class="run-expandable-stats">
+                {% if run.files_cached > 0 %}
+                <span class="run-stat-pill run-stat-pill--cached" data-stat="Cached">{{ run.files_cached }} cached</span>
+                {% endif %}
+                {% if run.files_restored > 0 %}
+                <span class="run-stat-pill run-stat-pill--restored" data-stat="Restored">{{ run.files_restored }} restored</span>
+                {% endif %}
+                {% if run.bytes_total_display %}
+                <span class="run-stat-pill run-stat-pill--size">{{ run.bytes_total_display }}</span>
+                {% endif %}
+            </span>
+        </div>
+    </td>
+</tr>
+
+{% for entry in run.entries %}
+{% if entry.is_group %}
+{% set show_id = run.run_id ~ '-show-' ~ loop.index %}
+<tr class="run-row run-show-parent{% if is_newest %} is-visible{% endif %}"
+    data-run-member="{{ run.run_id }}"
+    data-show-id="{{ show_id }}"
+    data-action="{{ entry.action }}"
+    onclick="ActivityRuns.toggleShow(this)">
+    <td>{{ entry.time_display }}</td>
+    <td>{{ action_badge(entry.action) }}</td>
+    <td class="text-muted activity-file-col">
+        <span class="chev">&#8250;</span>{{ entry.show_name }}
+        <span class="badge badge-group badge-sm">{{ entry.episode_count }} eps</span>
+    </td>
+    <td class="user-badges">
+        {% if entry.users and entry.users|length > 0 %}
+            {% for user in entry.users[:3] %}{{ user_badge(user, user_types, classes='badge-sm') }}{% endfor %}
+            {% if entry.users|length > 3 %}<span class="badge badge-muted badge-sm">+{{ entry.users|length - 3 }}</span>{% endif %}
         {% else %}
-        <span class="badge badge-muted">{{ item.action }}</span>
+        <span class="text-muted">-</span>
         {% endif %}
     </td>
-    <td class="text-muted activity-file-col" title="{{ item.filename }}">{{ item.filename }}</td>
+    <td>{{ entry.size }}</td>
+</tr>
+{% for ep in entry.episodes %}
+<tr class="run-row run-show-child"
+    data-run-member="{{ run.run_id }}"
+    data-show-child="{{ show_id }}"
+    data-action="{{ entry.action }}">
+    <td class="text-muted" style="font-variant-numeric: tabular-nums;">{{ ep.time_display }}</td>
+    <td></td>
+    <td class="associated-sub-file" title="{{ ep.filename }}"><span class="associated-sub-arrow">&#8627;</span> {{ ep.filename }}</td>
+    <td></td>
+    <td class="associated-sub-size">{{ ep.size if ep.size else '-' }}</td>
+</tr>
+{% endfor %}
+{% else %}
+<tr class="run-row{% if is_newest %} is-visible{% endif %}{% if entry.associated_files %} af-parent{% endif %}"
+    data-run-member="{{ run.run_id }}"
+    data-action="{{ entry.action }}"
+    {% if entry.associated_files %}{{ af_expand_onclick() }}{% endif %}>
+    <td>{{ entry.time_display }}</td>
+    <td>{{ action_badge(entry.action) }}</td>
+    <td class="text-muted activity-file-col" title="{{ entry.filename }}">{{ entry.filename }}</td>
     <td class="user-badges">
-        {% if item.users and item.users|length > 0 %}
-            {% for user in item.users[:3] %}
-            {{ user_badge(user, user_types, classes='badge-sm') }}
-            {% endfor %}
-            {% if item.users|length > 3 %}
-            <span class="badge badge-muted badge-sm">+{{ item.users|length - 3 }}</span>
-            {% endif %}
+        {% if entry.users and entry.users|length > 0 %}
+            {% for user in entry.users[:3] %}{{ user_badge(user, user_types, classes='badge-sm') }}{% endfor %}
+            {% if entry.users|length > 3 %}<span class="badge badge-muted badge-sm">+{{ entry.users|length - 3 }}</span>{% endif %}
         {% else %}
         <span class="text-muted">-</span>
         {% endif %}
     </td>
     <td>
-        {{ item.size }}
-        {{ af_expand_badge(item.associated_files) }}
+        {{ entry.size }}
+        {{ af_expand_badge(entry.associated_files) }}
     </td>
 </tr>
-{{ af_expand_rows(item.associated_files, {"data-action": item.action, "data-date-group": item.date_key}) }}
+{{ af_expand_rows(entry.associated_files, {"data-run-member": run.run_id, "data-action": entry.action}) }}
+{% endif %}
 {% endfor %}
+
 {% endfor %}
 {% else %}
 <tr>

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -114,50 +114,187 @@ document.addEventListener('DOMContentLoaded', loadVerbosePreference);
 // Save preference when toggle changes
 document.getElementById('verbose-toggle').addEventListener('change', saveVerbosePreference);
 
-// ── Activity Filter Pills ──────────────────────────────
-const KNOWN_ACTIONS = ['Cached', 'Restored', 'Moved to Array', 'Protected'];
+// ── Activity Runs (Option D run-grouped view) ──────────────────────────
+// Use `var` so re-execution after HTMX swap of recent_activity.html doesn't
+// throw on `const` redeclaration (the partial includes its own <script>).
+var ActivityRuns = window.ActivityRuns || {
+    EXPANDED_RUNS_KEY: 'plexcache_dashboard_expanded_runs',
+    KNOWN_ACTIONS: ['Cached', 'Restored', 'Moved to Array', 'Protected'],
 
-function getActiveFilter() {
-    const active = document.querySelector('.activity-filter-pill.active');
-    return active ? active.getAttribute('data-filter') : 'all';
-}
+    loadExpandedRuns: function() {
+        try {
+            return new Set(JSON.parse(localStorage.getItem(this.EXPANDED_RUNS_KEY) || '[]'));
+        } catch (e) { return new Set(); }
+    },
+    saveExpandedRuns: function(set) {
+        try {
+            localStorage.setItem(this.EXPANDED_RUNS_KEY, JSON.stringify(Array.from(set)));
+        } catch (e) {}
+    },
 
-function applyActivityFilter(filter) {
-    const rows = document.querySelectorAll('#recent-activity tr[data-action]');
-    rows.forEach(row => {
-        const action = row.getAttribute('data-action');
-        if (filter === 'all') {
-            row.style.display = '';
-        } else if (filter === 'other') {
-            row.style.display = KNOWN_ACTIONS.includes(action) ? 'none' : '';
-        } else {
-            row.style.display = (action === filter) ? '' : 'none';
+    getActiveFilter: function() {
+        var active = document.querySelector('.activity-filter-pill.active');
+        return active ? active.getAttribute('data-filter') : 'all';
+    },
+
+    toggleRun: function(headerEl) {
+        var runId = headerEl.getAttribute('data-run-id');
+        if (!runId) return;
+        var isOpen = headerEl.classList.toggle('is-open');
+        var chev = headerEl.querySelector('.run-expandable-chev');
+        if (chev) chev.classList.toggle('open', isOpen);
+
+        var memberSel = '.run-row[data-run-member="' + CSS.escape(runId) + '"]';
+        document.querySelectorAll(memberSel).forEach(function(row) {
+            if (!isOpen) {
+                row.classList.remove('is-visible');
+                return;
+            }
+            // Re-expanding: show-children obey their show-parent's open state
+            var showChild = row.getAttribute('data-show-child');
+            if (showChild) {
+                var parent = document.querySelector('.run-show-parent[data-show-id="' + CSS.escape(showChild) + '"]');
+                row.classList.toggle('is-visible', !!(parent && parent.classList.contains('is-open')));
+            } else {
+                row.classList.add('is-visible');
+            }
+        });
+
+        // Movie sidecars (rendered by the af_expand_rows macro) carry
+        // data-run-member but use the af-visible class. Collapse them too
+        // when the run collapses so they don't visually orphan.
+        if (!isOpen) {
+            var sidecarSel = '.associated-sub-row[data-run-member="' + CSS.escape(runId) + '"]';
+            document.querySelectorAll(sidecarSel).forEach(function(row) {
+                row.classList.remove('af-visible');
+            });
+            // Reset the af-expanded flag on the parent so the badge re-shows
+            document.querySelectorAll('.af-parent[data-run-member="' + CSS.escape(runId) + '"]').forEach(function(parent) {
+                parent.classList.remove('af-expanded');
+            });
         }
-    });
 
-    // Show/hide date group headers based on visible rows in each group
-    document.querySelectorAll('#recent-activity tr.date-group-header').forEach(header => {
-        const dateKey = header.getAttribute('data-date-group');
-        const groupRows = document.querySelectorAll(
-            '#recent-activity tr[data-action][data-date-group="' + dateKey + '"]'
-        );
-        const anyVisible = Array.from(groupRows).some(r => r.style.display !== 'none');
-        header.style.display = anyVisible ? '' : 'none';
-    });
-}
+        var expanded = this.loadExpandedRuns();
+        if (isOpen) { expanded.add(runId); } else { expanded.delete(runId); }
+        this.saveExpandedRuns(expanded);
 
+        this.applyFilter(this.getActiveFilter());
+    },
+
+    toggleShow: function(parentEl) {
+        var showId = parentEl.getAttribute('data-show-id');
+        if (!showId) return;
+        var isOpen = parentEl.classList.toggle('is-open');
+        var sel = '.run-show-child[data-show-child="' + CSS.escape(showId) + '"]';
+        document.querySelectorAll(sel).forEach(function(row) {
+            row.classList.toggle('is-visible', isOpen);
+        });
+        this.applyFilter(this.getActiveFilter());
+    },
+
+    applyFilter: function(filter) {
+        var tbody = document.getElementById('recent-activity');
+        if (!tbody) return;
+        var self = this;
+
+        // Per-row filter decision
+        tbody.querySelectorAll('.run-row[data-action]').forEach(function(row) {
+            var action = row.getAttribute('data-action');
+            var pass = (
+                filter === 'all' ||
+                (filter === 'other' && self.KNOWN_ACTIONS.indexOf(action) === -1) ||
+                action === filter
+            );
+            row.dataset.filterPass = pass ? '1' : '0';
+            // When filtered out, force-hide via inline style (overrides .is-visible)
+            row.style.display = pass ? '' : 'none';
+        });
+
+        // Per-run header: hide if no member passes; dim partial stat pills
+        tbody.querySelectorAll('.run-expandable-header').forEach(function(header) {
+            var runId = header.getAttribute('data-run-id');
+            var members = tbody.querySelectorAll('.run-row[data-run-member="' + CSS.escape(runId) + '"][data-action]');
+            var anyPass = Array.from(members).some(function(r) { return r.dataset.filterPass === '1'; });
+            header.style.display = anyPass ? '' : 'none';
+
+            var filesCached = parseInt(header.getAttribute('data-files-cached') || '0', 10);
+            var filesRestored = parseInt(header.getAttribute('data-files-restored') || '0', 10);
+            header.querySelectorAll('.run-stat-pill[data-stat]').forEach(function(pill) {
+                var stat = pill.getAttribute('data-stat');
+                var dim = false;
+                if (filter === 'Cached') {
+                    dim = (stat !== 'Cached');
+                } else if (filter === 'Restored' || filter === 'Moved to Array') {
+                    dim = (stat !== 'Restored');
+                } else if (filter === 'other') {
+                    dim = (stat === 'Cached' || stat === 'Restored');
+                }
+                pill.classList.toggle('is-dimmed', dim);
+                if (dim) {
+                    var orig = stat === 'Cached' ? filesCached : filesRestored;
+                    pill.setAttribute('title', orig + ' ' + stat.toLowerCase() + ' (filtered out)');
+                } else {
+                    pill.removeAttribute('title');
+                }
+            });
+        });
+
+        // Hide date headers whose runs are all hidden
+        tbody.querySelectorAll('.date-group-header').forEach(function(header) {
+            var dateKey = header.getAttribute('data-date-group');
+            var visibleRuns = false;
+            var node = header.nextElementSibling;
+            while (node && !node.classList.contains('date-group-header')) {
+                if (node.classList.contains('run-expandable-header') && node.style.display !== 'none') {
+                    visibleRuns = true;
+                    break;
+                }
+                node = node.nextElementSibling;
+            }
+            header.style.display = visibleRuns ? '' : 'none';
+        });
+    },
+
+    restoreState: function() {
+        var tbody = document.getElementById('recent-activity');
+        if (!tbody) return;
+        var expanded = this.loadExpandedRuns();
+
+        var headers = tbody.querySelectorAll('.run-expandable-header');
+        headers.forEach(function(header, idx) {
+            var runId = header.getAttribute('data-run-id');
+            // Newest run always starts expanded regardless of stored state
+            var shouldOpen = idx === 0 || expanded.has(runId);
+            header.classList.toggle('is-open', shouldOpen);
+            var chev = header.querySelector('.run-expandable-chev');
+            if (chev) chev.classList.toggle('open', shouldOpen);
+
+            tbody.querySelectorAll('.run-row[data-run-member="' + CSS.escape(runId) + '"]').forEach(function(row) {
+                var showChild = row.getAttribute('data-show-child');
+                if (showChild) {
+                    row.classList.remove('is-visible');  // shows always start collapsed
+                } else {
+                    row.classList.toggle('is-visible', shouldOpen);
+                }
+            });
+        });
+        this.applyFilter(this.getActiveFilter());
+    },
+};
+
+// Filter pill click → apply filter
 document.querySelector('.activity-filter-bar')?.addEventListener('click', function(e) {
-    const pill = e.target.closest('.activity-filter-pill');
+    var pill = e.target.closest('.activity-filter-pill');
     if (!pill) return;
-    document.querySelectorAll('.activity-filter-pill').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.activity-filter-pill').forEach(function(p) { p.classList.remove('active'); });
     pill.classList.add('active');
-    applyActivityFilter(pill.getAttribute('data-filter'));
+    ActivityRuns.applyFilter(pill.getAttribute('data-filter'));
 });
 
-// Re-apply filter after HTMX refreshes activity table
+// Restore expanded-run state after every HTMX swap
 document.body.addEventListener('htmx:afterSwap', function(e) {
     if (e.detail.target && e.detail.target.id === 'recent-activity') {
-        applyActivityFilter(getActiveFilter());
+        ActivityRuns.restoreState();
     }
 });
 </script>

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -69,7 +69,14 @@
     </div>
     <div class="card-body" style="padding: 0;">
         <div class="recent-activity-scroll">
-            <table>
+            <table class="recent-activity-table">
+                <colgroup>
+                    <col class="activity-col-time">
+                    <col class="activity-col-action">
+                    <col class="activity-col-file">
+                    <col class="activity-col-users">
+                    <col class="activity-col-size">
+                </colgroup>
                 <thead>
                     <tr>
                         <th>Time</th>

--- a/web/templates/settings/partials/pinned_chip_list.html
+++ b/web/templates/settings/partials/pinned_chip_list.html
@@ -86,17 +86,14 @@
                     {% if pin.size_bytes %}
                         <span style="color: var(--plex-text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; flex-shrink: 0;">{{ pin.size_display }}</span>
                     {% endif %}
-                    <form hx-post="/api/pinned/toggle"
-                          hx-swap="none"
-                          style="margin: 0; flex-shrink: 0;">
-                        <input type="hidden" name="rating_key" value="{{ pin.rating_key }}">
-                        <input type="hidden" name="pin_type" value="{{ pin.type }}">
-                        <input type="hidden" name="title" value="{{ pin.title }}">
-                        <button type="submit" class="btn-icon" title="Unpin" aria-label="Unpin {{ pin.scope_text }}"
-                                style="background: none; border: 0; cursor: pointer; color: var(--plex-text-muted); padding: 0.1rem 0.3rem; display: inline-flex; align-items: center; border-radius: var(--plex-radius-sm);">
-                            <i data-lucide="x" style="width: 14px; height: 14px;"></i>
-                        </button>
-                    </form>
+                    <button type="button" class="btn-icon pinned-unpin-btn"
+                            title="Unpin"
+                            aria-label="Unpin {{ pin.scope_text }}"
+                            data-rating-key="{{ pin.rating_key }}"
+                            onclick="UnpinDebounce.add(this.dataset.ratingKey, this);"
+                            style="background: none; border: 0; cursor: pointer; color: var(--plex-text-muted); padding: 0.1rem 0.3rem; display: inline-flex; align-items: center; border-radius: var(--plex-radius-sm); flex-shrink: 0;">
+                        <i data-lucide="x" style="width: 14px; height: 14px;"></i>
+                    </button>
                 </li>
             {% endfor %}
             </ul>
@@ -126,5 +123,70 @@
     {% endif %}
 </div>
 <script>
+    // Buffer rapid unpin clicks into a single batch POST so the runner sees
+    // one eviction (one run_id, one Recent Activity entry) instead of N.
+    // Re-declared on every chip list HTMX swap; `window.X || {...}` preserves
+    // the pending set + timer across the swap so a click made just before
+    // a swap still flushes correctly.
+    var UnpinDebounce = window.UnpinDebounce || {
+        pending: new Set(),
+        timer: null,
+        delayMs: 1500,
+
+        add: function(ratingKey, btnEl) {
+            if (!ratingKey) return;
+            this.pending.add(String(ratingKey));
+            var row = btnEl ? btnEl.closest('.pinned-row') : null;
+            if (row) row.classList.add('pinned-row-pending-unpin');
+            if (btnEl) btnEl.disabled = true;
+            if (this.timer) clearTimeout(this.timer);
+            var self = this;
+            this.timer = setTimeout(function() { self.flush(); }, this.delayMs);
+        },
+
+        flush: function() {
+            if (this.pending.size === 0) return;
+            var keys = Array.from(this.pending);
+            this.pending.clear();
+            this.timer = null;
+
+            var fd = new FormData();
+            keys.forEach(function(k) { fd.append('rating_keys', k); });
+
+            fetch('/api/pinned/unpin-group', {
+                method: 'POST',
+                body: fd,
+                headers: {'HX-Request': 'true'}
+            }).then(function(resp) {
+                // Re-dispatch HX-Trigger header events so the chip list
+                // refresh and banner kickoff still fire (htmx.ajax would
+                // do this for us, but it doesn't serialize repeated form
+                // values cleanly).
+                var trigger = resp.headers.get('HX-Trigger');
+                if (trigger) {
+                    try {
+                        var events = JSON.parse(trigger);
+                        Object.keys(events).forEach(function(name) {
+                            document.body.dispatchEvent(new CustomEvent(name, {
+                                detail: events[name],
+                                bubbles: true
+                            }));
+                        });
+                    } catch (e) { /* noop */ }
+                }
+                return resp.text();
+            }).then(function(html) {
+                var target = document.getElementById('settings-alert-container');
+                if (target) {
+                    target.innerHTML = html;
+                    if (typeof htmx !== 'undefined') htmx.process(target);
+                    if (typeof lucide !== 'undefined') lucide.createIcons();
+                }
+            }).catch(function(err) {
+                console.error('Unpin batch failed:', err);
+            });
+        }
+    };
+    window.UnpinDebounce = UnpinDebounce;
     if (typeof lucide !== 'undefined') lucide.createIcons();
 </script>

--- a/web/templates/settings/partials/pinned_chip_list.html
+++ b/web/templates/settings/partials/pinned_chip_list.html
@@ -174,6 +174,11 @@
                         });
                     } catch (e) { /* noop */ }
                 }
+                // Flip Pin/Unpin button state on any matching rows still
+                // visible in the search results / expanded children, so the
+                // user doesn't see stale "Unpin" labels on items they just
+                // unpinned (which would re-pin them on a follow-up click).
+                keys.forEach(UnpinDebounce.flipSearchButtonToPin);
                 return resp.text();
             }).then(function(html) {
                 var target = document.getElementById('settings-alert-container');
@@ -185,6 +190,29 @@
             }).catch(function(err) {
                 console.error('Unpin batch failed:', err);
             });
+        },
+
+        flipSearchButtonToPin: function(ratingKey) {
+            // Match both top-level result rows and lazy-expanded child rows.
+            // Mirror the markup from pinned_result_row.html / pinned_children.html
+            // for the not-pinned state so a follow-up click pins, not re-pins.
+            var rows = document.querySelectorAll(
+                '.pinned-result-row[data-rating-key="' + ratingKey + '"], ' +
+                '.pinned-child-row[data-rating-key="' + ratingKey + '"]'
+            );
+            rows.forEach(function(row) {
+                var form = row.querySelector('form');
+                if (!form) return;
+                var btn = form.querySelector('button[type="submit"]');
+                if (!btn) return;
+                btn.className = 'btn btn-sm btn-primary';
+                btn.title = 'Pin this item';
+                btn.innerHTML =
+                    '<i data-lucide="pin" style="width: 14px; height: 14px; vertical-align: middle;"></i> Pin';
+            });
+            if (rows.length && typeof lucide !== 'undefined') {
+                lucide.createIcons();
+            }
         }
     };
     window.UnpinDebounce = UnpinDebounce;


### PR DESCRIPTION
## Summary

Recent Activity on the dashboard currently lists every cached/restored file as a flat row. Long scheduled runs (especially audit cycles that touch dozens of episodes) push all other context off-screen, and there's no way to tell where one run ends and the next begins. This PR groups the feed by run, with each run's files collapsed under a header showing source, file counts, byte totals, and duration.

The grouping reuses the show-episode helper introduced in #157 (`group_episodes_by_show`) — that helper has been hoisted from `OperationRunner` to `core.activity` so both the completion banner and the dashboard share it.

Builds on the freshly-landed #157.

## Screenshot

<img width="1228" height="535" alt="image" src="https://github.com/user-attachments/assets/219c88c5-61c3-422e-9fc4-f194bf3b647f" />

## Changes

**1. Group Recent Activity by run on the dashboard** (`df2b449`)
- `FileActivity` (in `core/activity.py`) gains `run_id: Optional[str]` and `run_source: str` (`"scheduled"` | `"web"` | `"cli"` | `"maintenance"` | `"legacy"`). Pre-existing entries default to `run_id=None`, `run_source="legacy"`.
- Three entry points mint a UUID at run start and attach it to every `FileActivity` they create:
  - `OperationRunner.start_operation(source=)` — web + scheduled
  - `PlexCacheApp._setup_logging()` — CLI (also written into the log header as `=== PlexCache-D vX run_id=HEX ===`)
  - `MaintenanceRunner.start_action()` — maintenance
- `web/routers/pinned.py:_record_pin_activity()` mints one UUID per pin batch so multi-file pins group as a single mini-run.
- New `web/services/activity_grouping.py:group_activity_into_runs()` does a two-pass transform: bucket by `run_id`, fall back to 15-min time-window clusters for legacy entries, then per-bucket show-grouping via the shared helper.
- `GET /operations/activity` now returns `{activity, runs}`.
- New `web/templates/components/recent_activity.html` renders the run header + member rows + show-group children. Newest run is open by default (server-side via `loop.first`).
- `ActivityRuns` JS namespace in `dashboard.html` handles toggle/filter; expanded set persists in `localStorage` and is restored on `htmx:afterSwap`.
- Sidecars (`af-visible` class) collapse when their containing run collapses.

**2. Activity Feed blurb update** (`21c8443`) — README note about run-grouping.

**3. Snapshot file sizes before maintenance actions** (`4de9b48`)
- Maintenance actions (clear-cache, restore-cache) record sizes from disk *before* deletion/move so the post-action FileActivity rows show real numbers instead of `0 B`.

**4. Coalesce rapid unpin evictions** (`e6f5dc9`)
- Multiple unpins fired in quick succession used to enqueue separate eviction operations, each minting its own `run_id` and showing as a separate run on the dashboard.
- New `merge_into_queued()` path in `pinned_service.py` coalesces unpins that arrive while another is pending, so the dashboard shows one mini-run for the batch.

**5. Lock Recent Activity column widths** (`2f188b2`)
- Expanding a run header used to reflow column widths because the child rows have different content. Pin column widths via CSS so headers stay aligned.

**6. Real run start/end times in `run_summaries.json`** (`cbd2bef`)
- Run header durations were computed as `last_file_timestamp - first_file_timestamp`, missing the Plex API + scanning + audit tail (often 30s–2min on its own).
- Replaces single-dict `last_run_summary.json` with a keyed `run_summaries.json`. All three primary run paths write `started_at`/`completed_at` indexed by `run_id`.
- Grouping service joins activity buckets to run summaries by `run_id`; legacy entries fall back to first/last `FileActivity` timestamps.
- `load_last_run_summary()` returns the most recent caching-run entry for the dashboard widget (excludes maintenance by default). Legacy `last_run_summary.json` is migrated on first load and removed.

## Test plan

- [x] Trigger a scheduled run (or `Run Now`); confirm the new run appears at the top of Recent Activity, expanded, with correct file counts, byte totals, and duration covering the full run (not just the file-move window).
- [x] Pin three movies in quick succession; confirm they appear as a single mini-run, not three separate runs.
- [x] Unpin three movies in quick succession; confirm the unpin-evictions show as one batch on the dashboard.
- [x] Run a maintenance clear-cache on a few files; confirm the resulting Recent Activity rows show real sizes (not `0 B`) and the run is labeled "maintenance".
- [x] Click a run header to collapse; sidecars (associated subtitle/sidecar files) under that run also collapse.
- [x] Reload the page; previously-expanded runs stay expanded (localStorage); newest run is always open regardless.
- [x] Filter pills (Cached / Restored): when a filter hides one type, the corresponding count pill on each run header dims and shows a tooltip with the original count.
- [x] CLI run via `python3 plexcache.py`; the run appears on the dashboard with `run_source="cli"` and a purple CLI badge.
- [x] Pre-existing activity entries (no `run_id` on disk) bucket into 15-min time-window clusters labeled `legacy`.
- [x] Existing pytest suite passes (1,155 tests on this branch's working tree, including 17 new unit tests for grouping logic and 6 endpoint integration tests).