### PR TITLE
Priority report: fix badge colors to match tier definitions

### DIFF
--- a/web/templates/cache/partials/eviction_simulation.html
+++ b/web/templates/cache/partials/eviction_simulation.html
@@ -38,7 +38,7 @@
                     <td title="{{ file.path }}">{{ file.filename }}</td>
                     <td class="text-muted">{{ file.size_display }}</td>
                     <td>
-                        <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
+                        <span class="priority-badge {{ 'high' if file.priority_score >= 90 else 'medium' if file.priority_score >= 70 else 'low' }}">
                             {{ file.priority_score }}
                         </span>
                     </td>

--- a/web/templates/cache/partials/file_table.html
+++ b/web/templates/cache/partials/file_table.html
@@ -17,7 +17,7 @@
         </td>
         {% if eviction_enabled %}
         <td>
-            <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
+            <span class="priority-badge {{ 'high' if file.priority_score >= 90 else 'medium' if file.priority_score >= 70 else 'low' }}">
                 {{ file.priority_score }}
             </span>
         </td>

--- a/web/templates/cache/partials/priorities_content.html
+++ b/web/templates/cache/partials/priorities_content.html
@@ -166,7 +166,7 @@
                         </span>
                     </td>
                     <td>
-                        <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
+                        <span class="priority-badge {{ 'high' if file.priority_score >= 90 else 'medium' if file.priority_score >= 70 else 'low' }}">
                             {{ file.priority_score }}
                         </span>
                     </td>

--- a/web/templates/cache/partials/storage_stats.html
+++ b/web/templates/cache/partials/storage_stats.html
@@ -325,7 +325,7 @@
                             </td>
                             {% if data.config.eviction_enabled %}
                             <td>
-                                <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
+                                <span class="priority-badge {{ 'high' if file.priority_score >= 90 else 'medium' if file.priority_score >= 70 else 'low' }}">
                                     {{ file.priority_score }}
                                 </span>
                             </td>
@@ -391,7 +391,7 @@
                             </td>
                             {% if data.config.eviction_enabled %}
                             <td>
-                                <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
+                                <span class="priority-badge {{ 'high' if file.priority_score >= 90 else 'medium' if file.priority_score >= 70 else 'low' }}">
                                     {{ file.priority_score }}
                                 </span>
                             </td>
@@ -467,7 +467,7 @@
                             </td>
                             {% if data.config.eviction_enabled %}
                             <td>
-                                <span class="priority-badge {{ 'high' if file.priority_score >= 70 else 'medium' if file.priority_score >= 40 else 'low' }}">
+                                <span class="priority-badge {{ 'high' if file.priority_score >= 90 else 'medium' if file.priority_score >= 70 else 'low' }}">
                                     {{ file.priority_score }}
                                 </span>
                             </td>
@@ -546,7 +546,7 @@
                             </td>
                             {% if data.config.eviction_enabled %}
                             <td>
-                                <span class="priority-badge {{ 'high' if item.file.priority_score >= 70 else 'medium' if item.file.priority_score >= 40 else 'low' }}">
+                                <span class="priority-badge {{ 'high' if item.file.priority_score >= 90 else 'medium' if item.file.priority_score >= 70 else 'low' }}">
                                     {{ item.file.priority_score }}
                                 </span>
                             </td>


### PR DESCRIPTION
Fixes #175

## Problem

On the Priority Report (and the storage breakdown, file table, and eviction simulator), the per-item score badges were colored with outdated thresholds — `>= 70` for green/high and `>= 40` for orange/medium. The Priority Distribution legend and the backend tier counts use `90-100` high, `70-89` medium, `0-69` low. As a result the badge color contradicted the legend: a score of 85 or 70 showed green (when the legend marks them medium), and a 60 showed orange (when the legend marks it low/eviction).

## Fix

Align the badge color thresholds in the four templates with the canonical tier boundaries already used by the backend (`cache_service.py`):

- `>= 90` -> high (green)
- `>= 70` -> medium (orange)
- `< 70` -> low (red)

This makes the list badges match the Priority Distribution cards, the footer summary badges, and the actual eviction behavior.

## Test steps

1. Cache a set of items with a spread of priority scores (or use `--show-priorities`).
2. Open the web UI -> Cache -> Priority Report.
3. Confirm the score badge colors now match the Priority Distribution legend:
   - 90-100 renders green (High)
   - 70-89 renders orange (Medium)
   - 0-69 renders red (Low)
4. Spot-check the Storage breakdown, the cache file table, and the eviction simulator preview — badge colors are consistent everywhere.
