### PR TITLE
Add searchable Settings (Spotlight-style)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ FUTURE_ENHANCEMENTS.md
 COMPLETED_ENHANCEMENTS.md
 TODO.md
 PINNED_MEDIA_PLAN.md
+
+# Design mockups (local-only, see COMPLETED_ENHANCEMENTS.md entries)
+mockup_*.html

--- a/web/config.py
+++ b/web/config.py
@@ -69,6 +69,11 @@ templates.env.globals["is_docker"] = IS_DOCKER
 templates.env.globals["web_version"] = __version__
 templates.env.globals["product_version"] = PLEXCACHE_PRODUCT_VERSION
 
+# Searchable Settings index — exposed as JSON for client-side search.
+# See web/services/settings_search_index.py for the source of truth.
+from web.services.settings_search_index import get_search_index
+templates.env.globals["settings_search_index_json"] = json.dumps(get_search_index())
+
 
 def get_time_format() -> str:
     """Read time_format from settings JSON. Returns '12h' or '24h' (default)."""

--- a/web/config.py
+++ b/web/config.py
@@ -70,8 +70,10 @@ templates.env.globals["web_version"] = __version__
 templates.env.globals["product_version"] = PLEXCACHE_PRODUCT_VERSION
 
 # Searchable Settings index — exposed as JSON for client-side search.
-# See web/services/settings_search_index.py for the source of truth.
-from web.services.settings_search_index import get_search_index
+# See web/settings_search_index.py for the source of truth. Module lives outside
+# web/services/ to avoid a circular import (services/__init__.py loads cache_service
+# which re-imports web.config).
+from web.settings_search_index import get_search_index
 templates.env.globals["settings_search_index_json"] = json.dumps(get_search_index())
 
 

