### PR TITLE
Retry switchHomeUser on transient plex.tv network errors

### DIFF
--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -628,10 +628,17 @@ class PlexManager:
                     try:
                         from plexapi.myplex import MyPlexAccount
                         logging.debug(f"[PLEX API] No token for {username}, trying switchHomeUser...")
-                        self._rate_limited_api_call()
-                        admin_account = MyPlexAccount(token=self.plex_token)
-                        self._rate_limited_api_call()
-                        switched = admin_account.switchHomeUser(username)
+
+                        def _switch_to_home_user():
+                            self._rate_limited_api_call()
+                            admin = MyPlexAccount(token=self.plex_token)
+                            self._rate_limited_api_call()
+                            return admin.switchHomeUser(username)
+
+                        switched = _retry_plextv_call(
+                            _switch_to_home_user,
+                            label=f"switchHomeUser for {username}",
+                        )
                         return username, PlexServer(self.plex_url, switched.authenticationToken)
                     except Exception as e:
                         _log_api_error(f"switchHomeUser for {username}", e)
@@ -1180,10 +1187,16 @@ class PlexManager:
             else:
                 # Home/managed user - create fresh admin account then switch to home user
                 try:
-                    self._rate_limited_api_call()
-                    fresh_admin_account = MyPlexAccount(token=self.plex_token, session=fresh_session)
-                    self._rate_limited_api_call()
-                    account = fresh_admin_account.switchHomeUser(current_username)
+                    def _switch_to_home_user():
+                        self._rate_limited_api_call()
+                        admin = MyPlexAccount(token=self.plex_token, session=fresh_session)
+                        self._rate_limited_api_call()
+                        return admin.switchHomeUser(current_username)
+
+                    account = _retry_plextv_call(
+                        _switch_to_home_user,
+                        label=f"switch to home user {current_username}",
+                    )
                     logging.debug(f"[USER:{current_username}] Switched to home user via fresh admin account")
                 except Exception as e:
                     _log_api_error(f"switch to home user {current_username}", e)

