### PR TITLE
CI: publish versioned images on GitHub Release (fixes #194)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,10 @@ name: Build and Publish Docker Image
 on:
   push:
     branches: [dev, v3.0, main]
-    tags: ['v*']
   pull_request:
     branches: [dev, v3.0, main]
+  release:
+    types: [published]
 
 jobs:
   test:
@@ -43,7 +44,7 @@ jobs:
 
   build-and-push:
     needs: test
-    if: github.event_name == 'push'
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -77,23 +78,23 @@ jobs:
             ${{ vars.DOCKERHUB_ENABLED == 'true' && format('{0}/plexcache-d', secrets.DOCKERHUB_USERNAME) || '' }}
             ghcr.io/${{ github.repository_owner }}/plexcache-d
           tags: |
-            # dev tag for dev branch
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
-            # latest tag for v3.0 and main branches
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/v3.0' || github.ref == 'refs/heads/main' }}
-            # semver tags for version tags (v3.0.1 -> latest, v3.0.1, v3.0, v3)
+            # dev tag for dev branch pushes (rolling test channel)
+            type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
+            # semver tags from the published release's tag (v3.2.0 -> 3.2.0, 3.2, 3)
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            # latest only for full (non-prerelease) releases
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
 
       - name: Compute IMAGE_TAG build arg
         id: image_tag
         run: |
           if [[ "$GITHUB_REF" == refs/heads/dev ]]; then
             echo "value=dev" >> "$GITHUB_OUTPUT"
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            echo "value=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            tag="${GITHUB_REF#refs/tags/}"
+            echo "value=${tag#v}" >> "$GITHUB_OUTPUT"
           else
             echo "value=latest" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Addresses #194.

Right now the container registry only ever gets a `latest` tag, and the "Latest" badge on the Releases page is stuck on 2.1.2 while 3.2.0 sits as a pre-release. The cause is in the CI trigger: semver images only build on `v*` tag pushes, but the tags here are `2.1.2`, `beta-3.0`, `3.0` (no `v`), so those builds never fire. Meanwhile `main`/`v3.0` pushes publish `:latest`, so `:latest` ends up tracking the tip of main rather than a release.

This moves image publishing onto the GitHub Release event.

What changes:
- Publishing a release builds semver image tags from the release tag. `v3.2.0` produces `3.2.0`, `3.2`, and `3`.
- `:latest` moves only when the release is a full (non-prerelease) release.
- Pre-releases still build and publish their full tag (e.g. `3.2.0-beta1`) but leave `:latest` untouched.
- The `dev` branch keeps publishing `:dev` as a rolling test channel.
- The `v` prefix on the tag is optional now. metadata-action strips it, so `v3.2.0` and `3.2.0` both build the `3.2.0` image.

One behavior change worth calling out: `main`/`v3.0` pushes no longer publish `:latest`. `:latest` now means the current stable release, which keeps it in sync with the Releases page and gives compose/IaC users something stable to pin. Pushes to those branches still run the test job, they just don't publish an image.

Cutting a release after this merges:
1. Create a GitHub Release with tag `v3.2.0`, leave "pre-release" unchecked.
2. CI runs the tests, then publishes `3.2.0`, `3.2`, `3`, and `latest`.

For a beta, check "pre-release" and tag it `v3.2.0-beta1`. That publishes `3.2.0-beta1` and leaves `latest` alone.

If you'd prefer a rolling image for `main` as well, I can add an `:edge` tag on main pushes. I left it out to keep `latest` meaning "stable release."