--- a/web/services/settings_search_index.py
+++ b/web/services/settings_search_index.py
@@ -1,0 +1,694 @@
+"""Searchable Settings index.
+
+Single source of truth for the Settings page search experience. Each entry maps
+a user-facing setting to its tab + DOM target (data-setting-id) and carries the
+metadata the frontend needs to render results: label, hint, section/subsection
+breadcrumb, lucide icon, color tone, and keyword synonyms.
+
+The index is exported to the client as JSON via a template global (see
+web/config.py) and consumed by web/static/js/settings_search.js. Settings
+templates annotate matching form-groups with data-setting-id="<id>" so the
+click-to-jump flow can locate and flash the target field.
+
+When adding a new setting in a template:
+    1. Add data-setting-id="some_id" to the form-group div.
+    2. Add a matching entry here.
+
+Tones map to CSS classes in custom.css:
+    ""           -> default orange
+    "tone-info"  -> blue
+    "tone-ok"    -> green
+    "tone-purple"-> purple
+    "tone-warn"  -> amber/red
+"""
+
+from typing import Any, Dict, List
+
+# Icon vocabulary aligns with lucide icons already used elsewhere in the UI.
+# Tones map to the .result-icon.tone-* classes in custom.css.
+_INDEX: List[Dict[str, Any]] = [
+    # --- Plex Server -------------------------------------------------------
+    {
+        "tab": "plex", "setting_id": "plex_url",
+        "label": "Plex URL", "hint": "Base URL of your Plex Media Server.",
+        "section": "Plex Server", "subsection": "Server Connection",
+        "icon": "link", "tone": "",
+        "keywords": ["plex", "url", "host", "address", "server", "32400", "ip"],
+    },
+    {
+        "tab": "plex", "setting_id": "plex_token",
+        "label": "Plex Token",
+        "hint": "Auth token. Click \"Get Token\" to sign in with Plex.",
+        "section": "Plex Server", "subsection": "Server Connection",
+        "icon": "key", "tone": "tone-warn",
+        "keywords": ["plex", "token", "auth", "authentication", "login", "oauth", "sign in", "api key", "credentials"],
+    },
+    {
+        "tab": "plex", "setting_id": "plex_oauth_btn",
+        "label": "Get Token (Sign in with Plex)",
+        "hint": "Open the Plex OAuth flow and capture a token automatically.",
+        "section": "Plex Server", "subsection": "Server Connection",
+        "icon": "key", "tone": "tone-warn",
+        "keywords": ["oauth", "sign in", "plex login", "get token", "auto"],
+    },
+    {
+        "tab": "plex", "setting_id": "plex_test",
+        "label": "Test Plex Connection",
+        "hint": "Verify the URL + token can reach your Plex server.",
+        "section": "Plex Server", "subsection": "Server Connection",
+        "icon": "plug", "tone": "tone-info",
+        "keywords": ["test", "verify", "ping", "connection", "check"],
+    },
+
+    # --- Libraries --------------------------------------------------------
+    {
+        "tab": "libraries", "setting_id": "library_toggles",
+        "label": "Enabled Libraries",
+        "hint": "Pick which Plex libraries PlexCache should watch and cache from.",
+        "section": "Libraries", "subsection": "",
+        "icon": "library", "tone": "",
+        "keywords": ["library", "libraries", "sections", "movies", "tv", "shows", "enable", "scan"],
+    },
+    {
+        "tab": "libraries", "setting_id": "path_mappings",
+        "label": "Path Mappings",
+        "hint": "Translate Plex paths (e.g. /data/) into local mount paths (/mnt/user/) and define cache destinations.",
+        "section": "Libraries", "subsection": "Custom Mappings",
+        "icon": "folder", "tone": "tone-info",
+        "keywords": ["path", "mapping", "mappings", "mount", "docker", "remap", "/mnt/", "/data/", "translate", "host cache", "plex path", "real path", "cache path", "name"],
+    },
+
+    # --- Users -------------------------------------------------------------
+    {
+        "tab": "users", "setting_id": "users_toggle",
+        "label": "Enable Multi-User Support",
+        "hint": "Cache media from other Plex Home users' OnDeck and Watchlist.",
+        "section": "Users", "subsection": "Multi-User Support",
+        "icon": "users", "tone": "",
+        "keywords": ["multi-user", "users", "home users", "shared", "managed users", "enable"],
+    },
+    {
+        "tab": "users", "setting_id": "users_sync_btn",
+        "label": "Sync Users from Plex",
+        "hint": "Refresh the list of Plex Home and shared users.",
+        "section": "Users", "subsection": "User Preferences",
+        "icon": "refresh-cw", "tone": "tone-info",
+        "keywords": ["sync", "refresh", "users", "fetch", "reload"],
+    },
+    {
+        "tab": "users", "setting_id": "auth_link_enabled",
+        "label": "Enable Self-Service Auth Link",
+        "hint": "Let shared users link their Plex account via a shareable URL so PlexCache can monitor their OnDeck. Requires PlexCache to be reachable (reverse proxy, Tailscale, etc.).",
+        "section": "Users", "subsection": "Self-Service Authentication",
+        "icon": "link", "tone": "tone-purple",
+        "keywords": ["self-service", "auth link", "shareable", "invite", "share", "friends", "token capture"],
+    },
+    {
+        "tab": "users", "setting_id": "auth_link_url",
+        "label": "Shareable Auth Link",
+        "hint": "URL to share with your Plex friends so they can self-link their account.",
+        "section": "Users", "subsection": "Self-Service Authentication",
+        "icon": "link", "tone": "tone-purple",
+        "keywords": ["shareable", "url", "link", "invite", "share"],
+    },
+    {
+        "tab": "users", "setting_id": "plex_db_path",
+        "label": "Plex Database Path",
+        "hint": "Path to the Plex database (read-only). Used to read OnDeck for shared users when no token is available.",
+        "section": "Users", "subsection": "Database Fallback",
+        "icon": "database", "tone": "tone-info",
+        "keywords": ["plex", "database", "db", "sqlite", "fallback", "read-only", "ondeck"],
+    },
+    {
+        "tab": "users", "setting_id": "remote_watchlist_toggle",
+        "label": "Enable Remote Watchlist (RSS fallback) – Users",
+        "hint": "Allow shared users to expose their watchlist via Plex RSS when the API isn't available.",
+        "section": "Users", "subsection": "Remote User Watchlists",
+        "icon": "rss", "tone": "tone-warn",
+        "keywords": ["rss", "feed", "remote", "watchlist", "users", "fallback", "shared"],
+    },
+    {
+        "tab": "users", "setting_id": "remote_watchlist_rss_url",
+        "label": "Remote Watchlist RSS URL – Users",
+        "hint": "Generate at: Plex Settings > Watchlist > Generate URL.",
+        "section": "Users", "subsection": "Remote User Watchlists",
+        "icon": "rss", "tone": "tone-warn",
+        "keywords": ["rss", "feed", "url", "watchlist", "plex.tv", "remote"],
+    },
+
+    # --- Cache: Content Discovery -----------------------------------------
+    {
+        "tab": "cache", "setting_id": "number_episodes",
+        "label": "Episodes to Prefetch",
+        "hint": "Upcoming episodes to cache for in-progress shows.",
+        "section": "Cache", "subsection": "Content Discovery",
+        "icon": "database", "tone": "tone-ok",
+        "keywords": ["episodes", "prefetch", "ondeck", "next", "tv", "shows", "count"],
+    },
+    {
+        "tab": "cache", "setting_id": "days_to_monitor",
+        "label": "Days to Monitor",
+        "hint": "How far back to check OnDeck for recently watched items.",
+        "section": "Cache", "subsection": "Content Discovery",
+        "icon": "clock", "tone": "tone-ok",
+        "keywords": ["days", "monitor", "ondeck", "window", "lookback", "history", "range"],
+    },
+    {
+        "tab": "cache", "setting_id": "prefetch_minimum_minutes",
+        "label": "Minimum Prefetch Runtime (minutes)",
+        "hint": "Ensures prefetched episodes cover at least this many minutes of runtime. 0 disables.",
+        "section": "Cache", "subsection": "Content Discovery",
+        "icon": "clock", "tone": "tone-ok",
+        "keywords": ["minimum", "runtime", "minutes", "prefetch", "duration", "episodes"],
+    },
+
+    # --- Cache: Watchlist --------------------------------------------------
+    {
+        "tab": "cache", "setting_id": "watchlist_toggle",
+        "label": "Enable Watchlist Caching",
+        "hint": "Cache items from each user's Plex Watchlist.",
+        "section": "Cache", "subsection": "Watchlist",
+        "icon": "bookmark", "tone": "tone-ok",
+        "keywords": ["watchlist", "queue", "enable", "toggle"],
+    },
+    {
+        "tab": "cache", "setting_id": "watchlist_episodes",
+        "label": "Watchlist Episodes to Prefetch",
+        "hint": "Episodes to cache per watchlist item.",
+        "section": "Cache", "subsection": "Watchlist",
+        "icon": "bookmark", "tone": "tone-ok",
+        "keywords": ["watchlist", "episodes", "prefetch", "count", "season"],
+    },
+
+    # --- Cache: Retention --------------------------------------------------
+    {
+        "tab": "cache", "setting_id": "cache_retention_hours",
+        "label": "Cache Retention (hours)",
+        "hint": "Keep files cached at least this long before moving back (0 = no minimum).",
+        "section": "Cache", "subsection": "Retention",
+        "icon": "clock", "tone": "tone-info",
+        "keywords": ["retention", "hours", "keep", "minimum", "cooldown"],
+    },
+    {
+        "tab": "cache", "setting_id": "watchlist_retention_days",
+        "label": "Watchlist Retention (days)",
+        "hint": "Auto-expire watchlist items after this period (0 = never).",
+        "section": "Cache", "subsection": "Retention",
+        "icon": "clock", "tone": "tone-info",
+        "keywords": ["watchlist", "retention", "expire", "days", "cleanup"],
+    },
+    {
+        "tab": "cache", "setting_id": "ondeck_retention_days",
+        "label": "OnDeck Retention (days)",
+        "hint": "Auto-expire OnDeck items after this period (0 = never).",
+        "section": "Cache", "subsection": "Retention",
+        "icon": "clock", "tone": "tone-info",
+        "keywords": ["ondeck", "retention", "expire", "days", "cleanup"],
+    },
+
+    # --- Cache: File Handling ---------------------------------------------
+    {
+        "tab": "cache", "setting_id": "watched_move",
+        "label": "Move Watched Files Back to Array",
+        "hint": "When a user finishes an item, move it from cache back to the array.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "arrow-left-right", "tone": "",
+        "keywords": ["watched", "move", "array", "return", "restore"],
+    },
+    {
+        "tab": "cache", "setting_id": "create_plexcached_backups",
+        "label": "Create .plexcached Backup Files",
+        "hint": "Keep a renamed copy on the array (.plexcached) when caching so files can be recovered if the cache drive fails.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "archive", "tone": "tone-info",
+        "keywords": ["plexcached", "backup", "safety", "recovery", "array"],
+    },
+    {
+        "tab": "cache", "setting_id": "cleanup_empty_folders",
+        "label": "Clean Up Empty Folders",
+        "hint": "Remove empty parent folders on cache after moving files to array.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "folder", "tone": "",
+        "keywords": ["cleanup", "empty", "folders", "directories", "remove"],
+    },
+    {
+        "tab": "cache", "setting_id": "use_symlinks",
+        "label": "Create Symlinks After Caching",
+        "hint": "Non-Unraid only: create a symlink at the original path pointing to the cached copy so Plex can find files.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "link", "tone": "tone-info",
+        "keywords": ["symlink", "softlink", "link", "mergerfs", "non-unraid"],
+    },
+    {
+        "tab": "cache", "setting_id": "auto_transfer_upgrades",
+        "label": "Auto-Transfer Tracking on Media Upgrades",
+        "hint": "When Sonarr/Radarr upgrades a cached file, transfer exclude list + tracker entries to the new file using Plex rating keys.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "trending-up", "tone": "tone-info",
+        "keywords": ["upgrade", "sonarr", "radarr", "transfer", "tracking", "rating key", "quality"],
+    },
+    {
+        "tab": "cache", "setting_id": "backup_upgraded_files",
+        "label": "Backup Upgraded Files",
+        "hint": "Create a .plexcached backup of the new file when a cached file is upgraded (only if the old file had a backup).",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "archive", "tone": "tone-info",
+        "keywords": ["backup", "upgrade", "sonarr", "radarr", "plexcached"],
+    },
+    {
+        "tab": "cache", "setting_id": "hardlinked_files",
+        "label": "Hardlinked Files Handling",
+        "hint": "Files with multiple hardlinks (e.g., seeding torrents). Skip preserves links; Move copies.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "link", "tone": "tone-warn",
+        "keywords": ["hardlink", "hardlinks", "torrent", "seeding", "links"],
+    },
+    {
+        "tab": "cache", "setting_id": "check_hardlinks_on_restore",
+        "label": "Check Hardlinks on Restore",
+        "hint": "Skip cached files with multiple hardlinks (e.g., actively seeding) when moving back to array.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "link", "tone": "tone-warn",
+        "keywords": ["hardlink", "restore", "skip", "seeding", "torrent"],
+    },
+    {
+        "tab": "cache", "setting_id": "cache_associated_files",
+        "label": "Associated Files",
+        "hint": "Which files to cache alongside videos: subtitles, artwork, NFO sidecars.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "file-text", "tone": "",
+        "keywords": ["associated", "sidecar", "subtitles", "subs", "srt", "nfo", "artwork", "metadata"],
+    },
+    {
+        "tab": "cache", "setting_id": "excluded_folders",
+        "label": "Excluded Folders",
+        "hint": "Folders to skip during scanning. Common examples: @Recycle, #recycle.",
+        "section": "Cache", "subsection": "File Handling",
+        "icon": "folder-x", "tone": "tone-warn",
+        "keywords": ["excluded", "ignore", "skip", "folders", "recycle", "trash"],
+    },
+
+    # --- Cache: Storage Limits --------------------------------------------
+    {
+        "tab": "cache", "setting_id": "cache_drive_size",
+        "label": "Cache Drive Size",
+        "hint": "Override auto-detected size (e.g., 3.7TB). For ZFS pools where dataset size differs from pool size.",
+        "section": "Cache", "subsection": "Storage Limits",
+        "icon": "hard-drive", "tone": "",
+        "keywords": ["cache", "drive", "size", "capacity", "zfs", "override"],
+    },
+    {
+        "tab": "cache", "setting_id": "cache_limit",
+        "label": "Cache Limit",
+        "hint": "Max total drive usage before PlexCache stops caching (e.g., 500GB or 75%).",
+        "section": "Cache", "subsection": "Storage Limits",
+        "icon": "hard-drive", "tone": "tone-warn",
+        "keywords": ["limit", "cap", "size", "max", "storage", "quota"],
+    },
+    {
+        "tab": "cache", "setting_id": "min_free_space",
+        "label": "Min Free Space",
+        "hint": "Safety floor: always keep at least this much free space on the drive.",
+        "section": "Cache", "subsection": "Storage Limits",
+        "icon": "hard-drive", "tone": "tone-warn",
+        "keywords": ["free", "space", "floor", "minimum", "safety", "reserve"],
+    },
+    {
+        "tab": "cache", "setting_id": "plexcache_quota",
+        "label": "PlexCache Quota",
+        "hint": "Max space for PlexCache-managed files only (excludes other apps).",
+        "section": "Cache", "subsection": "Storage Limits",
+        "icon": "hard-drive", "tone": "tone-warn",
+        "keywords": ["quota", "limit", "plexcache", "managed", "cap"],
+    },
+
+    # --- Cache: Eviction ---------------------------------------------------
+    {
+        "tab": "cache", "setting_id": "cache_eviction_mode",
+        "label": "Eviction Mode",
+        "hint": "How to choose files to evict when the cache fills.",
+        "section": "Cache", "subsection": "Eviction",
+        "icon": "trash-2", "tone": "tone-warn",
+        "keywords": ["eviction", "evict", "mode", "policy", "lru", "priority"],
+    },
+    {
+        "tab": "cache", "setting_id": "cache_eviction_threshold_percent",
+        "label": "Eviction Threshold (%)",
+        "hint": "Start evicting low-priority files when usage exceeds this percent of your Cache Limit.",
+        "section": "Cache", "subsection": "Eviction",
+        "icon": "trash-2", "tone": "tone-warn",
+        "keywords": ["eviction", "threshold", "percent", "trigger", "watermark"],
+    },
+    {
+        "tab": "cache", "setting_id": "eviction_min_priority",
+        "label": "Minimum Priority to Keep",
+        "hint": "Only evict files below this priority (OnDeck ~60-80, Watchlist ~40-60).",
+        "section": "Cache", "subsection": "Eviction",
+        "icon": "trash-2", "tone": "tone-warn",
+        "keywords": ["eviction", "priority", "minimum", "keep", "protect", "score"],
+    },
+
+    # --- Cache: Advanced ---------------------------------------------------
+    {
+        "tab": "cache", "setting_id": "exit_if_active_session",
+        "label": "Skip Run if Plex Has Active Playback",
+        "hint": "Exit without processing if someone is currently watching.",
+        "section": "Cache", "subsection": "Advanced",
+        "icon": "pause", "tone": "tone-info",
+        "keywords": ["active", "session", "playing", "watching", "skip", "exit", "playback"],
+    },
+    {
+        "tab": "cache", "setting_id": "max_concurrent_moves_cache",
+        "label": "Concurrent Moves to Cache",
+        "hint": "Max parallel file operations when moving TO cache (default: 5).",
+        "section": "Cache", "subsection": "Advanced",
+        "icon": "git-branch", "tone": "",
+        "keywords": ["concurrent", "parallel", "moves", "threads", "workers", "cache"],
+    },
+    {
+        "tab": "cache", "setting_id": "max_concurrent_moves_array",
+        "label": "Concurrent Moves to Array",
+        "hint": "Max parallel file operations when moving TO array (default: 2).",
+        "section": "Cache", "subsection": "Advanced",
+        "icon": "git-branch", "tone": "",
+        "keywords": ["concurrent", "parallel", "moves", "threads", "workers", "array"],
+    },
+
+    # --- Cache: Pinned Media ----------------------------------------------
+    {
+        "tab": "cache", "setting_id": "pinned_preferred_resolution",
+        "label": "Pinned Preferred Version",
+        "hint": "Which version to cache when a pinned item has multiple media files (e.g., 4K + 1080p).",
+        "section": "Cache", "subsection": "Pinned Media",
+        "icon": "pin", "tone": "tone-purple",
+        "keywords": ["pinned", "pin", "preferred", "version", "resolution", "4k", "1080p"],
+    },
+    {
+        "tab": "cache", "setting_id": "pinned_search",
+        "label": "Search Plex (Pin Media)",
+        "hint": "Pick a movie, show, season, or episode to pin to the cache.",
+        "section": "Cache", "subsection": "Pinned Media",
+        "icon": "search", "tone": "tone-purple",
+        "keywords": ["pin", "pinned", "search", "plex", "media", "force cache"],
+    },
+
+    # --- Schedule ----------------------------------------------------------
+    {
+        "tab": "schedule", "setting_id": "schedule_enabled",
+        "label": "Enable Scheduled Runs",
+        "hint": "Run PlexCache automatically on a schedule while the Web UI is up.",
+        "section": "Schedule", "subsection": "",
+        "icon": "clock", "tone": "tone-info",
+        "keywords": ["schedule", "enable", "auto", "automatic", "cron", "timer"],
+    },
+    {
+        "tab": "schedule", "setting_id": "schedule_type",
+        "label": "Schedule Type",
+        "hint": "Choose between simple interval or advanced cron expression.",
+        "section": "Schedule", "subsection": "",
+        "icon": "clock", "tone": "tone-info",
+        "keywords": ["schedule", "type", "interval", "cron", "mode"],
+    },
+    {
+        "tab": "schedule", "setting_id": "interval_hours",
+        "label": "Run Every (interval)",
+        "hint": "Run interval in hours.",
+        "section": "Schedule", "subsection": "",
+        "icon": "clock", "tone": "tone-info",
+        "keywords": ["interval", "every", "hours", "frequency", "schedule"],
+    },
+    {
+        "tab": "schedule", "setting_id": "interval_start_time",
+        "label": "Starting At (anchor time)",
+        "hint": "Anchor time for the schedule (e.g., 02:00 means runs at 02:00, 06:00, 10:00...).",
+        "section": "Schedule", "subsection": "",
+        "icon": "clock", "tone": "tone-info",
+        "keywords": ["start", "anchor", "time", "begin", "schedule"],
+    },
+    {
+        "tab": "schedule", "setting_id": "cron_expression",
+        "label": "Cron Expression",
+        "hint": "Format: minute hour day month weekday. e.g., 0 */4 * * * (every 4 hours).",
+        "section": "Schedule", "subsection": "",
+        "icon": "clock", "tone": "tone-info",
+        "keywords": ["cron", "crontab", "expression", "advanced", "schedule", "syntax"],
+    },
+    {
+        "tab": "schedule", "setting_id": "cron_validate_btn",
+        "label": "Validate Cron Expression",
+        "hint": "Check that the cron syntax parses correctly.",
+        "section": "Schedule", "subsection": "",
+        "icon": "check", "tone": "tone-ok",
+        "keywords": ["validate", "check", "cron", "syntax", "test"],
+    },
+    {
+        "tab": "schedule", "setting_id": "dry_run",
+        "label": "Dry Run",
+        "hint": "Simulate without moving files (logs only).",
+        "section": "Schedule", "subsection": "Run Options",
+        "icon": "play-circle", "tone": "",
+        "keywords": ["dry run", "dry-run", "simulate", "preview", "no-op"],
+    },
+    {
+        "tab": "schedule", "setting_id": "verbose",
+        "label": "Verbose Logging",
+        "hint": "Enable detailed debug output during scheduled runs.",
+        "section": "Schedule", "subsection": "Run Options",
+        "icon": "file-text", "tone": "",
+        "keywords": ["verbose", "debug", "logging", "detailed", "log"],
+    },
+
+    # --- Notifications -----------------------------------------------------
+    {
+        "tab": "notifications", "setting_id": "notification_type",
+        "label": "Notification Type",
+        "hint": "Choose Unraid, Webhook, or both.",
+        "section": "Notifications", "subsection": "",
+        "icon": "bell", "tone": "",
+        "keywords": ["notify", "notification", "type", "channel"],
+    },
+    {
+        "tab": "notifications", "setting_id": "unraid_levels",
+        "label": "Unraid Notification Levels",
+        "hint": "Which events to send to Unraid's notification system: summary, activity, success, warning, error.",
+        "section": "Notifications", "subsection": "Unraid Notifications",
+        "icon": "bell", "tone": "tone-info",
+        "keywords": ["unraid", "levels", "summary", "activity", "success", "warning", "error"],
+    },
+    {
+        "tab": "notifications", "setting_id": "webhook_url",
+        "label": "Webhook URL",
+        "hint": "Discord, Slack, or any Discord-compatible webhook endpoint.",
+        "section": "Notifications", "subsection": "Webhook Notifications",
+        "icon": "webhook", "tone": "tone-purple",
+        "keywords": ["webhook", "discord", "slack", "url", "notify", "chat", "endpoint"],
+    },
+    {
+        "tab": "notifications", "setting_id": "test_webhook_btn",
+        "label": "Test Webhook",
+        "hint": "Send a test notification to verify the webhook URL works.",
+        "section": "Notifications", "subsection": "Webhook Notifications",
+        "icon": "send", "tone": "tone-purple",
+        "keywords": ["test", "webhook", "verify", "ping", "discord", "slack"],
+    },
+    {
+        "tab": "notifications", "setting_id": "webhook_levels",
+        "label": "Webhook Notification Levels",
+        "hint": "Which events to send via webhook: summary, activity, success, warning, error.",
+        "section": "Notifications", "subsection": "Webhook Notifications",
+        "icon": "webhook", "tone": "tone-purple",
+        "keywords": ["webhook", "levels", "summary", "activity", "success", "warning", "error"],
+    },
+
+    # --- Logging -----------------------------------------------------------
+    {
+        "tab": "logging", "setting_id": "max_log_files",
+        "label": "Maximum Log Files",
+        "hint": "Number of log files to keep (one per run).",
+        "section": "Logging", "subsection": "Log Retention",
+        "icon": "archive", "tone": "",
+        "keywords": ["log", "logs", "retention", "rotation", "max", "files"],
+    },
+    {
+        "tab": "logging", "setting_id": "keep_error_logs_days",
+        "label": "Error Log Retention (days)",
+        "hint": "Days to keep logs containing warnings/errors (0 = disabled).",
+        "section": "Logging", "subsection": "Log Retention",
+        "icon": "archive", "tone": "tone-warn",
+        "keywords": ["error", "warning", "retention", "days", "keep"],
+    },
+    {
+        "tab": "logging", "setting_id": "time_format",
+        "label": "Time Format",
+        "hint": "12-hour or 24-hour clock for timestamps in the Web UI.",
+        "section": "Logging", "subsection": "Time Display",
+        "icon": "clock", "tone": "",
+        "keywords": ["time", "format", "12h", "24h", "am", "pm", "clock", "timestamp"],
+    },
+    {
+        "tab": "logging", "setting_id": "activity_retention_hours",
+        "label": "Recent Activity Retention (hours)",
+        "hint": "How long Recent Activity entries persist on the Dashboard.",
+        "section": "Logging", "subsection": "Dashboard",
+        "icon": "activity", "tone": "tone-purple",
+        "keywords": ["activity", "retention", "dashboard", "history", "recent", "hours"],
+    },
+
+    # --- Integrations ------------------------------------------------------
+    {
+        "tab": "integrations", "setting_id": "arr_instances",
+        "label": "Sonarr / Radarr Instances",
+        "hint": "Add a Sonarr or Radarr server. Used to detect quality-upgrade file swaps so trackers transfer correctly.",
+        "section": "Integrations", "subsection": "",
+        "icon": "plug", "tone": "tone-info",
+        "keywords": ["sonarr", "radarr", "arr", "upgrades", "api", "name", "type", "url"],
+    },
+    {
+        "tab": "integrations", "setting_id": "arr_api_key",
+        "label": "Sonarr / Radarr API Key",
+        "hint": "Found under Settings > General > API Key in Sonarr/Radarr.",
+        "section": "Integrations", "subsection": "",
+        "icon": "key", "tone": "tone-warn",
+        "keywords": ["api key", "sonarr", "radarr", "arr", "token", "credentials"],
+    },
+    {
+        "tab": "integrations", "setting_id": "arr_test_btn",
+        "label": "Test Sonarr / Radarr Instance",
+        "hint": "Verify the URL + API key can reach the instance.",
+        "section": "Integrations", "subsection": "",
+        "icon": "plug", "tone": "tone-info",
+        "keywords": ["test", "sonarr", "radarr", "verify", "ping"],
+    },
+
+    # --- Security ----------------------------------------------------------
+    {
+        "tab": "security", "setting_id": "auth_enabled",
+        "label": "Require Login for Web UI",
+        "hint": "Only the Plex server owner can sign in to access the Web UI.",
+        "section": "Security", "subsection": "Web UI Authentication",
+        "icon": "shield", "tone": "tone-warn",
+        "keywords": ["auth", "login", "password", "security", "gate", "sign in", "require"],
+    },
+    {
+        "tab": "security", "setting_id": "auth_session_hours",
+        "label": "Session Duration",
+        "hint": "How long a login session lasts. \"Remember me\" extends to 7 days.",
+        "section": "Security", "subsection": "Web UI Authentication",
+        "icon": "clock", "tone": "tone-warn",
+        "keywords": ["session", "duration", "expiry", "logout", "remember me"],
+    },
+    {
+        "tab": "security", "setting_id": "auth_password_enabled",
+        "label": "Enable Password Login",
+        "hint": "Optional password login as fallback when Plex OAuth is unavailable.",
+        "section": "Security", "subsection": "Password Fallback",
+        "icon": "lock", "tone": "tone-warn",
+        "keywords": ["password", "login", "fallback", "local", "credentials"],
+    },
+    {
+        "tab": "security", "setting_id": "auth_password_username",
+        "label": "Username (Password Fallback)",
+        "hint": "Local username for password login.",
+        "section": "Security", "subsection": "Password Fallback",
+        "icon": "user", "tone": "tone-warn",
+        "keywords": ["username", "login", "user", "credentials", "password"],
+    },
+    {
+        "tab": "security", "setting_id": "auth_password",
+        "label": "New Password",
+        "hint": "Local password for fallback login. Leave blank to keep current.",
+        "section": "Security", "subsection": "Password Fallback",
+        "icon": "key", "tone": "tone-warn",
+        "keywords": ["password", "auth", "login", "credentials", "change"],
+    },
+    {
+        "tab": "security", "setting_id": "logout_all_btn",
+        "label": "Sign Out All Sessions",
+        "hint": "Invalidate every active login token.",
+        "section": "Security", "subsection": "Active Sessions",
+        "icon": "log-out", "tone": "tone-warn",
+        "keywords": ["logout", "sign out", "sessions", "revoke", "all"],
+    },
+
+    # --- Import / Export ---------------------------------------------------
+    {
+        "tab": "import-export", "setting_id": "include_sensitive",
+        "label": "Include Sensitive Data in Export",
+        "hint": "When unchecked, redacts tokens, URLs, webhooks, client ID, usernames, and user IDs.",
+        "section": "Import / Export", "subsection": "Export Settings",
+        "icon": "shield", "tone": "tone-warn",
+        "keywords": ["sensitive", "redact", "export", "share", "tokens", "privacy"],
+    },
+    {
+        "tab": "import-export", "setting_id": "download_backup_btn",
+        "label": "Download Settings Backup",
+        "hint": "Download your current settings as a JSON file for backup or migration.",
+        "section": "Import / Export", "subsection": "Export Settings",
+        "icon": "download", "tone": "",
+        "keywords": ["download", "backup", "export", "save", "json", "settings"],
+    },
+    {
+        "tab": "import-export", "setting_id": "settings_file",
+        "label": "Settings File (Import)",
+        "hint": "Select a PlexCache backup JSON file to import.",
+        "section": "Import / Export", "subsection": "Import Settings",
+        "icon": "upload", "tone": "",
+        "keywords": ["import", "settings", "file", "json", "restore", "upload"],
+    },
+    {
+        "tab": "import-export", "setting_id": "import_mode",
+        "label": "Import Mode",
+        "hint": "Merge with current settings or replace everything.",
+        "section": "Import / Export", "subsection": "Import Settings",
+        "icon": "arrow-left-right", "tone": "",
+        "keywords": ["import", "mode", "merge", "replace", "overwrite"],
+    },
+    {
+        "tab": "import-export", "setting_id": "validate_settings_btn",
+        "label": "Validate Settings File",
+        "hint": "Check the uploaded JSON before importing.",
+        "section": "Import / Export", "subsection": "Import Settings",
+        "icon": "check", "tone": "tone-ok",
+        "keywords": ["validate", "check", "import", "settings", "verify"],
+    },
+    {
+        "tab": "import-export", "setting_id": "import_settings_btn",
+        "label": "Import Settings",
+        "hint": "Apply the validated settings file.",
+        "section": "Import / Export", "subsection": "Import Settings",
+        "icon": "upload", "tone": "tone-info",
+        "keywords": ["import", "apply", "restore", "settings"],
+    },
+    {
+        "tab": "import-export", "setting_id": "cli_cache_prefix",
+        "label": "CLI Cache Path Prefix",
+        "hint": "The cache path used in your CLI installation (for migration).",
+        "section": "Import / Export", "subsection": "CLI Migration",
+        "icon": "folder", "tone": "tone-info",
+        "keywords": ["cli", "migration", "cache", "path", "prefix", "import"],
+    },
+    {
+        "tab": "import-export", "setting_id": "docker_cache_prefix",
+        "label": "Docker Cache Path",
+        "hint": "The cache path inside your Docker container (usually /mnt/cache/).",
+        "section": "Import / Export", "subsection": "CLI Migration",
+        "icon": "folder", "tone": "tone-info",
+        "keywords": ["docker", "cache", "path", "container", "migration"],
+    },
+    {
+        "tab": "import-export", "setting_id": "cli_import_btn",
+        "label": "Import CLI Data",
+        "hint": "Import configuration and tracking data from a CLI installation.",
+        "section": "Import / Export", "subsection": "CLI Migration",
+        "icon": "upload", "tone": "tone-info",
+        "keywords": ["cli", "import", "migration", "data", "tracking"],
+    },
+]
+
+
+def get_search_index() -> List[Dict[str, Any]]:
+    """Return the searchable settings index.
+
+    The list is returned as-is (no copy). Callers must treat it as read-only.
+    """
+    return _INDEX

