### PR TITLE
Fix mobile table columns and log viewer toolbar (#187)

### DIFF
--- a/web/static/css/plex-theme.css
+++ b/web/static/css/plex-theme.css
@@ -2824,12 +2824,6 @@ footer .version {
     th, td {
         padding: 0.625rem 0.75rem;
     }
-
-    /* Hide checkbox column on mobile for better spacing */
-    table th:first-child,
-    table td:first-child {
-        display: none;
-    }
 }
 
 /* Desktop theme toggle position */

--- a/web/templates/logs/viewer.html
+++ b/web/templates/logs/viewer.html
@@ -108,7 +108,7 @@
                     <span>Aa</span>
                 </label>
             </div>
-            <div class="flex items-center gap-1">
+            <div class="flex flex-wrap items-center gap-1">
                 <div class="time-range-inputs">
                     <input type="time" id="time-from" step="1" title="From time" placeholder="From">
                     <span class="text-muted">&ndash;</span>


### PR DESCRIPTION
## What

Two mobile layout fixes.

**1. Tables lost their first column on mobile (fixes #187)**

The mobile breakpoint had a rule that hid the first column of every table on screens 768px and under. It was meant to drop a checkbox column for spacing, but it applied to all tables, so on a phone:

- Maintenance > Untracked Files and Cached Files lost their selection checkbox, so there was no way to select anything (this is what #187 reported)
- Maintenance > Multi-Version and Storage breakdown tables lost their File name column
- Dashboard Recent Activity and Maintenance Action History lost their Time column
- Recently Added lost its Title column

Removing the rule brings those columns back. The checkbox column is 40px and the tables already scroll inside their container, so spacing is fine.

**2. Log viewer toolbar toggles were unreachable on mobile**

The time-range and toggle group in the log viewer toolbar used a non-wrapping flex row. On narrow screens the Auto-scroll and Live Updates switches were pushed past the edge of the viewport and clipped by the card, so you could not reach them. Added the existing `flex-wrap` utility to that group so it wraps to a second line when space runs out. No change on wider screens.

## Test steps

Open the web UI on a phone, or use desktop browser devtools with a mobile viewport (around 390px wide).

1. Go to Maintenance and run an audit. Under Untracked Files, confirm each row now shows a selection checkbox and you can select files and use Keep on Cache / Move to Array.
2. On the Dashboard, confirm Recent Activity shows the Time column.
3. On Storage, confirm the breakdown tables show the File column.
4. On Recently Added, confirm the Title column is visible.
5. On Logs, confirm the Auto-scroll and Live Updates toggles are visible and tappable (they wrap to their own line rather than running off the edge).
6. On a normal desktop width, confirm all of the above pages look the same as before.
