### PR TITLE
Fix plex.tv DNS blips blocking array restore, clarify locked admin toggles

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -536,7 +536,8 @@ class PlexCacheApp:
             delay=self.config_manager.performance.delay,
             token_cache_file=token_cache_file,
             rss_cache_file=rss_cache_file,
-            plex_db_path=self.config_manager.plex.plex_db_path
+            plex_db_path=self.config_manager.plex.plex_db_path,
+            watchlist_enabled=self.config_manager.cache.watchlist_toggle
         )
 
     def _init_path_modifier(self) -> None:
@@ -1242,12 +1243,16 @@ class PlexCacheApp:
 
         # Check for files that should be moved back to array (no longer needed in cache)
         # Only check if watched_move is enabled - otherwise files stay on cache indefinitely
-        # Skip if OnDeck or watchlist data is incomplete to prevent accidental moves
+        # Skip if OnDeck or watchlist data is incomplete to prevent accidental moves.
+        # The watchlist guard only applies when watchlist caching is enabled - with it
+        # off, no cached file is held by the watchlist, so incomplete plex.tv data
+        # can't cause a wrong move.
         if self.config_manager.cache.watched_move:
             if not self.plex_manager.is_ondeck_data_complete():
                 logging.warning("Skipping array restore - OnDeck data incomplete (Plex server unreachable)")
                 logging.warning("Files will remain on cache until next successful run")
-            elif not self.plex_manager.is_watchlist_data_complete():
+            elif (self.config_manager.cache.watchlist_toggle
+                    and not self.plex_manager.is_watchlist_data_complete()):
                 logging.warning("Skipping array restore - watchlist data incomplete (plex.tv unreachable)")
                 logging.warning("Files will remain on cache until next successful run")
             else:

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -301,7 +301,7 @@ class PlexManager:
 
     def __init__(self, plex_url: str, plex_token: str, retry_limit: int = 3, delay: int = 5,
                  token_cache_file: Optional[str] = None, rss_cache_file: Optional[str] = None,
-                 plex_db_path: str = ""):
+                 plex_db_path: str = "", watchlist_enabled: bool = True):
         self.plex_url = plex_url
         self.plex_token = plex_token
         self.retry_limit = retry_limit
@@ -310,6 +310,7 @@ class PlexManager:
         self._token_cache = UserTokenCache(cache_file=token_cache_file, cache_expiry_hours=24)
         self._rss_cache_file = rss_cache_file  # Path to RSS cache file
         self._plex_db_path = plex_db_path  # Path to Plex SQLite DB (fallback for tokenless shared users)
+        self.watchlist_enabled = watchlist_enabled  # Controls watchlist-specific warnings on plex.tv failure
         self._user_tokens: Dict[str, str] = {}  # username -> token (populated at startup)
         self._token_lock = threading.Lock()  # Protects _user_tokens dict access
         self._user_id_to_name: Dict[str, str] = {}  # user_id (str) -> username (for RSS author lookup)
