### PR TITLE
Move Pinned Media Preferred Version dropdown into the Pinned Media card

### DIFF
--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -7,7 +7,7 @@
         <h2>Cache Behavior Settings</h2>
     </div>
     <div class="card-body">
-        <form hx-put="/settings/cache" hx-target="#settings-alert-container" hx-swap="innerHTML">
+        <form id="cache-settings-form" hx-put="/settings/cache" hx-target="#settings-alert-container" hx-swap="innerHTML">
 
             <h3 style="font-size: 1rem; color: var(--plex-orange); margin-bottom: 1rem;">
                 <i data-lucide="search" style="width: 18px; height: 18px; vertical-align: middle;"></i>
@@ -396,26 +396,6 @@
                 </div>
             </div>
 
-            <hr style="border-color: var(--plex-border); margin: 1.5rem 0;">
-
-            <h3 style="font-size: 1rem; color: var(--plex-orange); margin-bottom: 1rem;">
-                <i data-lucide="pin" style="width: 18px; height: 18px; vertical-align: middle;"></i>
-                Pinned Media
-            </h3>
-
-            <div class="form-group">
-                <label for="pinned_preferred_resolution">Preferred Version</label>
-                <select id="pinned_preferred_resolution" name="pinned_preferred_resolution">
-                    <option value="highest" {% if settings.pinned_preferred_resolution == 'highest' or not settings.pinned_preferred_resolution %}selected{% endif %}>Highest quality (largest bitrate)</option>
-                    <option value="lowest" {% if settings.pinned_preferred_resolution == 'lowest' %}selected{% endif %}>Lowest quality (saves cache space)</option>
-                    <option value="4k" {% if settings.pinned_preferred_resolution == '4k' %}selected{% endif %}>4K (fallback to highest)</option>
-                    <option value="1080p" {% if settings.pinned_preferred_resolution == '1080p' %}selected{% endif %}>1080p (fallback to highest)</option>
-                    <option value="720p" {% if settings.pinned_preferred_resolution == '720p' %}selected{% endif %}>720p (fallback to highest)</option>
-                    <option value="first" {% if settings.pinned_preferred_resolution == 'first' %}selected{% endif %}>First version (Plex default order)</option>
-                </select>
-                <div class="form-hint">Which version to cache when a pinned item has multiple media files (e.g., 4K + 1080p). Use the picker below to add pins.</div>
-            </div>
-
             <div class="form-group mb-0">
                 <button type="submit" class="btn btn-primary">
                     <i data-lucide="save"></i>
@@ -435,6 +415,19 @@
         <p class="form-hint" style="margin-bottom: 1.25rem;">
             Pinned media is always cached and is never evicted or moved back to the array, regardless of watch state or priority score. Useful for intro episodes, favorite movies, or anything you always want instantly available with the array spun down. Use the Cache Pinned Now button below to copy any missing files immediately, or wait for the next scheduled run.
         </p>
+
+        <div class="form-group">
+            <label for="pinned_preferred_resolution">Preferred Version</label>
+            <select id="pinned_preferred_resolution" name="pinned_preferred_resolution" form="cache-settings-form">
+                <option value="highest" {% if settings.pinned_preferred_resolution == 'highest' or not settings.pinned_preferred_resolution %}selected{% endif %}>Highest quality (largest bitrate)</option>
+                <option value="lowest" {% if settings.pinned_preferred_resolution == 'lowest' %}selected{% endif %}>Lowest quality (saves cache space)</option>
+                <option value="4k" {% if settings.pinned_preferred_resolution == '4k' %}selected{% endif %}>4K (fallback to highest)</option>
+                <option value="1080p" {% if settings.pinned_preferred_resolution == '1080p' %}selected{% endif %}>1080p (fallback to highest)</option>
+                <option value="720p" {% if settings.pinned_preferred_resolution == '720p' %}selected{% endif %}>720p (fallback to highest)</option>
+                <option value="first" {% if settings.pinned_preferred_resolution == 'first' %}selected{% endif %}>First version (Plex default order)</option>
+            </select>
+            <div class="form-hint">Which version to cache when a pinned item has multiple media files (e.g., 4K + 1080p). Saved with <strong>Save Cache Settings</strong> in the Cache Behavior card above.</div>
+        </div>
 
         <div class="form-group">
             <label for="pinned-search-input">


### PR DESCRIPTION
## Summary

The Pinned Media settings page currently shows two separate Pinned Media sections because the **Preferred Version** dropdown lives in the *Cache Behavior* card while the rest of the Pinned Media UI (chip list, Cache Pinned Now button, search) lives in the *Pinned Media* card below.

This PR moves the dropdown into the Pinned Media card so the page only has a single Pinned Media section.

To preserve the existing one-save-button behavior, the `<select>` uses HTML5 `form="cache-settings-form"` so it still submits with the existing **Save Cache Settings** button in the Cache Behavior card above. The hint copy now points users at that button.

- No new endpoint
- No second save button
- No behavior change — purely a layout fix

## Test plan

- [x] Visit **Settings → Cache**. Confirm there is now only one **Pinned Media** heading on the page (previously two).
- [x] The **Preferred Version** dropdown appears at the top of the Pinned Media card, above the chip list, with hint text pointing to **Save Cache Settings**.
- [x] Change the dropdown to a different value, scroll up, and click **Save Cache Settings** in the Cache Behavior card. Confirm the new value persists across reloads (settings POST round-trips correctly).
- [x] Reload the page and confirm the dropdown reflects the saved value.
- [x] No JavaScript console errors on page load or save.