--- a/web/settings_search_index.py
+++ b/web/settings_search_index.py
@@ -14,6 +14,11 @@ When adding a new setting in a template:
     1. Add data-setting-id="some_id" to the form-group div.
     2. Add a matching entry here.
 
+This module lives at web/ (not under web/services/) to avoid a circular import:
+web.config imports from here, but services/__init__.py imports cache_service
+which re-imports web.config. Keeping this module as pure data with no project
+imports lets web.config pull it in cleanly during initial load.
+
 Tones map to CSS classes in custom.css:
     ""           -> default orange
     "tone-info"  -> blue

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1401,3 +1401,311 @@ footer {
 .pinned-row-pending-unpin .pinned-unpin-btn {
     cursor: default;
 }
+
+/* ============================================================
+   Settings Search
+   See web/services/settings_search_index.py + settings_search.js
+   ============================================================ */
+.settings-search {
+    position: relative;
+    margin-bottom: 1.25rem;
+}
+.settings-search-input-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+    background: var(--plex-bg-card);
+    border: 1px solid var(--plex-border);
+    border-radius: var(--plex-radius-md);
+    padding: 0 0.85rem;
+    transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+.settings-search-input-wrap:focus-within {
+    border-color: rgba(229, 160, 13, 0.5);
+    box-shadow: 0 0 0 3px rgba(229, 160, 13, 0.12);
+}
+.settings-search-lead {
+    width: 18px;
+    height: 18px;
+    color: var(--plex-text-muted);
+    flex-shrink: 0;
+}
+#settings-search-input {
+    flex: 1;
+    background: transparent;
+    border: 0;
+    outline: 0;
+    color: var(--plex-text);
+    font-size: 1rem;
+    padding: 0.75rem 0.65rem;
+    min-width: 0;
+}
+#settings-search-input::placeholder {
+    color: var(--plex-text-muted);
+}
+.settings-search-kbd {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.7rem;
+    color: var(--plex-text-muted);
+    background: var(--plex-bg-input);
+    border: 1px solid var(--plex-border);
+    border-radius: var(--plex-radius-xs);
+    padding: 0.15rem 0.4rem;
+    flex-shrink: 0;
+}
+.settings-search-kbd .kbd-mod {
+    font-size: 0.9em;
+    opacity: 0.9;
+}
+.settings-search-clear {
+    background: transparent;
+    border: 0;
+    color: var(--plex-text-muted);
+    cursor: pointer;
+    padding: 0.25rem;
+    display: none;
+    align-items: center;
+    justify-content: center;
+}
+.settings-search-clear i {
+    width: 16px;
+    height: 16px;
+}
+.settings-search-clear:hover {
+    color: var(--plex-text);
+}
+.settings-search.has-query .settings-search-clear {
+    display: inline-flex;
+}
+.settings-search.has-query .settings-search-kbd {
+    display: none;
+}
+
+/* Results panel */
+.settings-search-results {
+    margin-top: 0.75rem;
+    background: var(--plex-bg-card);
+    border: 1px solid var(--plex-border);
+    border-radius: var(--plex-radius-md);
+    box-shadow: var(--plex-shadow-card);
+    overflow: hidden;
+    max-height: 60vh;
+    overflow-y: auto;
+    display: none;
+}
+.settings-search.has-query .settings-search-results {
+    display: block;
+}
+
+.ss-results-summary {
+    padding: 0.65rem 1rem;
+    border-bottom: 1px solid var(--plex-border);
+    font-size: 0.8rem;
+    color: var(--plex-text-muted);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.ss-results-summary kbd {
+    font-family: ui-monospace, monospace;
+    font-size: 0.7rem;
+    background: var(--plex-bg-input);
+    border: 1px solid var(--plex-border);
+    border-radius: var(--plex-radius-xs);
+    padding: 0.1rem 0.35rem;
+    color: var(--plex-text-light);
+}
+
+.ss-results-group {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--plex-border);
+}
+.ss-results-group:last-child {
+    border-bottom: 0;
+}
+.ss-results-group-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--plex-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.ss-results-group-header i {
+    width: 12px;
+    height: 12px;
+}
+
+.ss-result-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    padding: 0.7rem 1rem;
+    cursor: pointer;
+    border-left: 3px solid transparent;
+    transition: background 120ms ease, border-color 120ms ease;
+}
+.ss-result-row:hover {
+    background: var(--plex-bg-hover);
+}
+.ss-result-row.is-selected {
+    background: var(--plex-bg-hover);
+    border-left-color: var(--plex-orange);
+}
+.ss-result-icon {
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    border-radius: var(--plex-radius-sm);
+    background: rgba(229, 160, 13, 0.08);
+    color: var(--plex-orange);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.ss-result-icon i {
+    width: 16px;
+    height: 16px;
+}
+.ss-result-icon.tone-info  { background: rgba(10, 132, 255, 0.10); color: var(--plex-info); }
+.ss-result-icon.tone-ok    { background: rgba(52, 199, 89, 0.10); color: var(--plex-success); }
+.ss-result-icon.tone-purple{ background: rgba(167, 139, 250, 0.12); color: var(--plex-purple); }
+.ss-result-icon.tone-warn  { background: rgba(255, 152, 0, 0.10); color: var(--plex-warning); }
+.ss-result-body {
+    flex: 1;
+    min-width: 0;
+}
+.ss-result-crumb {
+    font-size: 0.72rem;
+    color: var(--plex-text-muted);
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-bottom: 0.15rem;
+    flex-wrap: wrap;
+}
+.ss-result-crumb i {
+    width: 11px;
+    height: 11px;
+}
+.ss-result-label {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--plex-text);
+}
+.ss-result-hint {
+    font-size: 0.82rem;
+    color: var(--plex-text-muted);
+    margin-top: 0.1rem;
+    line-height: 1.35;
+}
+.ss-result-row mark {
+    background: rgba(229, 160, 13, 0.25);
+    color: var(--plex-orange-light);
+    padding: 0 0.1rem;
+    border-radius: 2px;
+}
+[data-theme="light"] .ss-result-row mark {
+    color: var(--plex-orange-dark);
+    background: rgba(229, 160, 13, 0.30);
+}
+.ss-result-arrow {
+    color: var(--plex-text-muted);
+    align-self: center;
+    flex-shrink: 0;
+}
+.ss-result-arrow i {
+    width: 14px;
+    height: 14px;
+}
+
+/* Empty state */
+.ss-empty-state {
+    padding: 1rem 1rem 0.25rem;
+}
+.ss-empty-section {
+    margin-bottom: 1rem;
+}
+.ss-empty-section:last-child {
+    margin-bottom: 0;
+}
+.ss-empty-section h4 {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: var(--plex-text-muted);
+    letter-spacing: 0.05em;
+    margin: 0 0 0.5rem 0;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.ss-empty-section h4 i {
+    width: 12px;
+    height: 12px;
+}
+.ss-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+.ss-chip {
+    background: var(--plex-bg-input);
+    border: 1px solid var(--plex-border);
+    color: var(--plex-text);
+    padding: 0.35rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    cursor: pointer;
+    transition: background 120ms ease, border-color 120ms ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+.ss-chip:hover {
+    background: var(--plex-bg-hover);
+    border-color: var(--plex-border-light);
+}
+.ss-chip-icon {
+    width: 12px;
+    height: 12px;
+}
+
+.ss-no-results {
+    text-align: center;
+    padding: 2rem 1rem;
+    color: var(--plex-text-muted);
+}
+.ss-no-results i {
+    width: 32px;
+    height: 32px;
+    margin-bottom: 0.5rem;
+    opacity: 0.5;
+}
+.ss-no-results-hint {
+    font-size: 0.78rem;
+    margin-top: 0.4rem;
+}
+
+/* Jump-and-flash highlight on the target setting (click-through from a result) */
+@keyframes ss-flash-ring {
+    0%   { box-shadow: 0 0 0 0   rgba(229, 160, 13, 0.55); background-color: rgba(229, 160, 13, 0.08); }
+    35%  { box-shadow: 0 0 0 6px rgba(229, 160, 13, 0.30); background-color: rgba(229, 160, 13, 0.10); }
+    100% { box-shadow: 0 0 0 0   rgba(229, 160, 13, 0);    background-color: transparent; }
+}
+.ss-flash-highlight {
+    animation: ss-flash-ring 1700ms ease-out;
+    border-radius: var(--plex-radius-sm);
+}
+.ss-flash-highlight-card {
+    border-color: rgba(229, 160, 13, 0.45) !important;
+    transition: border-color 1700ms ease;
+}

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1715,7 +1715,6 @@ footer {
 .ss-flash-highlight {
     outline: 3px solid rgba(229, 160, 13, 0.85);
     outline-offset: 2px;
-    box-shadow: inset 3px 0 0 rgba(229, 160, 13, 0.95);
     border-radius: var(--plex-radius-sm);
     animation: ss-flash-pulse 1100ms ease-out forwards;
 }
@@ -1729,13 +1728,11 @@ footer {
     border-radius: var(--plex-radius-sm);
     outline: 2px solid rgba(229, 160, 13, 0.60);
     outline-offset: 6px;
-    box-shadow: inset 3px 0 0 rgba(229, 160, 13, 0.95);
     background-color: rgba(229, 160, 13, 0.05);
-    transition: outline-color 420ms ease, background-color 420ms ease, box-shadow 420ms ease;
+    transition: outline-color 420ms ease, background-color 420ms ease;
 }
 .ss-flash-pinned.is-dismissing {
     outline-color: rgba(229, 160, 13, 0);
-    box-shadow: inset 3px 0 0 rgba(229, 160, 13, 0);
     background-color: transparent;
 }
 .ss-flash-pinned-card {

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1440,6 +1440,13 @@ footer {
     padding: 0.75rem 0.65rem;
     min-width: 0;
 }
+/* Suppress the global input:focus ring (plex-theme.css) — the wrapper's
+   :focus-within already provides the visual focus indicator, so the inner ring
+   would render a confusing double-outline. */
+#settings-search-input:focus {
+    box-shadow: none;
+    border-color: transparent;
+}
 #settings-search-input::placeholder {
     color: var(--plex-text-muted);
 }

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1703,39 +1703,43 @@ footer {
 }
 
 /* Jump-and-flash highlight on the target setting (click-through from a result).
- * Two-phase: bright ring/glow pulse, then a thin left-edge accent + soft ring
- * that persists until the user clicks or types so they can find their place. */
-@keyframes ss-flash-ring {
-    0%   { box-shadow: 0 0 0 0   rgba(229, 160, 13, 0.55); background-color: rgba(229, 160, 13, 0.08); }
-    40%  { box-shadow: 0 0 0 6px rgba(229, 160, 13, 0.32); background-color: rgba(229, 160, 13, 0.10); }
-    100% { box-shadow: 0 0 0 0   rgba(229, 160, 13, 0);    background-color: transparent; }
+ * Two-phase: bright outline pulse, then a padded outline that persists until
+ * the user clicks or presses a key, so they can find their place after the
+ * pulse fades. outline-offset puts a visible gap between the element edge
+ * and the ring (no layout shift). */
+@keyframes ss-flash-pulse {
+    0%   { outline-color: rgba(229, 160, 13, 0.85); outline-offset: 2px; background-color: rgba(229, 160, 13, 0.14); }
+    40%  { outline-color: rgba(229, 160, 13, 0.95); outline-offset: 8px; background-color: rgba(229, 160, 13, 0.20); }
+    100% { outline-color: rgba(229, 160, 13, 0.55); outline-offset: 6px; background-color: rgba(229, 160, 13, 0.06); }
 }
 .ss-flash-highlight {
-    animation: ss-flash-ring 1000ms ease-out;
+    outline: 3px solid rgba(229, 160, 13, 0.85);
+    outline-offset: 2px;
+    box-shadow: inset 3px 0 0 rgba(229, 160, 13, 0.95);
     border-radius: var(--plex-radius-sm);
+    animation: ss-flash-pulse 1100ms ease-out forwards;
 }
 .ss-flash-highlight-card {
-    border-color: rgba(229, 160, 13, 0.45) !important;
-    transition: border-color 1000ms ease;
+    border-color: rgba(229, 160, 13, 0.55) !important;
+    transition: border-color 1100ms ease;
 }
 
-/* Persistent marker after the initial flash. Cleared by JS on user interaction. */
+/* Persistent marker after the pulse. Cleared by JS on user interaction. */
 .ss-flash-pinned {
     border-radius: var(--plex-radius-sm);
-    box-shadow:
-        inset 3px 0 0 rgba(229, 160, 13, 0.85),
-        0 0 0 1px rgba(229, 160, 13, 0.22);
-    background-color: rgba(229, 160, 13, 0.035);
-    transition: box-shadow 420ms ease, background-color 420ms ease;
+    outline: 2px solid rgba(229, 160, 13, 0.60);
+    outline-offset: 6px;
+    box-shadow: inset 3px 0 0 rgba(229, 160, 13, 0.95);
+    background-color: rgba(229, 160, 13, 0.05);
+    transition: outline-color 420ms ease, background-color 420ms ease, box-shadow 420ms ease;
 }
 .ss-flash-pinned.is-dismissing {
-    box-shadow:
-        inset 3px 0 0 rgba(229, 160, 13, 0),
-        0 0 0 1px rgba(229, 160, 13, 0);
+    outline-color: rgba(229, 160, 13, 0);
+    box-shadow: inset 3px 0 0 rgba(229, 160, 13, 0);
     background-color: transparent;
 }
 .ss-flash-pinned-card {
-    border-color: rgba(229, 160, 13, 0.35) !important;
+    border-color: rgba(229, 160, 13, 0.45) !important;
     transition: border-color 420ms ease;
 }
 .ss-flash-pinned-card.is-dismissing {

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1702,17 +1702,42 @@ footer {
     margin-top: 0.4rem;
 }
 
-/* Jump-and-flash highlight on the target setting (click-through from a result) */
+/* Jump-and-flash highlight on the target setting (click-through from a result).
+ * Two-phase: bright ring/glow pulse, then a thin left-edge accent + soft ring
+ * that persists until the user clicks or types so they can find their place. */
 @keyframes ss-flash-ring {
     0%   { box-shadow: 0 0 0 0   rgba(229, 160, 13, 0.55); background-color: rgba(229, 160, 13, 0.08); }
-    35%  { box-shadow: 0 0 0 6px rgba(229, 160, 13, 0.30); background-color: rgba(229, 160, 13, 0.10); }
+    40%  { box-shadow: 0 0 0 6px rgba(229, 160, 13, 0.32); background-color: rgba(229, 160, 13, 0.10); }
     100% { box-shadow: 0 0 0 0   rgba(229, 160, 13, 0);    background-color: transparent; }
 }
 .ss-flash-highlight {
-    animation: ss-flash-ring 1700ms ease-out;
+    animation: ss-flash-ring 1000ms ease-out;
     border-radius: var(--plex-radius-sm);
 }
 .ss-flash-highlight-card {
     border-color: rgba(229, 160, 13, 0.45) !important;
-    transition: border-color 1700ms ease;
+    transition: border-color 1000ms ease;
+}
+
+/* Persistent marker after the initial flash. Cleared by JS on user interaction. */
+.ss-flash-pinned {
+    border-radius: var(--plex-radius-sm);
+    box-shadow:
+        inset 3px 0 0 rgba(229, 160, 13, 0.85),
+        0 0 0 1px rgba(229, 160, 13, 0.22);
+    background-color: rgba(229, 160, 13, 0.035);
+    transition: box-shadow 420ms ease, background-color 420ms ease;
+}
+.ss-flash-pinned.is-dismissing {
+    box-shadow:
+        inset 3px 0 0 rgba(229, 160, 13, 0),
+        0 0 0 1px rgba(229, 160, 13, 0);
+    background-color: transparent;
+}
+.ss-flash-pinned-card {
+    border-color: rgba(229, 160, 13, 0.35) !important;
+    transition: border-color 420ms ease;
+}
+.ss-flash-pinned-card.is-dismissing {
+    border-color: rgba(229, 160, 13, 0) !important;
 }

--- a/web/static/js/settings_search.js
+++ b/web/static/js/settings_search.js
@@ -270,65 +270,31 @@
 
     function flashTarget(settingId) {
         // Some settings live inside HTMX-loaded sub-partials (e.g. user rows,
-        // path-mapping rows). Poll for up to 3s so cross-tab navigation, slow
-        // partials, or first paint don't drop the highlight on the floor.
+        // path-mapping rows). Poll for up to 3s so cross-tab navigation and
+        // slow partials don't drop the highlight on the floor.
         // :not(.ss-result-row) excludes the search popup rows, which also
         // carry data-setting-id for click delegation but live inside the
-        // (hidden) results panel — without this filter the flash lands on
+        // hidden results panel — without this filter the flash would land on
         // an invisible element.
         var attempts = 0;
         var MAX_ATTEMPTS = 30;  // ~3s at 100ms per tick
         var selector = '[data-setting-id="' + cssEscape(settingId) + '"]:not(.ss-result-row)';
-        console.info('[settings-search] flashTarget:', settingId);
 
         function tryFlash() {
             var target = document.querySelector(selector);
             if (!target) {
                 attempts++;
-                if (attempts < MAX_ATTEMPTS) {
-                    setTimeout(tryFlash, 100);
-                } else {
-                    console.warn('[settings-search] Target not found after retries:', settingId, '(selector:', selector + ')');
-                }
+                if (attempts < MAX_ATTEMPTS) setTimeout(tryFlash, 100);
                 return;
-            }
-            if (attempts > 0) {
-                console.info('[settings-search] Target found after', attempts, 'retries:', settingId);
             }
             applyFlash(target);
         }
 
-        // First attempt on the next frame so layout has settled
         requestAnimationFrame(tryFlash);
-    }
-
-    // Inline style fallback so the highlight is visible even if a stale or
-    // mis-cached stylesheet is in play. CSS classes still drive the animation;
-    // these guarantee at least a visible static outline + tint.
-    var PIN_STYLES = {
-        outline: '2px solid rgba(229, 160, 13, 0.85)',
-        outlineOffset: '6px',
-        backgroundColor: 'rgba(229, 160, 13, 0.06)',
-        borderRadius: 'var(--plex-radius-sm, 8px)',
-        transition: 'outline-color 420ms ease, background-color 420ms ease'
-    };
-
-    function applyInlineStyles(el, styles) {
-        if (!el) return;
-        for (var k in styles) if (Object.prototype.hasOwnProperty.call(styles, k)) {
-            el.style[k] = styles[k];
-        }
-    }
-    function clearInlineStyles(el, styles) {
-        if (!el) return;
-        for (var k in styles) if (Object.prototype.hasOwnProperty.call(styles, k)) {
-            el.style[k] = '';
-        }
     }
 
     function applyFlash(target) {
         var card = target.closest('.card');
-        console.info('[settings-search] applyFlash: target=', target, 'card=', card);
 
         // Clear any prior pinned highlight before flashing the new target
         clearPinned(/*instant=*/true);
@@ -354,9 +320,6 @@
 
             target.classList.add('ss-flash-pinned');
             if (card) card.classList.add('ss-flash-pinned-card');
-
-            // Inline fallback (also clears any stuck inline styles from prior runs)
-            applyInlineStyles(target, PIN_STYLES);
 
             _pinnedTarget = target;
             _pinnedCard   = card;
@@ -395,19 +358,14 @@
         if (instant) {
             t.classList.remove('ss-flash-pinned', 'is-dismissing');
             if (c) c.classList.remove('ss-flash-pinned-card', 'is-dismissing');
-            clearInlineStyles(t, PIN_STYLES);
             return;
         }
         // Animated fade-out via .is-dismissing, then remove
         t.classList.add('is-dismissing');
         if (c) c.classList.add('is-dismissing');
-        // Fade the inline outline/bg to transparent so the visual decay matches
-        t.style.outlineColor = 'rgba(229, 160, 13, 0)';
-        t.style.backgroundColor = 'transparent';
         setTimeout(function() {
             t.classList.remove('ss-flash-pinned', 'is-dismissing');
             if (c) c.classList.remove('ss-flash-pinned-card', 'is-dismissing');
-            clearInlineStyles(t, PIN_STYLES);
         }, 450);
     }
 

--- a/web/static/js/settings_search.js
+++ b/web/static/js/settings_search.js
@@ -298,13 +298,39 @@
         requestAnimationFrame(tryFlash);
     }
 
+    // Inline style fallback so the highlight is visible even if a stale or
+    // mis-cached stylesheet is in play. CSS classes still drive the animation;
+    // these guarantee at least a visible static outline + tint.
+    var PIN_STYLES = {
+        outline: '2px solid rgba(229, 160, 13, 0.85)',
+        outlineOffset: '6px',
+        boxShadow: 'inset 3px 0 0 rgba(229, 160, 13, 0.95)',
+        backgroundColor: 'rgba(229, 160, 13, 0.06)',
+        borderRadius: 'var(--plex-radius-sm, 8px)',
+        transition: 'outline-color 420ms ease, background-color 420ms ease'
+    };
+
+    function applyInlineStyles(el, styles) {
+        if (!el) return;
+        for (var k in styles) if (Object.prototype.hasOwnProperty.call(styles, k)) {
+            el.style[k] = styles[k];
+        }
+    }
+    function clearInlineStyles(el, styles) {
+        if (!el) return;
+        for (var k in styles) if (Object.prototype.hasOwnProperty.call(styles, k)) {
+            el.style[k] = '';
+        }
+    }
+
     function applyFlash(target) {
         var card = target.closest('.card');
+        console.info('[settings-search] applyFlash: target=', target, 'card=', card);
 
         // Clear any prior pinned highlight before flashing the new target
         clearPinned(/*instant=*/true);
 
-        // Phase 1: bright pulse (matches @keyframes ss-flash-ring duration)
+        // Phase 1: bright pulse (matches @keyframes ss-flash-pulse duration)
         target.classList.add('ss-flash-highlight');
         if (card) card.classList.add('ss-flash-highlight-card');
 
@@ -325,6 +351,9 @@
 
             target.classList.add('ss-flash-pinned');
             if (card) card.classList.add('ss-flash-pinned-card');
+
+            // Inline fallback (also clears any stuck inline styles from prior runs)
+            applyInlineStyles(target, PIN_STYLES);
 
             _pinnedTarget = target;
             _pinnedCard   = card;
@@ -363,14 +392,20 @@
         if (instant) {
             t.classList.remove('ss-flash-pinned', 'is-dismissing');
             if (c) c.classList.remove('ss-flash-pinned-card', 'is-dismissing');
+            clearInlineStyles(t, PIN_STYLES);
             return;
         }
         // Animated fade-out via .is-dismissing, then remove
         t.classList.add('is-dismissing');
         if (c) c.classList.add('is-dismissing');
+        // Fade the inline outline/bg to transparent so the visual decay matches
+        t.style.outlineColor = 'rgba(229, 160, 13, 0)';
+        t.style.boxShadow = 'inset 3px 0 0 rgba(229, 160, 13, 0)';
+        t.style.backgroundColor = 'transparent';
         setTimeout(function() {
             t.classList.remove('ss-flash-pinned', 'is-dismissing');
             if (c) c.classList.remove('ss-flash-pinned-card', 'is-dismissing');
+            clearInlineStyles(t, PIN_STYLES);
         }, 450);
     }
 

--- a/web/static/js/settings_search.js
+++ b/web/static/js/settings_search.js
@@ -272,9 +272,13 @@
         // Some settings live inside HTMX-loaded sub-partials (e.g. user rows,
         // path-mapping rows). Poll for up to 3s so cross-tab navigation, slow
         // partials, or first paint don't drop the highlight on the floor.
+        // :not(.ss-result-row) excludes the search popup rows, which also
+        // carry data-setting-id for click delegation but live inside the
+        // (hidden) results panel — without this filter the flash lands on
+        // an invisible element.
         var attempts = 0;
         var MAX_ATTEMPTS = 30;  // ~3s at 100ms per tick
-        var selector = '[data-setting-id="' + cssEscape(settingId) + '"]';
+        var selector = '[data-setting-id="' + cssEscape(settingId) + '"]:not(.ss-result-row)';
         console.info('[settings-search] flashTarget:', settingId);
 
         function tryFlash() {

--- a/web/static/js/settings_search.js
+++ b/web/static/js/settings_search.js
@@ -275,6 +275,7 @@
         var attempts = 0;
         var MAX_ATTEMPTS = 30;  // ~3s at 100ms per tick
         var selector = '[data-setting-id="' + cssEscape(settingId) + '"]';
+        console.info('[settings-search] flashTarget:', settingId);
 
         function tryFlash() {
             var target = document.querySelector(selector);
@@ -283,9 +284,12 @@
                 if (attempts < MAX_ATTEMPTS) {
                     setTimeout(tryFlash, 100);
                 } else {
-                    console.warn('[settings-search] Target not found after retries:', settingId);
+                    console.warn('[settings-search] Target not found after retries:', settingId, '(selector:', selector + ')');
                 }
                 return;
+            }
+            if (attempts > 0) {
+                console.info('[settings-search] Target found after', attempts, 'retries:', settingId);
             }
             applyFlash(target);
         }

--- a/web/static/js/settings_search.js
+++ b/web/static/js/settings_search.js
@@ -308,7 +308,6 @@
     var PIN_STYLES = {
         outline: '2px solid rgba(229, 160, 13, 0.85)',
         outlineOffset: '6px',
-        boxShadow: 'inset 3px 0 0 rgba(229, 160, 13, 0.95)',
         backgroundColor: 'rgba(229, 160, 13, 0.06)',
         borderRadius: 'var(--plex-radius-sm, 8px)',
         transition: 'outline-color 420ms ease, background-color 420ms ease'
@@ -404,7 +403,6 @@
         if (c) c.classList.add('is-dismissing');
         // Fade the inline outline/bg to transparent so the visual decay matches
         t.style.outlineColor = 'rgba(229, 160, 13, 0)';
-        t.style.boxShadow = 'inset 3px 0 0 rgba(229, 160, 13, 0)';
         t.style.backgroundColor = 'transparent';
         setTimeout(function() {
             t.classList.remove('ss-flash-pinned', 'is-dismissing');

--- a/web/static/js/settings_search.js
+++ b/web/static/js/settings_search.js
@@ -263,28 +263,111 @@
         }
     }
 
+    // Track the currently pinned target so a new jump clears the old marker.
+    var _pinnedTarget = null;
+    var _pinnedCard   = null;
+    var _pinnedDismissHandler = null;
+
     function flashTarget(settingId) {
-        // Defer to next frame to ensure layout is settled
-        requestAnimationFrame(function() {
-            var target = document.querySelector('[data-setting-id="' + cssEscape(settingId) + '"]');
-            if (!target) return;
+        // Some settings live inside HTMX-loaded sub-partials (e.g. user rows,
+        // path-mapping rows). Poll for up to 3s so cross-tab navigation, slow
+        // partials, or first paint don't drop the highlight on the floor.
+        var attempts = 0;
+        var MAX_ATTEMPTS = 30;  // ~3s at 100ms per tick
+        var selector = '[data-setting-id="' + cssEscape(settingId) + '"]';
 
-            var card = target.closest('.card');
-            target.classList.add('ss-flash-highlight');
-            if (card) card.classList.add('ss-flash-highlight-card');
+        function tryFlash() {
+            var target = document.querySelector(selector);
+            if (!target) {
+                attempts++;
+                if (attempts < MAX_ATTEMPTS) {
+                    setTimeout(tryFlash, 100);
+                } else {
+                    console.warn('[settings-search] Target not found after retries:', settingId);
+                }
+                return;
+            }
+            applyFlash(target);
+        }
 
-            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        // First attempt on the next frame so layout has settled
+        requestAnimationFrame(tryFlash);
+    }
 
-            setTimeout(function() {
-                target.classList.remove('ss-flash-highlight');
-                if (card) card.classList.remove('ss-flash-highlight-card');
-            }, 1700);
+    function applyFlash(target) {
+        var card = target.closest('.card');
 
-            var focusable = target.querySelector('input, select, textarea');
-            if (focusable) setTimeout(function() {
-                try { focusable.focus({ preventScroll: true }); } catch (e) {}
-            }, 450);
-        });
+        // Clear any prior pinned highlight before flashing the new target
+        clearPinned(/*instant=*/true);
+
+        // Phase 1: bright pulse (matches @keyframes ss-flash-ring duration)
+        target.classList.add('ss-flash-highlight');
+        if (card) card.classList.add('ss-flash-highlight-card');
+
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+        // Auto-focus the first interactive child after the smooth scroll settles
+        var focusable = target.querySelector('input, select, textarea');
+        if (focusable) setTimeout(function() {
+            try { focusable.focus({ preventScroll: true }); } catch (e) {}
+        }, 450);
+
+        // Phase 2: after the pulse finishes, settle into a persistent pin.
+        // The pin clears on the next click or keystroke (installed after a
+        // short tick so the click that triggered the jump doesn't dismiss it).
+        setTimeout(function() {
+            target.classList.remove('ss-flash-highlight');
+            if (card) card.classList.remove('ss-flash-highlight-card');
+
+            target.classList.add('ss-flash-pinned');
+            if (card) card.classList.add('ss-flash-pinned-card');
+
+            _pinnedTarget = target;
+            _pinnedCard   = card;
+
+            setTimeout(installPinnedDismiss, 60);
+        }, 1000);
+    }
+
+    function installPinnedDismiss() {
+        if (_pinnedDismissHandler) return;  // already installed
+        _pinnedDismissHandler = function(e) {
+            // Don't dismiss if there's no pin to clear
+            if (!_pinnedTarget) {
+                teardownPinnedDismiss();
+                return;
+            }
+            clearPinned(false);
+        };
+        document.addEventListener('click', _pinnedDismissHandler, true);
+        document.addEventListener('keydown', _pinnedDismissHandler, true);
+    }
+
+    function teardownPinnedDismiss() {
+        if (!_pinnedDismissHandler) return;
+        document.removeEventListener('click', _pinnedDismissHandler, true);
+        document.removeEventListener('keydown', _pinnedDismissHandler, true);
+        _pinnedDismissHandler = null;
+    }
+
+    function clearPinned(instant) {
+        var t = _pinnedTarget, c = _pinnedCard;
+        _pinnedTarget = null;
+        _pinnedCard = null;
+        teardownPinnedDismiss();
+        if (!t) return;
+        if (instant) {
+            t.classList.remove('ss-flash-pinned', 'is-dismissing');
+            if (c) c.classList.remove('ss-flash-pinned-card', 'is-dismissing');
+            return;
+        }
+        // Animated fade-out via .is-dismissing, then remove
+        t.classList.add('is-dismissing');
+        if (c) c.classList.add('is-dismissing');
+        setTimeout(function() {
+            t.classList.remove('ss-flash-pinned', 'is-dismissing');
+            if (c) c.classList.remove('ss-flash-pinned-card', 'is-dismissing');
+        }, 450);
     }
 
     function cssEscape(s) {
@@ -401,9 +484,9 @@
         var hash = location.hash;
         if (hash && hash.indexOf('#setting-') === 0) {
             var id = hash.slice('#setting-'.length);
-            // Small delay so HTMX-loaded partials (e.g. user list) have a chance
-            // to render before we try to find the target.
-            setTimeout(function() { flashTarget(id); }, 200);
+            // flashTarget() polls for the element for up to 3s, so HTMX-loaded
+            // partials (user list, path-mapping rows) have time to render.
+            flashTarget(id);
         }
     }
     handleInitialHash();

--- a/web/static/js/settings_search.js
+++ b/web/static/js/settings_search.js
@@ -1,0 +1,413 @@
+/* Settings Search
+ *
+ * Powers the searchable Settings experience.
+ *  - Reads the index from #settings-search-index (JSON injected by web/config.py).
+ *  - Filters with simple multi-term scoring (label > keywords > hint > section).
+ *  - Renders grouped results, supports arrow-key navigation + Cmd/Ctrl+K focus.
+ *  - Clicking a result navigates to /settings/<tab>#setting-<id>; on load the
+ *    target form-group (data-setting-id) is scrolled into view and flashed.
+ *
+ * Defensive: the `var X = window.X || {...}` pattern is used so the script
+ * survives HTMX partial swaps that may re-execute it within the same page.
+ */
+(function() {
+    'use strict';
+
+    var root = document.getElementById('settings-search');
+    if (!root) return;  // not on a settings page
+
+    var input        = document.getElementById('settings-search-input');
+    var resultsEl    = document.getElementById('settings-search-results');
+    var clearBtn     = document.getElementById('settings-search-clear');
+    var indexScript  = document.getElementById('settings-search-index');
+    var activeTab    = root.dataset.activeTab || '';
+
+    if (!input || !resultsEl || !indexScript) return;
+
+    var INDEX = [];
+    try {
+        INDEX = JSON.parse(indexScript.textContent || '[]');
+    } catch (e) {
+        console.error('[settings-search] Failed to parse index JSON', e);
+        return;
+    }
+    if (!Array.isArray(INDEX) || INDEX.length === 0) return;
+
+    // Popular settings shown in the empty state (curated subset)
+    var POPULAR_IDS = [
+        'plex_token',
+        'webhook_url',
+        'schedule_enabled',
+        'number_episodes',
+        'path_mappings'
+    ];
+
+    // Suggested searches (chips). Maps to common user intent.
+    var SUGGESTED_QUERIES = ['token', 'discord', 'rss', 'cron', 'sonarr', 'backup', 'webhook'];
+
+    var selectedIdx    = 0;
+    var currentResults = [];
+    var debounceTimer  = null;
+
+    // ---- search scoring ---------------------------------------------------
+    function scoreEntry(entry, query) {
+        var q = query.toLowerCase().trim();
+        if (!q) return 0;
+
+        var label = (entry.label || '').toLowerCase();
+        var hint  = (entry.hint  || '').toLowerCase();
+        var kws   = (entry.keywords || []).join(' ').toLowerCase();
+        var sect  = ((entry.section || '') + ' ' + (entry.subsection || '')).toLowerCase();
+
+        var score = 0;
+        if (label.indexOf(q) === 0)        score += 100;
+        else if (label.indexOf(q) !== -1)  score += 60;
+        if (kws.indexOf(q) !== -1)         score += 40;
+        if (hint.indexOf(q) !== -1)        score += 15;
+        if (sect.indexOf(q) !== -1)        score += 10;
+
+        // Every space-separated term must hit somewhere — otherwise drop
+        var haystack = label + ' ' + hint + ' ' + kws + ' ' + sect;
+        var terms = q.split(/\s+/).filter(Boolean);
+        for (var i = 0; i < terms.length; i++) {
+            if (haystack.indexOf(terms[i]) === -1) return 0;
+        }
+
+        // Boost entries on the user's current tab — less context switching
+        if (activeTab && entry.tab === activeTab) score += 5;
+
+        return score;
+    }
+
+    function search(query) {
+        if (!query.trim()) return [];
+        var scored = [];
+        for (var i = 0; i < INDEX.length; i++) {
+            var s = scoreEntry(INDEX[i], query);
+            if (s > 0) scored.push({ entry: INDEX[i], score: s });
+        }
+        scored.sort(function(a, b) { return b.score - a.score; });
+        return scored.map(function(r) { return r.entry; });
+    }
+
+    // ---- rendering helpers -----------------------------------------------
+    function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, function(c) {
+            return ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+            })[c];
+        });
+    }
+
+    function highlight(text, query) {
+        if (!text) return '';
+        if (!query.trim()) return escapeHtml(text);
+        var terms = query.trim().split(/\s+/)
+            .filter(Boolean)
+            .map(function(t) { return t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); });
+        if (!terms.length) return escapeHtml(text);
+        var re = new RegExp('(' + terms.join('|') + ')', 'gi');
+        return escapeHtml(text).replace(re, '<mark>$1</mark>');
+    }
+
+    function renderResultRow(entry, query, idx) {
+        var labelHtml = highlight(entry.label, query);
+        var hintHtml  = highlight(entry.hint, query);
+        var crumb = entry.subsection
+            ? escapeHtml(entry.section) + ' <i data-lucide="chevron-right"></i> ' + escapeHtml(entry.subsection)
+            : escapeHtml(entry.section);
+        var tone = entry.tone || '';
+        return '<div class="ss-result-row" role="option" data-idx="' + idx + '"' +
+               ' data-tab="' + escapeHtml(entry.tab) + '"' +
+               ' data-setting-id="' + escapeHtml(entry.setting_id) + '">' +
+                 '<div class="ss-result-icon ' + tone + '">' +
+                     '<i data-lucide="' + escapeHtml(entry.icon || 'circle') + '"></i>' +
+                 '</div>' +
+                 '<div class="ss-result-body">' +
+                     '<div class="ss-result-crumb">' + crumb + '</div>' +
+                     '<div class="ss-result-label">' + labelHtml + '</div>' +
+                     (hintHtml ? '<div class="ss-result-hint">' + hintHtml + '</div>' : '') +
+                 '</div>' +
+                 '<div class="ss-result-arrow"><i data-lucide="chevron-right"></i></div>' +
+               '</div>';
+    }
+
+    function renderEmptyState() {
+        // Map ids → entries, drop misses
+        var popular = [];
+        for (var i = 0; i < POPULAR_IDS.length; i++) {
+            for (var j = 0; j < INDEX.length; j++) {
+                if (INDEX[j].setting_id === POPULAR_IDS[i]) {
+                    popular.push(INDEX[j]);
+                    break;
+                }
+            }
+        }
+
+        var chipsHtml = SUGGESTED_QUERIES.map(function(q) {
+            return '<button class="ss-chip" type="button" data-suggest="' + escapeHtml(q) + '">' +
+                       '<i data-lucide="search" class="ss-chip-icon"></i>' + escapeHtml(q) +
+                   '</button>';
+        }).join('');
+
+        var popularHtml = popular.map(function(e, i) {
+            return renderResultRow(e, '', i);
+        }).join('');
+
+        resultsEl.innerHTML =
+            '<div class="ss-empty-state">' +
+                '<div class="ss-empty-section">' +
+                    '<h4><i data-lucide="search"></i> Try searching for</h4>' +
+                    '<div class="ss-chip-row">' + chipsHtml + '</div>' +
+                '</div>' +
+                '<div class="ss-empty-section">' +
+                    '<h4><i data-lucide="trending-up"></i> Popular settings</h4>' +
+                '</div>' +
+            '</div>' +
+            '<div class="ss-results-group ss-results-group-popular">' + popularHtml + '</div>';
+
+        currentResults = popular;
+        selectedIdx = 0;
+        updateSelection();
+        refreshIcons();
+    }
+
+    function renderNoResults(query) {
+        resultsEl.innerHTML =
+            '<div class="ss-no-results">' +
+                '<i data-lucide="search-x"></i>' +
+                '<div>No settings match &ldquo;' + escapeHtml(query) + '&rdquo;</div>' +
+                '<div class="ss-no-results-hint">Try a broader term, or browse the tabs below.</div>' +
+            '</div>';
+        currentResults = [];
+        refreshIcons();
+    }
+
+    function renderResults(query) {
+        var results = search(query);
+        currentResults = results;
+        selectedIdx = 0;
+
+        if (results.length === 0) {
+            renderNoResults(query);
+            return;
+        }
+
+        // Group by section, preserving score-order
+        var grouped = {};
+        var order = [];
+        results.forEach(function(r, i) {
+            var key = r.section || 'Other';
+            if (!grouped[key]) { grouped[key] = []; order.push(key); }
+            grouped[key].push({ entry: r, idx: i });
+        });
+
+        var sections = order.map(function(name) {
+            var rows = grouped[name].map(function(g) {
+                return renderResultRow(g.entry, query, g.idx);
+            }).join('');
+            return '<div class="ss-results-group">' +
+                       '<div class="ss-results-group-header">' +
+                           '<i data-lucide="chevron-right"></i>' + escapeHtml(name) +
+                       '</div>' + rows +
+                   '</div>';
+        }).join('');
+
+        resultsEl.innerHTML =
+            '<div class="ss-results-summary">' +
+                '<div><strong>' + results.length + '</strong> result' +
+                    (results.length === 1 ? '' : 's') +
+                    ' in <strong>' + order.length + '</strong> categor' +
+                    (order.length === 1 ? 'y' : 'ies') +
+                '</div>' +
+                '<div><kbd>&uarr;&darr;</kbd> navigate &nbsp; <kbd>&crarr;</kbd> open &nbsp; <kbd>Esc</kbd> close</div>' +
+            '</div>' + sections;
+
+        updateSelection();
+        refreshIcons();
+    }
+
+    function updateSelection() {
+        var rows = resultsEl.querySelectorAll('.ss-result-row');
+        for (var i = 0; i < rows.length; i++) {
+            var idx = parseInt(rows[i].getAttribute('data-idx'), 10);
+            if (idx === selectedIdx) {
+                rows[i].classList.add('is-selected');
+                rows[i].scrollIntoView({ block: 'nearest' });
+            } else {
+                rows[i].classList.remove('is-selected');
+            }
+        }
+    }
+
+    function refreshIcons() {
+        if (typeof window.lucide !== 'undefined' && window.lucide.createIcons) {
+            window.lucide.createIcons({ nameAttr: 'data-lucide', node: resultsEl });
+        }
+    }
+
+    // ---- navigation: jump to setting -------------------------------------
+    function jumpToSetting(tab, settingId) {
+        var currentTab = activeTab;
+        var hash = '#setting-' + settingId;
+        if (tab === currentTab) {
+            // Same tab — just flash + clear search
+            input.value = '';
+            root.classList.remove('has-query');
+            input.setAttribute('aria-expanded', 'false');
+            history.replaceState(null, '', location.pathname + hash);
+            flashTarget(settingId);
+        } else {
+            // Cross-tab — full nav, target tab's onload handler does the flash
+            window.location.href = '/settings/' + tab + hash;
+        }
+    }
+
+    function flashTarget(settingId) {
+        // Defer to next frame to ensure layout is settled
+        requestAnimationFrame(function() {
+            var target = document.querySelector('[data-setting-id="' + cssEscape(settingId) + '"]');
+            if (!target) return;
+
+            var card = target.closest('.card');
+            target.classList.add('ss-flash-highlight');
+            if (card) card.classList.add('ss-flash-highlight-card');
+
+            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+            setTimeout(function() {
+                target.classList.remove('ss-flash-highlight');
+                if (card) card.classList.remove('ss-flash-highlight-card');
+            }, 1700);
+
+            var focusable = target.querySelector('input, select, textarea');
+            if (focusable) setTimeout(function() {
+                try { focusable.focus({ preventScroll: true }); } catch (e) {}
+            }, 450);
+        });
+    }
+
+    function cssEscape(s) {
+        // CSS.escape polyfill for safety
+        if (typeof window.CSS !== 'undefined' && window.CSS.escape) return window.CSS.escape(s);
+        return String(s).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+    }
+
+    // ---- event wiring ----------------------------------------------------
+    input.addEventListener('input', function() {
+        var q = input.value;
+        root.classList.toggle('has-query', q.length > 0);
+        input.setAttribute('aria-expanded', q.length > 0 ? 'true' : 'false');
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(function() {
+            if (q.trim()) renderResults(q);
+            else renderEmptyState();
+        }, 80);
+    });
+
+    input.addEventListener('focus', function() {
+        if (!input.value.trim()) {
+            root.classList.add('has-query');
+            input.setAttribute('aria-expanded', 'true');
+            renderEmptyState();
+        }
+    });
+
+    document.addEventListener('click', function(e) {
+        if (!root.contains(e.target) && !input.value.trim()) {
+            root.classList.remove('has-query');
+            input.setAttribute('aria-expanded', 'false');
+        }
+    });
+
+    clearBtn.addEventListener('click', function() {
+        input.value = '';
+        input.focus();
+        renderEmptyState();
+    });
+
+    resultsEl.addEventListener('click', function(e) {
+        var row = e.target.closest('.ss-result-row');
+        if (row) {
+            jumpToSetting(row.getAttribute('data-tab'), row.getAttribute('data-setting-id'));
+            return;
+        }
+        var chip = e.target.closest('.ss-chip[data-suggest]');
+        if (chip) {
+            input.value = chip.getAttribute('data-suggest');
+            input.dispatchEvent(new Event('input'));
+            input.focus();
+        }
+    });
+
+    resultsEl.addEventListener('mousemove', function(e) {
+        var row = e.target.closest('.ss-result-row');
+        if (!row) return;
+        var idx = parseInt(row.getAttribute('data-idx'), 10);
+        if (idx !== selectedIdx) {
+            selectedIdx = idx;
+            updateSelection();
+        }
+    });
+
+    input.addEventListener('keydown', function(e) {
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            if (currentResults.length) {
+                selectedIdx = (selectedIdx + 1) % currentResults.length;
+                updateSelection();
+            }
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            if (currentResults.length) {
+                selectedIdx = (selectedIdx - 1 + currentResults.length) % currentResults.length;
+                updateSelection();
+            }
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            var target = currentResults[selectedIdx];
+            if (target) jumpToSetting(target.tab, target.setting_id);
+        } else if (e.key === 'Escape') {
+            if (input.value) {
+                input.value = '';
+                renderEmptyState();
+            } else {
+                input.blur();
+                root.classList.remove('has-query');
+                input.setAttribute('aria-expanded', 'false');
+            }
+        }
+    });
+
+    // Global Cmd/Ctrl+K focus
+    document.addEventListener('keydown', function(e) {
+        var k = e.key && e.key.toLowerCase();
+        if ((e.metaKey || e.ctrlKey) && k === 'k') {
+            // Don't intercept if the user is typing in a different input
+            // unless they explicitly hit the global shortcut
+            e.preventDefault();
+            input.focus();
+            input.select();
+        }
+    });
+
+    // Pre-render the empty state (hidden) so first focus is instant
+    renderEmptyState();
+    root.classList.remove('has-query');
+    input.setAttribute('aria-expanded', 'false');
+
+    // ---- on-load: if URL has #setting-<id>, flash it ---------------------
+    function handleInitialHash() {
+        var hash = location.hash;
+        if (hash && hash.indexOf('#setting-') === 0) {
+            var id = hash.slice('#setting-'.length);
+            // Small delay so HTMX-loaded partials (e.g. user list) have a chance
+            // to render before we try to find the target.
+            setTimeout(function() { flashTarget(id); }, 200);
+        }
+    }
+    handleInitialHash();
+
+    // If hash changes while on the page (e.g., back/forward), re-flash
+    window.addEventListener('hashchange', handleInitialHash);
+})();

