### PR TITLE
Maintenance: reload settings when the file changes so audits reflect current cache paths

### DIFF
--- a/tests/test_maintenance_service.py
+++ b/tests/test_maintenance_service.py
@@ -182,6 +182,94 @@ class TestGetPaths:
 
 
 # ============================================================================
+# Settings reload tests (StudioNirin/PlexCache-D#176)
+# ============================================================================
+
+class TestSettingsReloadOnChange:
+    """The singleton must not serve a stale settings/path snapshot.
+
+    A stale snapshot caused the audit to scan an old/empty cache path and report
+    "0 on cache", flagging every tracked file as stale until a restart.
+    """
+
+    @staticmethod
+    def _bump_mtime(path):
+        """Force a newer mtime (avoids same-second resolution flakiness)."""
+        future = path.stat().st_mtime + 10
+        os.utime(path, (future, future))
+
+    def test_get_paths_refreshes_when_settings_change(self, tmp_path):
+        svc = _make_service(tmp_path)
+        cache_dirs, _ = svc._get_paths()
+        assert cache_dirs == ["/mnt/cache/media/Movies", "/mnt/cache/media/TV"]
+
+        # Simulate the user editing path mappings after the process started.
+        new_settings = {
+            "path_mappings": [
+                {
+                    "name": "Movies",
+                    "cache_path": "/mnt/cache/newmedia/Movies",
+                    "real_path": "/mnt/user/newmedia/Movies",
+                    "cacheable": True,
+                    "enabled": True,
+                },
+            ]
+        }
+        svc.settings_file.write_text(json.dumps(new_settings), encoding="utf-8")
+        self._bump_mtime(svc.settings_file)
+
+        cache_dirs2, array_dirs2 = svc._get_paths()
+        assert cache_dirs2 == ["/mnt/cache/newmedia/Movies"]
+        assert array_dirs2 == ["/mnt/user0/newmedia/Movies"]
+
+    def test_get_paths_stays_cached_when_unchanged(self, tmp_path):
+        svc = _make_service(tmp_path)
+        cache1, array1 = svc._get_paths()
+        cache2, array2 = svc._get_paths()
+        # No file change → same cached objects (no needless recompute).
+        assert cache1 is cache2
+        assert array1 is array2
+
+    def test_cache_scan_recovers_after_mapping_fix(self, tmp_path):
+        """Reproduces #176: a corrected cache_path is picked up without restart."""
+        # Start with a mapping pointing at an empty cache dir → 0 files found.
+        empty_cache = tmp_path / "empty_cache"
+        empty_cache.mkdir()
+        settings_v1 = {
+            "path_mappings": [{
+                "name": "Movies",
+                "cache_path": str(empty_cache),
+                "real_path": "/mnt/user/media/Movies",
+                "cacheable": True,
+                "enabled": True,
+            }]
+        }
+        svc = _make_service(tmp_path, settings_v1)
+        assert svc.get_cache_files() == set()
+
+        # User fixes the mapping to the real cache dir that holds a file.
+        real_cache = tmp_path / "real_cache"
+        real_cache.mkdir()
+        (real_cache / "movie.mkv").write_text("x", encoding="utf-8")
+        settings_v2 = {
+            "path_mappings": [{
+                "name": "Movies",
+                "cache_path": str(real_cache),
+                "real_path": "/mnt/user/media/Movies",
+                "cacheable": True,
+                "enabled": True,
+            }]
+        }
+        svc.settings_file.write_text(json.dumps(settings_v2), encoding="utf-8")
+        self._bump_mtime(svc.settings_file)
+
+        # Without the fix this still returns set() (stale path).
+        files = svc.get_cache_files()
+        assert len(files) == 1
+        assert os.path.basename(next(iter(files))) == "movie.mkv"
+
+
+# ============================================================================
 # _cache_to_array_path() tests
 # ============================================================================
 

--- a/web/services/maintenance_service.py
+++ b/web/services/maintenance_service.py
@@ -200,21 +200,37 @@ class MaintenanceService:
         self._cache_dirs: List[str] = []
         self._array_dirs: List[str] = []
         self._settings: Dict = {}