--- a/tests/test_plex_api_switch_home_user_retry.py
+++ b/tests/test_plex_api_switch_home_user_retry.py
@@ -1,0 +1,217 @@
+"""Tests for switchHomeUser retry wiring.
+
+Verifies that `get_plex_instance` and `get_watchlist_media` wrap their
+plex.tv `MyPlexAccount(...)` + `switchHomeUser(...)` pair in
+`_retry_plextv_call` so transient connection resets / timeouts don't
+fail the user's run on the first hiccup. The helper's own retry
+semantics live in `test_plex_api_retry.py`; this module focuses on
+integration at the two call sites.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import requests
+
+from core.plex_api import PlexManager, PLEXTV_MAX_RETRIES
+
+
+def _bare_api():
+    """Construct a PlexManager without running __init__ (avoids network auth)."""
+    api = PlexManager.__new__(PlexManager)
+    api.plex_url = "http://localhost:32400"
+    api.plex_token = "ADMIN_TOKEN"
+    api._user_tokens = {}
+    api._user_is_home = {}
+    api._ondeck_data_complete = True
+    api._watchlist_data_complete = True
+    # _token_lock + _rate_limited_api_call are touched by both call sites
+    import threading
+    api._token_lock = threading.Lock()
+    api._rate_limited_api_call = MagicMock()
+    api._token_cache = MagicMock()
+    return api
+
+
+class TestGetPlexInstanceSwitchHomeUserRetry:
+    """get_plex_instance() home-user fallback path."""
+
+    def test_transient_then_success_returns_plex_server(self):
+        """ConnectionResetError on first attempt, success on second → user gets a PlexServer."""
+        api = _bare_api()
+        api._user_is_home["Paige"] = True
+
+        switched = MagicMock()
+        switched.authenticationToken = "PAIGE_TOKEN"
+        admin = MagicMock()
+        # First switchHomeUser raises a wrapped ConnectionResetError; second succeeds.
+        admin.switchHomeUser.side_effect = [
+            requests.ConnectionError("('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"),
+            switched,
+        ]
+
+        user = MagicMock()
+        user.title = "Paige"
+
+        with patch('plexapi.myplex.MyPlexAccount', return_value=admin) as mock_acct, \
+             patch('core.plex_api.PlexServer') as mock_server, \
+             patch('core.plex_api.time.sleep'):
+            username, server = api.get_plex_instance(user=user)
+
+        assert username == "Paige"
+        assert server is mock_server.return_value
+        # Two construction attempts (one per retry attempt) and two switch attempts.
+        assert mock_acct.call_count == 2
+        assert admin.switchHomeUser.call_count == 2
+
+    def test_all_attempts_fail_returns_none(self):
+        """Persistent transient error → returns (None, None) after exhausting retries."""
+        api = _bare_api()
+        api._user_is_home["Paige"] = True
+
+        admin = MagicMock()
+        admin.switchHomeUser.side_effect = requests.ConnectionError("connection reset")
+
+        user = MagicMock()
+        user.title = "Paige"
+
+        with patch('plexapi.myplex.MyPlexAccount', return_value=admin), \
+             patch('core.plex_api.PlexServer'), \
+             patch('core.plex_api.time.sleep'):
+            username, server = api.get_plex_instance(user=user)
+
+        assert username is None
+        assert server is None
+        assert admin.switchHomeUser.call_count == PLEXTV_MAX_RETRIES
+
+    def test_non_retriable_error_not_retried(self):
+        """Auth errors (e.g. 401) raise immediately; no retry, no sleep."""
+        api = _bare_api()
+        api._user_is_home["Paige"] = True
+
+        admin = MagicMock()
+        admin.switchHomeUser.side_effect = ValueError("(401) Unauthorized")
+
+        user = MagicMock()
+        user.title = "Paige"
+
+        with patch('plexapi.myplex.MyPlexAccount', return_value=admin), \
+             patch('core.plex_api.PlexServer'), \
+             patch('core.plex_api.time.sleep') as mock_sleep:
+            username, server = api.get_plex_instance(user=user)
+
+        assert username is None
+        assert server is None
+        assert admin.switchHomeUser.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+class TestFetchUserWatchlistSwitchHomeUserRetry:
+    """_fetch_user_watchlist() home-user account-construction path."""
+
+    def _setup_for_watchlist(self, api):
+        """Wire up the minimum state _fetch_user_watchlist() touches before the switch."""
+        api._watchlist_data_complete = True
+        api.mark_watchlist_incomplete = MagicMock(
+            side_effect=lambda: setattr(api, '_watchlist_data_complete', False)
+        )
+
+    def test_transient_then_success_proceeds_to_watchlist(self):
+        """First attempt resets, second succeeds → watchlist is fetched (no incomplete flag)."""
+        api = _bare_api()
+        self._setup_for_watchlist(api)
+
+        switched_account = MagicMock()
+        switched_account.watchlist.return_value = []
+        admin = MagicMock()
+        admin.switchHomeUser.side_effect = [
+            requests.ConnectionError("Connection aborted."),
+            switched_account,
+        ]
+
+        user = MagicMock()
+        user.title = "Paige"
+
+        with patch('core.plex_api.MyPlexAccount', return_value=admin), \
+             patch('core.plex_api.requests.Session'), \
+             patch('core.plex_api.time.sleep'):
+            list(api._fetch_user_watchlist(
+                user=user,
+                valid_sections=[1],
+                watchlist_episodes=3,
+                skip_watchlist=[],
+                rss_url=None,
+                filtered_sections=[1],
+            ))
+
+        # Retry succeeded → no incomplete flag set, watchlist fetch reached.
+        assert api.mark_watchlist_incomplete.call_count == 0
+        assert admin.switchHomeUser.call_count == 2
+
+    def test_all_attempts_fail_marks_watchlist_incomplete(self):
+        """Persistent transient error → mark_watchlist_incomplete + early return."""
+        api = _bare_api()
+        self._setup_for_watchlist(api)
+
+        admin = MagicMock()
+        admin.switchHomeUser.side_effect = requests.ConnectionError("connection reset")
+
+        user = MagicMock()
+        user.title = "Paige"
+
+        with patch('core.plex_api.MyPlexAccount', return_value=admin), \
+             patch('core.plex_api.requests.Session'), \
+             patch('core.plex_api.time.sleep'):
+            list(api._fetch_user_watchlist(
+                user=user,
+                valid_sections=[1],
+                watchlist_episodes=3,
+                skip_watchlist=[],
+                rss_url=None,
+                filtered_sections=[1],
+            ))
+
+        api.mark_watchlist_incomplete.assert_called_once()
+        assert admin.switchHomeUser.call_count == PLEXTV_MAX_RETRIES
+
+    def test_non_retriable_error_not_retried(self):
+        """403 from switchHomeUser → no retry, mark incomplete, return."""
+        api = _bare_api()
+        self._setup_for_watchlist(api)
+
+        admin = MagicMock()
+        admin.switchHomeUser.side_effect = ValueError("(403) Forbidden")
+
+        user = MagicMock()
+        user.title = "Paige"
+
+        with patch('core.plex_api.MyPlexAccount', return_value=admin), \
+             patch('core.plex_api.requests.Session'), \
+             patch('core.plex_api.time.sleep') as mock_sleep:
+            list(api._fetch_user_watchlist(
+                user=user,
+                valid_sections=[1],
+                watchlist_episodes=3,
+                skip_watchlist=[],
+                rss_url=None,
+                filtered_sections=[1],
+            ))
+
+        api.mark_watchlist_incomplete.assert_called_once()
+        assert admin.switchHomeUser.call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
## Summary

The home-user fallback in `get_plex_instance` and `_fetch_user_watchlist` calls `MyPlexAccount(...)` + `switchHomeUser(...)` against plex.tv and fails the user immediately on any error. A transient connection reset (`ConnectionResetError(104, 'Connection reset by peer')` wrapped as `requests.ConnectionError`) currently marks that user's watchlist incomplete or skips their OnDeck for the whole run, even though the next call would have succeeded.

This PR wraps both call pairs in the existing `_retry_plextv_call` helper from #154 (3 attempts, 2s/4s exponential backoff) so the same kind of transient blip that's already retried for `account.watchlist()` and `account.userState()` is also retried for `switchHomeUser`. Auth errors and other non-network failures still raise immediately so callers can distinguish retry-worthy failures from permanent ones.

## Changes

- **`core/plex_api.py`** — Two call sites updated:
  - `get_plex_instance` (token-cache fallback for home users) — `MyPlexAccount(...)` + `switchHomeUser(...)` extracted into a closure and wrapped in `_retry_plextv_call`. On exhaustion, falls back to the existing `_log_api_error` + `(None, None)` path.
  - `_fetch_user_watchlist` (per-user watchlist fetch) — same closure shape. On exhaustion, falls back to the existing `_log_api_error` + `mark_watchlist_incomplete()` + early return.
- **`tests/test_plex_api_switch_home_user_retry.py`** — 6 new unit tests covering both call sites: transient-then-success, all-attempts-fail, and non-retriable error paths.

## Test Plan

**Manual**

1. Run a full sync with home users configured and a healthy plex.tv → confirm baseline behavior is unchanged (no new log lines, no extra latency).
2. Force a transient by briefly blocking outbound traffic to plex.tv during a watchlist run with a home user → confirm log shows `plex.tv switch to home user <user> attempt 1/3 timed out: ... Retrying in 2s...`, the run completes, and that user's watchlist is built normally.
3. Block plex.tv at the firewall for the entire run → confirm after 3 attempts the existing error log fires once and `[WATCHLIST] Watchlist data may be incomplete` warning is emitted (existing behavior preserved).
4. Set an invalid admin token (forces 401 on `MyPlexAccount` construction) → confirm no retry, immediate auth-failed error log.
5. Same scenarios via the OnDeck path (home user with no cached token) → confirm `get_plex_instance` retries and falls through to `(None, None)` on exhaustion just like before.

**Backward compatibility**

Failure paths are byte-for-byte unchanged when retries exhaust (same `_log_api_error` label, same `mark_watchlist_incomplete()` call, same return values). Success path is faster only when transient errors occur.