--- a/web/templates/settings/backup.html
+++ b/web/templates/settings/backup.html
@@ -12,7 +12,7 @@
             Download your current settings as a JSON file for backup or migration to another installation.
         </p>
 
-        <div class="form-group">
+        <div class="form-group" data-setting-id="include_sensitive">
             <label class="switch">
                 <input type="checkbox" id="include_sensitive" checked>
                 <span>Include sensitive data</span>
@@ -24,7 +24,7 @@
             </div>
         </div>
 
-        <div class="form-group mb-0">
+        <div class="form-group mb-0" data-setting-id="download_backup_btn">
             <button type="button" class="btn btn-primary" onclick="downloadBackup()">
                 <i data-lucide="download"></i>
                 Download Backup
@@ -45,14 +45,14 @@
         </p>
 
         <form id="import-form" enctype="multipart/form-data">
-            <div class="form-group">
+            <div class="form-group" data-setting-id="settings_file">
                 <label for="settings_file">Settings File</label>
                 <input type="file" id="settings_file" name="settings_file" accept=".json,application/json"
                        onchange="updateFileLabel(this)">
                 <div class="form-hint">Select a PlexCache backup JSON file</div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="import_mode">
                 <label>Import Mode</label>
                 <div style="display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.5rem;">
                     <label class="radio-label">