+        self._settings_mtime: Optional[float] = None
 
     def _load_settings(self) -> Dict:
-        """Load settings from plexcache_settings.json"""
-        if self._settings:
+        """Load settings from plexcache_settings.json.
+
+        Reloads automatically when the file's modification time changes so this
+        long-lived singleton never serves a stale snapshot. Previously the first
+        load was memoized for the life of the web process; if settings were
+        edited afterwards (e.g. path mappings gaining a cache_path) the audit
+        kept scanning the old/empty cache path and flagged every tracked file as
+        stale until a container restart. See StudioNirin/PlexCache-D#176.
+        """
+        try:
+            mtime = self.settings_file.stat().st_mtime
+        except OSError:
+            # File missing or unreadable — keep serving the last good snapshot.
             return self._settings
 
-        if not self.settings_file.exists():
-            return {}
+        if self._settings and mtime == self._settings_mtime:
+            return self._settings
 
         try:
             with open(self.settings_file, 'r', encoding='utf-8') as f:
                 self._settings = json.load(f)
+            self._settings_mtime = mtime
+            # Settings changed on disk — paths derived in _get_paths() are stale.
+            self._cache_dirs = []
+            self._array_dirs = []
             return self._settings
         except (json.JSONDecodeError, IOError):
-            return {}
+            return self._settings
 
     def _translate_host_to_container_path(self, path: str) -> str:
         """Translate host cache path to container path."""
@@ -257,10 +273,13 @@ class MaintenanceService:
 
     def _get_paths(self) -> tuple:
         """Get cache and array directory paths from settings"""
+        # Load settings first: _load_settings() clears the cached dirs below when
+        # the file changes, so this short-circuit can't return stale paths for
+        # the life of the singleton (StudioNirin/PlexCache-D#176).
+        settings = self._load_settings()
         if self._cache_dirs and self._array_dirs:
             return self._cache_dirs, self._array_dirs
 
-        settings = self._load_settings()
         cache_dirs = []
         array_dirs = []
 


### PR DESCRIPTION
Fixes #176.

## Problem

The Maintenance/audit layer (`MaintenanceService`) is a process-lifetime singleton that memoized settings and the derived cache/array directory paths on first use, with no invalidation. If path mappings were edited after the web process started (e.g. a mapping gained its `cache_path`), the audit kept scanning the previous path.

When that cached path resolved to an empty or old directory, the cache scan returned **0 files**, so the audit marked every tracked exclude and timestamp entry as "stale — no longer on cache." The dashboard then showed a large warning count (e.g. `140 warnings = 70 stale exclude + 70 stale timestamp`) and Maintenance showed `Protected: N of 0 on cache`. Cleaning removed the tracking entries (the physical files were untouched), and the next run re-created them, so the warnings returned every run. A container restart cleared the stale snapshot and the warnings stayed gone — confirming the cause.

The actual caching run was always correct: it resolves each file via `mapping.cache_path` and found all cached files. Only the long-lived audit singleton was out of date.

## Fix

`_load_settings()` now tracks the settings file `mtime` and reloads when it changes, clearing the derived `cache_dirs`/`array_dirs` so they are recomputed from the current configuration. `_get_paths()` consults `_load_settings()` before its cache short-circuit so the reload is honored. When settings are unchanged, behavior is identical to before (no extra file reads beyond a cheap `stat`).

## Testing

1. Start the Web UI and run a cache operation so files are tracked and the dashboard shows them as cached.
2. Edit a path mapping in Settings (or complete setup so a mapping gains its cache path) without restarting.
3. Open Maintenance / Dashboard and confirm the audit reflects the updated mapping — cached files are counted and no false "stale" warnings appear.
4. Confirm that with mappings unchanged, repeated runs keep a stable tracking count and an empty warning list.

Automated coverage added in `tests/test_maintenance_service.py` (`TestSettingsReloadOnChange`): paths refresh after a settings change, stay cached when unchanged, and the cache scan recovers once a mapping is corrected.