@@ -418,7 +419,13 @@ class PlexManager:
         """
         try:
             self._rate_limited_api_call()
-            account = self.plex.myPlexAccount()
+            # Retry transient network errors (DNS blips, connection resets). This is
+            # the first plex.tv call of a run, and a single failure here previously
+            # marked plex.tv unreachable for the whole run.
+            account = _retry_plextv_call(
+                lambda: self.plex.myPlexAccount(),
+                "main account lookup"
+            )
             actual_main_username = account.title
 
             # Update main account token with actual username from plex.tv
@@ -432,9 +439,13 @@ class PlexManager:
         except Exception as e:
             _log_api_error("load user tokens", e)
             self._plex_tv_reachable = False
-            self._watchlist_data_complete = False
             logging.warning("[PLEX API] plex.tv unreachable - using cached user data only")
-            logging.warning("[PLEX API] Watchlist data will be incomplete - array restore will be skipped")
+            # Only a watchlist run depends on plex.tv data being complete. With
+            # watchlist disabled there is nothing incomplete to guard against, so
+            # don't flag it and don't block array restore.
+            if self.watchlist_enabled:
+                self._watchlist_data_complete = False
+                logging.warning("[PLEX API] Watchlist data will be incomplete - array restore will be skipped")
             return None
 
     def _discover_new_users(self, account: 'MyPlexAccount', settings_usernames: Set[str],

--- a/tests/test_plextv_main_account_resilience.py
+++ b/tests/test_plextv_main_account_resilience.py
@@ -1,0 +1,150 @@
+"""Tests for plex.tv resilience during main-account lookup (issue #197).
+
+Two behaviours are covered:
+
+1. `_get_main_account()` wraps `myPlexAccount()` in `_retry_plextv_call`, so a
+   transient DNS failure or connection reset on the first plex.tv call of a run
+   no longer marks plex.tv unreachable for the whole run.
+
+2. When watchlist caching is disabled, a plex.tv failure must not set the
+   "watchlist data incomplete" flag. That flag gates array restore, and with
+   watchlist off no cached file is held by the watchlist, so blocking the
+   restore is a false positive.
+"""
+
+import os
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import requests
+
+from core.plex_api import PlexManager, PLEXTV_MAX_RETRIES
+
+
+# The exact error urllib3/requests raises when DNS returns no address, as
+# reported in issue #197 ([Errno -5] No address associated with hostname).
+DNS_FAILURE = requests.ConnectionError(
+    "HTTPSConnectionPool(host='plex.tv', port=443): Max retries exceeded with "
+    "url: /api/v2/user (Caused by NameResolutionError(\"HTTPSConnection("
+    "host='plex.tv', port=443): Failed to resolve 'plex.tv' "
+    "([Errno -5] No address associated with hostname)\"))"
+)
+
+
+def _bare_api(watchlist_enabled=True):
+    """Construct a PlexManager without running __init__ (avoids network auth)."""
+    api = PlexManager.__new__(PlexManager)
+    api.plex_url = "http://localhost:32400"
+    api.plex_token = "ADMIN_TOKEN"
+    api.watchlist_enabled = watchlist_enabled
+    api._user_tokens = {}
+    api._plex_tv_reachable = True
+    api._watchlist_data_complete = True
+    api._ondeck_data_complete = True
+    api._token_lock = threading.Lock()
+    api._rate_limited_api_call = MagicMock()
+    api.plex = MagicMock()
+    return api
+
+
+class TestMainAccountRetry:
+    """_get_main_account() retry wiring."""
+
+    def test_transient_dns_failure_then_success(self):
+        """DNS blip on the first attempt, success on the second → account returned."""
+        api = _bare_api()
+        account = MagicMock()
+        account.title = "Brandon"
+        api.plex.myPlexAccount.side_effect = [DNS_FAILURE, account]
+
+        with patch("core.plex_api.time.sleep"):
+            result = api._get_main_account("main")
+
+        assert result is account
+        assert api.plex.myPlexAccount.call_count == 2
+        # A recovered blip must leave both health flags untouched.
+        assert api._plex_tv_reachable is True
+        assert api._watchlist_data_complete is True
+
+    def test_retries_are_bounded_then_gives_up(self):
+        """Sustained DNS failure exhausts retries and reports plex.tv unreachable."""
+        api = _bare_api()
+        api.plex.myPlexAccount.side_effect = DNS_FAILURE
+
+        with patch("core.plex_api.time.sleep"):
+            result = api._get_main_account("main")
+
+        assert result is None
+        assert api.plex.myPlexAccount.call_count == PLEXTV_MAX_RETRIES
+        assert api._plex_tv_reachable is False
+
+    def test_success_on_first_attempt_makes_one_call(self):
+        """No retry overhead on the happy path."""
+        api = _bare_api()
+        account = MagicMock()
+        account.title = "Brandon"
+        api.plex.myPlexAccount.return_value = account
+
+        assert api._get_main_account("Brandon") is account
+        assert api.plex.myPlexAccount.call_count == 1
+
+    def test_auth_error_is_not_retried(self):
+        """Non-transient errors fail fast rather than burning retry budget."""
+        api = _bare_api()
+        api.plex.myPlexAccount.side_effect = ValueError("401 Unauthorized")
+
+        with patch("core.plex_api.time.sleep"):
+            assert api._get_main_account("main") is None
+
+        assert api.plex.myPlexAccount.call_count == 1
+        assert api._plex_tv_reachable is False
+
+
+class TestWatchlistFlagRespectsToggle:
+    """plex.tv failure should only flag watchlist data when watchlist is in use."""
+
+    def test_watchlist_enabled_flags_incomplete(self):
+        api = _bare_api(watchlist_enabled=True)
+        api.plex.myPlexAccount.side_effect = DNS_FAILURE
+
+        with patch("core.plex_api.time.sleep"):
+            api._get_main_account("main")
+
+        assert api._plex_tv_reachable is False
+        assert api._watchlist_data_complete is False
+        assert api.is_watchlist_data_complete() is False
+
+    def test_watchlist_disabled_leaves_data_complete(self):
+        """With watchlist off, array restore must not be blocked by a plex.tv outage."""
+        api = _bare_api(watchlist_enabled=False)
+        api.plex.myPlexAccount.side_effect = DNS_FAILURE
+
+        with patch("core.plex_api.time.sleep"):
+            api._get_main_account("main")
+
+        # plex.tv is still genuinely unreachable...
+        assert api._plex_tv_reachable is False
+        # ...but nothing watchlist-shaped is incomplete, so restore stays allowed.
+        assert api._watchlist_data_complete is True
+        assert api.is_watchlist_data_complete() is True
+
+    def test_constructor_defaults_watchlist_enabled_true(self):
+        """Existing callers that don't pass the flag keep the old guard behaviour."""
+        with patch("core.plex_api.UserTokenCache"):
+            api = PlexManager(plex_url="http://localhost:32400", plex_token="T")
+        assert api.watchlist_enabled is True

--- a/web/templates/settings/partials/users_table.html
+++ b/web/templates/settings/partials/users_table.html
@@ -34,7 +34,7 @@
                 </span>
                 <span class="user-col-group">
                     <span class="toggle-col">
-                        <label class="toggle-switch">
+                        <label class="toggle-switch" {% if user.is_admin %}title="The admin account is always included as an OnDeck source"{% endif %}>
                             <input type="checkbox" name="include_ondeck_{{ user.title }}" value="on"
                                    {% if not user.skip_ondeck %}checked{% endif %}
                                    {% if user.is_admin %}disabled checked{% endif %}>
@@ -42,7 +42,7 @@
                         </label>
                     </span>
                     <span class="toggle-col" style="position: relative;">
-                        <label class="toggle-switch" {% if not user.is_local %}title="Remote users use RSS feed"{% endif %}>
+                        <label class="toggle-switch" {% if user.is_admin %}title="The admin account is always included. To turn watchlist caching off for everyone, use Settings &gt; Cache &gt; Enable Watchlist Caching"{% elif not user.is_local %}title="Remote users use RSS feed"{% endif %}>
                             <input type="checkbox" name="include_watchlist_{{ user.title }}" value="on"
                                    {% if not user.skip_watchlist %}checked{% endif %}
                                    {% if user.is_admin %}disabled checked{% endif %}>
@@ -109,7 +109,7 @@
         {% endfor %}
     </div>
 </div>
-<div class="form-hint mt-1">Toggle sources OFF to exclude a user from caching. Monitoring overrides replace the global OnDeck/Watchlist days for that user (leave blank for global default).</div>
+<div class="form-hint mt-1">Toggle sources OFF to exclude a user from caching. Monitoring overrides replace the global OnDeck/Watchlist days for that user (leave blank for global default). The admin account's toggles are locked on &mdash; to disable watchlist caching for everyone, use <a href="/settings/cache#setting-watchlist_toggle">Settings &rsaquo; Cache &rsaquo; Enable Watchlist Caching</a>.</div>
 {% else %}
 <div class="no-libraries">
     <i data-lucide="users"></i>


### PR DESCRIPTION
Fixes #197

### What's happening

A user reported this during a scheduled run:

```
ERROR - [PLEX API] Error (load user tokens): ... Failed to resolve 'plex.tv' ([Errno -5] No address associated with hostname)
WARNING - [PLEX API] plex.tv unreachable - using cached user data only
WARNING - [PLEX API] Watchlist data will be incomplete - array restore will be skipped
```

Two problems fell out of it, plus a UI gap.

### 1. The first plex.tv call of a run had no retry

`_get_main_account()` called `myPlexAccount()` bare. It was the only plex.tv call in `core/plex_api.py` not going through `_retry_plextv_call`, which already retries `requests.ConnectionError` three times with 2s/4s backoff. A `NameResolutionError` surfaces as exactly that exception, so a brief DNS hiccup took out the whole run when a retry would have gone straight through.

Now wrapped in the existing helper. Non-transient errors (auth, parse) still fail fast on the first attempt.

### 2. A plex.tv outage blocked array restore even with watchlist disabled

The failure path set `_watchlist_data_complete = False` unconditionally, and `_process_media()` uses that flag to skip moving watched files back to the array. With watchlist caching turned off, no cached file is held by the watchlist, so there was nothing incomplete to guard against. Users who don't use the feature at all were still losing their array restore whenever plex.tv had a moment.

`PlexManager` now takes `watchlist_enabled` and only flags watchlist data when watchlist caching is actually on. `_process_media()` checks `watchlist_toggle` alongside the flag as a second gate. The OnDeck guard is unchanged, and behaviour with watchlist enabled is identical to before.

### 3. The locked admin toggles didn't explain themselves

The admin row's OnDeck and Watchlist toggles are disabled by design, but nothing said why or where to go instead, so the reporter thought they'd hit a bug. Added a tooltip on each, and a hint under the table linking to the global switch at Settings > Cache > Enable Watchlist Caching, which is what actually turns watchlist caching off for everyone.

### Testing

New `tests/test_plextv_main_account_resilience.py`, 7 tests:

- transient DNS failure then success returns the account and leaves both health flags clean
- sustained failure stops at `PLEXTV_MAX_RETRIES` and reports plex.tv unreachable
- happy path makes exactly one call
- auth-shaped errors aren't retried
- watchlist enabled still flags data incomplete
- watchlist disabled leaves data complete so restore proceeds
- constructor defaults `watchlist_enabled=True` for existing callers

Full suite: 1207 passed.

### Manual verification

1. Settings > Users, confirm the admin row's toggles show a tooltip on hover and the hint below links to the cache tab.
2. Click the hint link, confirm it lands on Enable Watchlist Caching and flashes it.
3. Turn off Enable Watchlist Caching, block DNS for plex.tv, run a cache operation. The log should show "plex.tv unreachable" but no "array restore will be skipped", and watched files should still move back to the array.
4. Turn Enable Watchlist Caching back on and repeat. The skip warning should return, matching current behaviour.