@@ -70,11 +70,11 @@
             <div id="validation-container" style="display: none;"></div>
 
             <div class="form-group mb-0" style="display: flex; gap: 0.75rem;">
-                <button type="button" class="btn btn-secondary" onclick="validateSettings()">
+                <button type="button" class="btn btn-secondary" data-setting-id="validate_settings_btn" onclick="validateSettings()">
                     <i data-lucide="check-circle"></i>
                     Validate
                 </button>
-                <button type="button" class="btn btn-primary" onclick="importSettings()" id="import-btn">
+                <button type="button" class="btn btn-primary" onclick="importSettings()" id="import-btn" data-setting-id="import_settings_btn">
                     <i data-lucide="upload"></i>
                     Import
                 </button>
@@ -165,7 +165,7 @@
                         Cache paths in your CLI data will be converted to Docker container paths.
                     </p>
 
-                    <div class="form-group" style="margin-bottom: 1rem;">
+                    <div class="form-group" data-setting-id="cli_cache_prefix" style="margin-bottom: 1rem;">
                         <label for="cli_cache_prefix">CLI Cache Path Prefix</label>
                         <input type="text" id="cli_cache_prefix" name="cli_cache_prefix"
                                value="/mnt/cache_downloads/"
@@ -173,7 +173,7 @@
                         <p class="form-hint">The cache path used in your CLI installation</p>
                     </div>
 
-                    <div class="form-group" style="margin-bottom: 0;">
+                    <div class="form-group" data-setting-id="docker_cache_prefix" style="margin-bottom: 0;">
                         <label for="docker_cache_prefix">Docker Cache Path</label>
                         <input type="text" id="docker_cache_prefix" name="docker_cache_prefix"
                                value="/mnt/cache/"
@@ -195,7 +195,7 @@
 
                 <!-- Action buttons -->
                 <div style="display: flex; gap: 0.75rem;">
-                    <button type="button" id="cli-import-btn" class="btn btn-primary" style="flex: 1;" onclick="executeCliImport()">
+                    <button type="button" id="cli-import-btn" class="btn btn-primary" data-setting-id="cli_import_btn" style="flex: 1;" onclick="executeCliImport()">
                         <i data-lucide="download" class="btn-icon"></i>
                         <span class="btn-text">Import Data</span>
                         <div class="spinner btn-spinner" style="display: none; width: 14px; height: 14px;"></div>

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -15,7 +15,7 @@
             </h3>
 
             <div class="grid grid-2">
-                <div class="form-group">
+                <div class="form-group" data-setting-id="number_episodes">
                     <label for="number_episodes">Episodes to Prefetch</label>
                     <input type="number" id="number_episodes" name="number_episodes"
                            class="input-narrow"
@@ -23,7 +23,7 @@
                     <div class="form-hint">Number of upcoming episodes to cache for in-progress shows</div>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" data-setting-id="days_to_monitor">
                     <label for="days_to_monitor">Days to Monitor</label>
                     <input type="number" id="days_to_monitor" name="days_to_monitor"
                            class="input-narrow"
@@ -32,7 +32,7 @@
                 </div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="prefetch_minimum_minutes">
                 <label for="prefetch_minimum_minutes">Minimum Prefetch Runtime (minutes)</label>
                 <input type="number" id="prefetch_minimum_minutes" name="prefetch_minimum_minutes"
                        class="input-narrow"
@@ -47,7 +47,7 @@
                 Watchlist
             </h3>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="watchlist_toggle">
                 <label class="switch">
                     <input type="checkbox" name="watchlist_toggle"
                            onchange="toggleWatchlistOptions()"
@@ -58,7 +58,7 @@
 
             <div id="watchlist-options"{% if not (settings.watchlist_toggle | default(true)) %} style="display: none;"{% endif %}>
                 <div class="grid grid-2">
-                    <div class="form-group">
+                    <div class="form-group" data-setting-id="watchlist_episodes">
                         <label for="watchlist_episodes">Watchlist Episodes to Prefetch</label>
                         <input type="number" id="watchlist_episodes" name="watchlist_episodes"
                                class="input-narrow"
@@ -93,7 +93,7 @@
             </h3>
 
             <div class="grid grid-2">
-                <div class="form-group">
+                <div class="form-group" data-setting-id="cache_retention_hours">
                     <label for="cache_retention_hours">Cache Retention (hours)</label>
                     <input type="number" id="cache_retention_hours" name="cache_retention_hours"
                            class="input-narrow"
@@ -101,7 +101,7 @@
                     <div class="form-hint">Keep files cached at least this long before moving back (0 = no minimum)</div>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" data-setting-id="watchlist_retention_days">
                     <label for="watchlist_retention_days">Watchlist Retention (days)</label>
                     <input type="number" id="watchlist_retention_days" name="watchlist_retention_days"
                            class="input-narrow"
@@ -111,7 +111,7 @@
             </div>
 
             <div class="grid grid-2">
-                <div class="form-group">
+                <div class="form-group" data-setting-id="ondeck_retention_days">
                     <label for="ondeck_retention_days">OnDeck Retention (days)</label>
                     <input type="number" id="ondeck_retention_days" name="ondeck_retention_days"
                            class="input-narrow"
@@ -127,7 +127,7 @@
                 File Handling
             </h3>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="watched_move">
                 <label class="switch">
                     <input type="checkbox" name="watched_move"
                            {% if settings.watched_move | default(true) %}checked{% endif %}>
@@ -135,7 +135,7 @@
                 </label>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="create_plexcached_backups">
                 <label class="switch">
                     <input type="checkbox" name="create_plexcached_backups"
                            {% if settings.create_plexcached_backups | default(true) %}checked{% endif %}>
@@ -144,7 +144,7 @@
                 <div class="form-hint">When moving files to cache, keep backup on array (allows recovery if cache fails)</div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="cleanup_empty_folders">
                 <label class="switch">
                     <input type="checkbox" name="cleanup_empty_folders"
                            {% if settings.cleanup_empty_folders | default(true) %}checked{% endif %}>
@@ -153,7 +153,7 @@
                 <div class="form-hint">Remove empty parent folders on cache after moving files to array. Disable if you use year-based or other intentional empty folder structures.</div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="use_symlinks">
                 <label class="switch">
                     <input type="checkbox" name="use_symlinks"
                            {% if settings.use_symlinks %}checked{% endif %}>
@@ -165,7 +165,7 @@
                 paths in PlexCache-D and Plex containers.</div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="auto_transfer_upgrades">
                 <label class="switch">
                     <input type="checkbox" name="auto_transfer_upgrades"
                            {% if settings.auto_transfer_upgrades | default(true) %}checked{% endif %}>
@@ -174,7 +174,7 @@
                 <div class="form-hint">When Sonarr/Radarr upgrades a cached file, automatically transfer exclude list and tracker entries to the new file using Plex rating keys.</div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="backup_upgraded_files">
                 <label class="switch">
                     <input type="checkbox" name="backup_upgraded_files"
                            {% if settings.backup_upgraded_files | default(true) %}checked{% endif %}>
@@ -183,7 +183,7 @@
                 <div class="form-hint">When a cached file is upgraded, create a .plexcached backup of the new file on the array (only if the old file had a backup).</div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="hardlinked_files">
                 <label for="hardlinked_files">Hardlinked Files Handling</label>
                 <select id="hardlinked_files" name="hardlinked_files">
                     <option value="skip" {% if settings.hardlinked_files == 'skip' or not settings.hardlinked_files %}selected{% endif %}>Skip (preserve for seeders)</option>
@@ -192,7 +192,7 @@
                 <div class="form-hint">Files with multiple hardlinks (e.g., seeding torrents). Skip preserves links, Move copies the file.</div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="check_hardlinks_on_restore">
                 <label class="switch">
                     <input type="checkbox" name="check_hardlinks_on_restore"
                            {% if settings.check_hardlinks_on_restore | default(false) %}checked{% endif %}>
@@ -201,7 +201,7 @@
                 <div class="form-hint">When enabled, cached files with multiple hard links (e.g., actively seeding from cache) are skipped and kept on cache until their links are resolved.</div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="cache_associated_files">
                 <label for="cache_associated_files">Associated Files</label>
                 <select id="cache_associated_files" name="cache_associated_files">
                     <option value="all" {% if settings.cache_associated_files == 'all' %}selected{% endif %}>All (subtitles, artwork, NFOs, metadata)</option>
@@ -216,7 +216,7 @@
                 Add additional folder names below for non-dot-prefixed directories to exclude from scanning.
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="excluded_folders">
                 <label>Excluded Folders</label>
                 <div id="excluded-folders-list">
                     {% for folder in settings.excluded_folders or [] %}
@@ -251,7 +251,7 @@
                 Cache Limit and Eviction are based on <strong>total drive usage</strong> (all files on the cache drive), not just PlexCache-managed files. Other applications, downloads, and system files all count toward the limit.
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="cache_drive_size">
                 <label for="cache_drive_size">Cache Drive Size {% if drive_info.is_zfs and not drive_info.is_manual_override %}(recommended for ZFS){% else %}(optional){% endif %}</label>
                 <input type="text" id="cache_drive_size" name="cache_drive_size"
                        class="input-medium"
@@ -276,7 +276,7 @@
             </div>
 
             <div class="grid grid-2">
-                <div class="form-group">
+                <div class="form-group" data-setting-id="cache_limit">
                     <label for="cache_limit">Cache Limit</label>
                     <input type="text" id="cache_limit" name="cache_limit"
                            class="input-medium"
@@ -292,7 +292,7 @@
                     <div id="cache_limit_hint" class="form-hint" style="display: none; color: var(--plex-text-muted); margin-top: 0.25rem;"></div>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" data-setting-id="min_free_space">
                     <label for="min_free_space">Min Free Space</label>
                     <input type="text" id="min_free_space" name="min_free_space"
                            class="input-medium"
@@ -309,7 +309,7 @@
                 </div>
             </div>
 
-            <div class="form-group" style="margin-top: 1rem;">
+            <div class="form-group" data-setting-id="plexcache_quota" style="margin-top: 1rem;">
                 <label for="plexcache_quota">PlexCache Quota</label>
                 <input type="text" id="plexcache_quota" name="plexcache_quota"
                        class="input-medium"
@@ -331,7 +331,7 @@
                 Eviction
             </h3>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="cache_eviction_mode">
                 <label for="cache_eviction_mode">Eviction Mode</label>
                 <select id="cache_eviction_mode" name="cache_eviction_mode" onchange="toggleEvictionOptions()">
                     <option value="smart" {% if settings.cache_eviction_mode == 'smart' %}selected{% endif %}>Smart (priority-based)</option>
@@ -342,7 +342,7 @@
 
             <div id="eviction-options"{% if settings.cache_eviction_mode == 'none' %} style="display: none;"{% endif %}>
                 <div class="grid grid-2">
-                    <div class="form-group">
+                    <div class="form-group" data-setting-id="cache_eviction_threshold_percent">
                         <label for="cache_eviction_threshold_percent">Eviction Threshold (%)</label>
                         <input type="number" id="cache_eviction_threshold_percent" name="cache_eviction_threshold_percent"
                                class="input-narrow"
@@ -352,7 +352,7 @@
                         <div id="eviction_threshold_calculated" class="form-hint" style="color: var(--plex-orange); margin-top: 0.25rem;"></div>
                     </div>
 
-                    <div class="form-group">
+                    <div class="form-group" data-setting-id="eviction_min_priority">
                         <label for="eviction_min_priority">Minimum Priority to Keep</label>
                         <input type="number" id="eviction_min_priority" name="eviction_min_priority"
                                class="input-narrow"
@@ -369,7 +369,7 @@
                 Advanced
             </h3>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="exit_if_active_session">
                 <label class="switch">
                     <input type="checkbox" name="exit_if_active_session"
                            {% if settings.exit_if_active_session %}checked{% endif %}>
@@ -379,7 +379,7 @@
             </div>
 
             <div class="grid grid-2">
-                <div class="form-group">
+                <div class="form-group" data-setting-id="max_concurrent_moves_cache">
                     <label for="max_concurrent_moves_cache">Concurrent Moves to Cache</label>
                     <input type="number" id="max_concurrent_moves_cache" name="max_concurrent_moves_cache"
                            class="input-narrow"
@@ -387,7 +387,7 @@
                     <div class="form-hint">Max parallel file operations when moving TO cache (default: 5)</div>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" data-setting-id="max_concurrent_moves_array">
                     <label for="max_concurrent_moves_array">Concurrent Moves to Array</label>
                     <input type="number" id="max_concurrent_moves_array" name="max_concurrent_moves_array"
                            class="input-narrow"
@@ -416,7 +416,7 @@
             Pinned media is always cached and is never evicted or moved back to the array, regardless of watch state or priority score. Useful for intro episodes, favorite movies, or anything you always want instantly available with the array spun down. Use the Cache Pinned Now button below to copy any missing files immediately, or wait for the next scheduled run.
         </p>
 
-        <div class="form-group">
+        <div class="form-group" data-setting-id="pinned_preferred_resolution">
             <label for="pinned_preferred_resolution">Preferred Version</label>
             <select id="pinned_preferred_resolution" name="pinned_preferred_resolution" form="cache-settings-form">
                 <option value="highest" {% if settings.pinned_preferred_resolution == 'highest' or not settings.pinned_preferred_resolution %}selected{% endif %}>Highest quality (largest bitrate)</option>
@@ -429,7 +429,7 @@
             <div class="form-hint">Which version to cache when a pinned item has multiple media files (e.g., 4K + 1080p). Saved with <strong>Save Cache Settings</strong> in the Cache Behavior card above.</div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" data-setting-id="pinned_search">
             <label for="pinned-search-input">
                 <i data-lucide="search" style="width: 14px; height: 14px; vertical-align: middle;"></i>
                 Search Plex

--- a/web/templates/settings/index.html
+++ b/web/templates/settings/index.html
@@ -14,6 +14,29 @@
     </div>
 </header>
 
+<!-- Settings Search -->
+<div class="settings-search" id="settings-search" data-active-tab="{{ active_tab | default('') }}">
+    <div class="settings-search-input-wrap">
+        <i data-lucide="search" class="settings-search-lead"></i>
+        <input id="settings-search-input"
+               type="text"
+               placeholder="Search settings — try &ldquo;token&rdquo;, &ldquo;discord&rdquo;, or &ldquo;schedule&rdquo;"
+               autocomplete="off"
+               spellcheck="false"
+               aria-label="Search settings"
+               aria-controls="settings-search-results"
+               aria-expanded="false">
+        <button class="settings-search-clear" id="settings-search-clear" type="button" aria-label="Clear search">
+            <i data-lucide="x"></i>
+        </button>
+        <span class="settings-search-kbd"><span class="kbd-mod">Ctrl</span>K</span>
+    </div>
+
+    <div class="settings-search-results" id="settings-search-results" role="listbox" aria-label="Settings search results"></div>
+</div>
+
+<script id="settings-search-index" type="application/json">{{ settings_search_index_json | safe }}</script>
+
 <!-- Settings Tabs -->
 <div class="tabs">
     <a href="/settings/plex" class="tab {% if active_tab == 'plex' %}active{% endif %}">
@@ -59,4 +82,6 @@
     </div>
 </div>
 {% endblock %}
+
+<script src="/static/js/settings_search.js" defer></script>
 {% endblock %}

--- a/web/templates/settings/integrations.html
+++ b/web/templates/settings/integrations.html
@@ -3,7 +3,7 @@
 {% block settings_content %}
 
 <!-- Add Instance Form -->
-<div class="card">
+<div class="card" data-setting-id="arr_instances">
     <div class="card-header">
         <i data-lucide="plus-circle"></i>
         <h2>Add Instance</h2>
@@ -28,7 +28,7 @@
                     <label for="arr-url">URL</label>
                     <input type="text" id="arr-url" name="url" placeholder="http://localhost:8989">
                 </div>
-                <div class="form-group mb-1">
+                <div class="form-group mb-1" data-setting-id="arr_api_key">
                     <label for="arr-api-key">API Key</label>
                     <div class="flex gap-1">
                         <input type="password" id="arr-api-key" name="api_key" placeholder="Your API key" style="flex: 1;">
@@ -45,7 +45,7 @@
                     <span>Enabled</span>
                 </label>
                 <div style="flex: 1;"></div>
-                <button type="button" class="btn btn-sm btn-secondary" onclick="testAddFormConnection()" id="add-test-btn">
+                <button type="button" class="btn btn-sm btn-secondary" onclick="testAddFormConnection()" id="add-test-btn" data-setting-id="arr_test_btn">
                     <i data-lucide="plug"></i> Test
                 </button>
                 <span id="add-test-result" style="margin-left: 0.25rem;"></span>

--- a/web/templates/settings/libraries.html
+++ b/web/templates/settings/libraries.html
@@ -16,7 +16,7 @@
         </div>
         {% endif %}
 
-        <div id="library-cards">
+        <div id="library-cards" data-setting-id="library_toggles">
             {% for card in library_cards %}
                 {% include "settings/partials/library_card.html" %}
             {% endfor %}
@@ -41,7 +41,7 @@
 
         <hr style="border-color: var(--plex-border); margin: 1.5rem 0;">
 
-        <details>
+        <details data-setting-id="path_mappings">
             <summary style="cursor: pointer; color: var(--plex-orange);">
                 <i data-lucide="plus"></i> Add Custom Path Mapping
             </summary>

--- a/web/templates/settings/logging.html
+++ b/web/templates/settings/logging.html
@@ -15,7 +15,7 @@
             </h3>
 
             <div class="grid grid-2">
-                <div class="form-group">
+                <div class="form-group" data-setting-id="max_log_files">
                     <label for="max_log_files">Maximum Log Files</label>
                     <input type="number" id="max_log_files" name="max_log_files"
                            class="input-narrow"
@@ -23,7 +23,7 @@
                     <div class="form-hint">Number of log files to keep (1 file created per run)</div>
                 </div>
 
-                <div class="form-group">
+                <div class="form-group" data-setting-id="keep_error_logs_days">
                     <label for="keep_error_logs_days">Error Log Retention (days)</label>
                     <input type="number" id="keep_error_logs_days" name="keep_error_logs_days"
                            class="input-narrow"
@@ -45,7 +45,7 @@
                 Time Display
             </h3>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="time_format">
                 <label for="time_format">Time Format</label>
                 <select id="time_format" name="time_format">
                     <option value="24h" {% if settings.time_format == '24h' %}selected{% endif %}>24-hour (14:30:00)</option>
@@ -59,7 +59,7 @@
                 Dashboard
             </h3>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="activity_retention_hours">
                 <label for="activity_retention_hours">Recent Activity Retention (hours)</label>
                 <select id="activity_retention_hours" name="activity_retention_hours">
                     <option value="12" {% if settings.activity_retention_hours == 12 %}selected{% endif %}>12 hours</option>

--- a/web/templates/settings/notifications.html
+++ b/web/templates/settings/notifications.html
@@ -9,7 +9,7 @@
     <div class="card-body">
         <form hx-put="/settings/notifications" hx-target="#settings-alert-container" hx-swap="innerHTML">
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="notification_type">
                 <label for="notification_type">Notification Type</label>
                 <select id="notification_type" name="notification_type">
                     <option value="system" {% if settings.notification_type == 'system' %}selected{% endif %}>System (console only)</option>
@@ -47,7 +47,7 @@
             </div>
             {% endif %}
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="unraid_levels">
                 <label>Unraid Notification Levels</label>
                 <div class="checkbox-group">
                     <label class="checkbox-label">
@@ -85,7 +85,7 @@
                 Webhook Notifications
             </h3>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="webhook_url">
                 <label for="webhook_url">Webhook URL</label>
                 <div style="display: flex; gap: 0.5rem;">
                     <input type="text" id="webhook_url" name="webhook_url"
@@ -93,6 +93,7 @@
                            placeholder="https://discord.com/api/webhooks/..."
                            style="flex: 1;">
                     <button type="button" class="btn btn-secondary" id="test-webhook-btn"
+                            data-setting-id="test_webhook_btn"
                             hx-post="/settings/notifications/test"
                             hx-include="#webhook_url"
                             hx-target="#webhook-test-result"
@@ -109,7 +110,7 @@
                 <div id="webhook-test-result" style="margin-top: 0.5rem;"></div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" data-setting-id="webhook_levels">
                 <label>Webhook Notification Levels</label>
                 <div class="checkbox-group">
                     <label class="checkbox-label">

--- a/web/templates/settings/plex.html
+++ b/web/templates/settings/plex.html
@@ -9,20 +9,20 @@
     </div>
     <div class="card-body">
         <div class="grid grid-2">
-            <div class="form-group">
+            <div class="form-group" data-setting-id="plex_url">
                 <label for="plex_url">Plex URL</label>
                 <input type="text" id="plex_url" name="plex_url"
                        value="{{ settings.plex_url | default('http://localhost:32400') }}"
                        placeholder="http://localhost:32400" required>
             </div>
 
-            <div class="form-group mb-0">
+            <div class="form-group mb-0" data-setting-id="plex_token">
                 <label for="plex_token">Plex Token</label>
                 <div class="flex gap-1">
                     <input type="password" id="plex_token" name="plex_token"
                            value="{{ settings.plex_token | default('') }}"
                            placeholder="Your Plex token" style="flex: 1;" required>
-                    <button type="button" class="btn btn-secondary oauth-btn" onclick="startPlexOAuth()" title="Sign in with Plex to get token automatically">
+                    <button type="button" class="btn btn-secondary oauth-btn" data-setting-id="plex_oauth_btn" onclick="startPlexOAuth()" title="Sign in with Plex to get token automatically">
                         <i data-lucide="key"></i>
                         <span>Get Token</span>
                     </button>
@@ -43,6 +43,7 @@
                 Save Connection
             </button>
             <button type="button" class="btn btn-secondary"
+                    data-setting-id="plex_test"
                     hx-post="/settings/plex/test"
                     hx-target="#plex-test-result"
                     hx-swap="innerHTML">

--- a/web/templates/settings/schedule.html
+++ b/web/templates/settings/schedule.html
@@ -48,7 +48,7 @@
     <div class="card-body">
         <form id="schedule-form" hx-post="/api/settings/schedule" hx-target="#settings-alert-container" hx-swap="innerHTML">
             <!-- Enable Toggle -->
-            <div class="form-group">
+            <div class="form-group" data-setting-id="schedule_enabled">
                 <label class="switch">
                     <input type="checkbox" name="enabled" id="schedule-enabled"
                            {% if schedule.enabled %}checked{% endif %}
@@ -60,7 +60,7 @@
 
             <div id="schedule-options" {% if not schedule.enabled %}style="opacity: 0.5; pointer-events: none;"{% endif %}>
                 <!-- Schedule Type -->
-                <div class="form-group">
+                <div class="form-group" data-setting-id="schedule_type">
                     <label>Schedule Type</label>
                     <div class="schedule-type-selector">
                         <label class="radio-card">
@@ -89,7 +89,7 @@
                 <!-- Interval Options -->
                 <div id="interval-options" {% if schedule.schedule_type != 'interval' %}style="display: none;"{% endif %}>
                     <div class="interval-grid">
-                        <div class="form-group">
+                        <div class="form-group" data-setting-id="interval_hours">
                             <label for="interval-hours">Run Every</label>
                             <select name="interval_hours" id="interval-hours">
                                 <option value="1" {% if schedule.interval_hours == 1 %}selected{% endif %}>1 hour</option>
@@ -100,7 +100,7 @@
                                 <option value="24" {% if schedule.interval_hours == 24 %}selected{% endif %}>24 hours</option>
                             </select>
                         </div>
-                        <div class="form-group">
+                        <div class="form-group" data-setting-id="interval_start_time">
                             <label for="interval-start-time">Starting At</label>
                             <input type="time" name="interval_start_time" id="interval-start-time"
                                    value="{{ schedule.interval_start_time|default('00:00') }}">
@@ -111,13 +111,13 @@
 
                 <!-- Cron Options -->
                 <div id="cron-options" {% if schedule.schedule_type != 'cron' %}style="display: none;"{% endif %}>
-                    <div class="form-group">
+                    <div class="form-group" data-setting-id="cron_expression">
                         <label for="cron-expression">Cron Expression</label>
                         <div class="cron-input-group">
                             <input type="text" name="cron_expression" id="cron-expression"
                                    value="{{ schedule.cron_expression }}"
                                    placeholder="0 */4 * * *">
-                            <button type="button" class="btn btn-secondary" onclick="validateCron()">
+                            <button type="button" class="btn btn-secondary" data-setting-id="cron_validate_btn" onclick="validateCron()">
                                 <i data-lucide="check"></i>
                                 Validate
                             </button>
@@ -134,12 +134,12 @@
                 <div class="form-group">
                     <label>Run Options</label>
                     <div class="checkbox-group">
-                        <label class="checkbox-item">
+                        <label class="checkbox-item" data-setting-id="dry_run">
                             <input type="checkbox" name="dry_run" {% if schedule.dry_run %}checked{% endif %}>
                             <span>Dry Run</span>
                             <small>Simulate without moving files</small>
                         </label>
-                        <label class="checkbox-item">
+                        <label class="checkbox-item" data-setting-id="verbose">
                             <input type="checkbox" name="verbose" {% if schedule.verbose %}checked{% endif %}>
                             <span>Verbose Logging</span>
                             <small>Enable detailed debug output</small>

--- a/web/templates/settings/security.html
+++ b/web/templates/settings/security.html
@@ -66,7 +66,7 @@
                     Web UI Authentication
                 </div>
 
-                <div class="form-group" style="margin-bottom: 0.75rem;">
+                <div class="form-group" data-setting-id="auth_enabled" style="margin-bottom: 0.75rem;">
                     <div class="security-toggle-row">
                         <div>
                             <label for="auth_enabled" style="margin-bottom: 0;">Require Login</label>
@@ -90,7 +90,7 @@
                 {% endif %}
 
                 <div id="auth-details" style="{% if not settings.auth_enabled %}display: none;{% endif %}">
-                    <div class="form-group" style="margin-top: 1.25rem; margin-bottom: 0;">
+                    <div class="form-group" data-setting-id="auth_session_hours" style="margin-top: 1.25rem; margin-bottom: 0;">
                         <label for="auth_session_hours">Session Duration</label>
                         <select id="auth_session_hours" name="auth_session_hours">
                             <option value="1" {% if settings.auth_session_hours == 1 %}selected{% endif %}>1 hour</option>
@@ -116,7 +116,7 @@
                     Optional password login as fallback when Plex OAuth is unavailable.
                 </div>
 
-                <div class="form-group" style="margin-bottom: 0.75rem;">
+                <div class="form-group" data-setting-id="auth_password_enabled" style="margin-bottom: 0.75rem;">
                     <div class="security-toggle-row">
                         <div>
                             <label for="auth_password_enabled" style="margin-bottom: 0;">Enable Password Login</label>
@@ -132,13 +132,13 @@
 
                 <div id="password-section" style="{% if not settings.auth_password_enabled %}display: none;{% endif %}">
                     <div class="grid grid-2" style="margin-top: 0.75rem;">
-                        <div class="form-group">
+                        <div class="form-group" data-setting-id="auth_password_username">
                             <label for="auth_password_username">Username</label>
                             <input type="text" id="auth_password_username" name="auth_password_username"
                                    value="{{ settings.auth_password_username | default('') }}"
                                    autocomplete="off">
                         </div>
-                        <div class="form-group">
+                        <div class="form-group" data-setting-id="auth_password">
                             <label for="auth_password">New Password</label>
                             <input type="password" id="auth_password" name="auth_password"
                                    placeholder="Leave blank to keep current"
@@ -161,6 +161,7 @@
                     </span>
                     {% if active_sessions > 0 %}
                     <button type="button" class="btn btn-sm"
+                            data-setting-id="logout_all_btn"
                             style="background: rgba(244, 67, 54, 0.1); color: var(--plex-error); border: 1px solid rgba(244, 67, 54, 0.3);"
                             hx-post="/settings/security/logout-all"
                             hx-target="#settings-alert-container"

--- a/web/templates/settings/users.html
+++ b/web/templates/settings/users.html
@@ -10,7 +10,7 @@
         <h2>Multi-User Support</h2>
     </div>
     <div class="card-body">
-        <div class="form-group mb-0">
+        <div class="form-group mb-0" data-setting-id="users_toggle">
             <label class="switch">
                 <input type="checkbox" name="users_toggle" id="users_toggle"
                        {% if settings.users_toggle %}checked{% endif %}
@@ -31,6 +31,7 @@
         </div>
         {% if has_plex_config %}
         <button type="button" class="btn btn-secondary"
+                data-setting-id="users_sync_btn"
                 hx-post="/settings/users/sync"
                 hx-target="#users-table-container"
                 hx-swap="innerHTML"
@@ -65,7 +66,7 @@
         <h2>Self-Service Authentication</h2>
     </div>
     <div class="card-body">
-        <div class="form-group">
+        <div class="form-group" data-setting-id="auth_link_enabled">
             <label class="switch">
                 <input type="checkbox" name="auth_link_enabled" id="auth_link_enabled"
                        {% if settings.auth_link_enabled %}checked{% endif %}
@@ -75,7 +76,7 @@
             <div class="form-hint">Allow shared users to link their Plex account by visiting a URL. This captures their access token so PlexCache can monitor their OnDeck items. Requires PlexCache to be reachable by the user (reverse proxy, Tailscale, etc.).</div>
         </div>
 
-        <div id="auth-link-url" class="form-group mb-0" style="{% if not settings.auth_link_enabled %}display: none;{% endif %}">
+        <div id="auth-link-url" class="form-group mb-0" data-setting-id="auth_link_url" style="{% if not settings.auth_link_enabled %}display: none;{% endif %}">
             <label>Shareable Link</label>
             <div style="display: flex; gap: 0.5rem; align-items: center;">
                 <input type="text" id="auth-link-url-input" readonly
@@ -98,7 +99,7 @@
         <h2>Database Fallback</h2>
     </div>
     <div class="card-body">
-        <div class="form-group mb-0">
+        <div class="form-group mb-0" data-setting-id="plex_db_path">
             <label for="plex_db_path">Plex Database Path</label>
             <input type="text" name="plex_db_path" id="plex_db_path" class="form-control path-browse-input"
                    value="{{ settings.plex_db_path }}"
@@ -129,7 +130,7 @@
             </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" data-setting-id="remote_watchlist_toggle">
             <label class="switch">
                 <input type="checkbox" name="remote_watchlist_toggle"
                        {% if settings.remote_watchlist_toggle %}checked{% endif %}>
@@ -137,7 +138,7 @@
             </label>
         </div>
 
-        <div class="form-group mb-0">
+        <div class="form-group mb-0" data-setting-id="remote_watchlist_rss_url">
             <label for="remote_watchlist_rss_url">RSS URL</label>
             <input type="text" id="remote_watchlist_rss_url" name="remote_watchlist_rss_url"
                    value="{{ settings.remote_watchlist_rss_url | default('') }}"


### PR DESCRIPTION
## Summary

Adds a persistent search bar at the top of every `/settings/*` tab that filters across all 10 tabs at once. Type a query, see matching settings grouped by tab, click one to jump to the right tab and have the setting flash-highlighted in place.

- 78 indexed settings live in `web/settings_search_index.py` (each with `tab`, `setting_id`, `label`, `hint`, `section`, `subsection`, `icon`, `tone`, `keywords` so synonyms work). Every indexed setting carries a matching `data-setting-id` on its form-group.
- Client-side JS in `web/static/js/settings_search.js` renders results live as you type, supports keyboard navigation (arrows / Enter / Esc), and on click navigates to `/settings/<tab>#setting-<id>`.
- The hash handler runs a two-phase highlight: a 1.1s `@keyframes ss-flash-pulse` gold outline pulse, then a persistent `.ss-flash-pinned` outline that dismisses on the next click or keypress. `flashTarget()` polls for the target up to 3s so HTMX-loaded partial tabs have time to render. The target selector excludes `.ss-result-row` so the flash never lands on the hidden popup row that also carries the `data-setting-id`.

## Test plan

- [x] Open `/settings/plex` and type a query like \"webhook\" in the top search bar — confirm results from multiple tabs appear, grouped by tab name.
- [x] Click a result on a different tab and confirm the page navigates to the right tab and the matching setting outlines in gold for ~1s, then keeps a persistent outline until you click or press a key.
- [x] Reload `/settings/notifications#setting-webhook_url` directly and confirm the highlight still applies (i.e. the polling fallback works for HTMX-loaded partials).
- [x] Use arrow keys + Enter in the results dropdown and confirm keyboard nav matches the visible highlight.
- [x] Search for synonyms (e.g. \"alert\" should surface notification settings, \"path\" should surface mapping/library settings) and confirm `keywords` matches as expected.
- [x] Confirm the focus ring inside `#settings-search-input` is suppressed (no double-ring against the wrapper outline).