### PR TITLE
Keep remote watchlists working when Plex refuses the RSS feed URL

### DIFF
--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -15,6 +15,7 @@ from email.utils import parsedate_to_datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List, Optional, Generator, Tuple, Dict, Set
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 from plexapi.server import PlexServer
 
@@ -131,6 +132,53 @@ PLEX_API_DELAY = 1.0
 # RSS feed retry and cache settings
 RSS_MAX_RETRIES = 3
 RSS_TIMEOUT = 15  # seconds
+
+# Age at which cached RSS data stops being treated as fresh. The cache is a
+# safety net for a brief plex.tv hiccup, not a substitute for the feed - past
+# this the user is told their remote watchlist data is going stale.
+RSS_CACHE_STALE_HOURS = 24
+
+# Hosts we're willing to attach X-Plex-Token to. remote_watchlist_rss_url is
+# user-supplied, so the token must never ride along to an arbitrary domain.
+_PLEX_TOKEN_HOSTS = ("plex.tv", "plex.direct")
+
+# Plex serves watchlist RSS from rss.plex.tv/<uuid>. In July 2026 that host
+# started returning 401 without a token and 404 with one, while the same feed
+# stayed reachable via discover.provider.plex.tv/rss/<uuid> (which 302s to a
+# presigned S3 object). Plex's own UI still hands out rss.plex.tv URLs, so we
+# keep using the configured URL and only fall back when it refuses us.
+_RSS_PRIMARY_HOST = "rss.plex.tv"
+_RSS_FALLBACK_TEMPLATE = "https://discover.provider.plex.tv/rss/{feed_id}"
+
+# Status codes that mean "this URL will not work" rather than "try again".
+_RSS_NO_RETRY_STATUS = (401, 403, 404)
+
+
+def _should_send_plex_token(url: str) -> bool:
+    """True if `url` points at a Plex-controlled host that may receive the token."""
+    try:
+        hostname = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    return any(hostname == h or hostname.endswith("." + h) for h in _PLEX_TOKEN_HOSTS)
+
+
+def _derive_rss_fallback_url(url: str) -> Optional[str]:
+    """Map a legacy rss.plex.tv feed URL to its discover.provider equivalent.
+
+    Returns None when `url` isn't an rss.plex.tv feed URL, so a custom or
+    already-migrated URL is never rewritten.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    if (parsed.hostname or "").lower() != _RSS_PRIMARY_HOST:
+        return None
+    feed_id = parsed.path.strip("/")
+    if not feed_id or "/" in feed_id:
+        return None
+    return _RSS_FALLBACK_TEMPLATE.format(feed_id=feed_id)
 
 # plex.tv API retry settings for transient network errors
 PLEXTV_MAX_RETRIES = 3
@@ -1193,43 +1241,111 @@ class PlexManager:
                 cache_time = datetime.fromisoformat(cache_data['timestamp'])
                 cache_age = datetime.now() - cache_time
                 cache_age_hours = cache_age.total_seconds() / 3600
-                logging.warning(f"Using cached RSS data ({len(items)} items, {cache_age_hours:.1f} hours old)")
+                if cache_age_hours >= RSS_CACHE_STALE_HOURS:
+                    # Still returned - stale data beats losing every remote
+                    # watchlist item - but the user needs to know it's stale.
+                    logging.warning(
+                        f"Using cached RSS data ({len(items)} items) but it is "
+                        f"{cache_age_hours:.1f} hours old - the Plex RSS feed has been "
+                        f"unreachable for over {RSS_CACHE_STALE_HOURS}h. Remote watchlist "
+                        f"changes are not being picked up; check the feed URL in Settings."
+                    )
+                else:
+                    logging.info(f"Using cached RSS data ({len(items)} items, {cache_age_hours:.1f} hours old)")
                 return items
         except Exception as e:
             logging.debug(f"Failed to load RSS cache: {e}")
         return []
 
+    def _request_rss(self, url: str) -> str:
+        """GET an RSS feed, adding the Plex token only for Plex-controlled hosts.
+
+        Plex redirects feed requests to a presigned S3 object. The redirect is
+        followed manually so the token isn't forwarded to the storage host,
+        which carries its own signed credentials.
+
+        Raises:
+            requests.HTTPError / requests.RequestException on failure.
+        """
+        headers = {}
+        if _should_send_plex_token(url) and self.plex_token:
+            headers["X-Plex-Token"] = self.plex_token
+
+        resp = requests.get(url, timeout=RSS_TIMEOUT, headers=headers, allow_redirects=False)
+
+        if resp.is_redirect or resp.is_permanent_redirect:
+            location = resp.headers.get("Location")
+            if location:
+                # No Plex headers here - the presigned URL authenticates itself.
+                resp = requests.get(location, timeout=RSS_TIMEOUT, allow_redirects=True)
+
+        resp.raise_for_status()
+        return resp.text
+
+    def _fetch_rss_from(self, url: str, label: str) -> Optional[List[Tuple[str, str, Optional[datetime], str, str]]]:
+        """Try one RSS URL, retrying only transient failures.
+
+        Returns parsed items, or None if the URL is unusable. Auth/not-found
+        responses return immediately - retrying them just burns time on a
+        deterministic answer.
+        """
+        for attempt in range(RSS_MAX_RETRIES):
+            try:
+                items = self._parse_rss_response(self._request_rss(url))
+                if attempt or label != "primary":
+                    logging.debug(f"RSS fetch succeeded from {label} URL")
+                return items
+            except requests.HTTPError as e:
+                status = e.response.status_code if e.response is not None else None
+                if status in _RSS_NO_RETRY_STATUS:
+                    logging.debug(f"RSS {label} URL returned {status} - not retrying")
+                    return None
+                last_error = e
+            except (requests.RequestException, ET.ParseError) as e:
+                last_error = e
+
+            if attempt < RSS_MAX_RETRIES - 1:
+                wait_time = 2 ** attempt  # 1s, 2s
+                logging.debug(
+                    f"RSS {label} fetch attempt {attempt + 1}/{RSS_MAX_RETRIES} "
+                    f"failed: {last_error}. Retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+
+        logging.debug(f"RSS {label} URL failed after {RSS_MAX_RETRIES} attempts: {last_error}")
+        return None
+
     def _fetch_rss_titles(self, url: str) -> List[Tuple[str, str, Optional[datetime], str, str]]:
         """Fetch titles, categories, pubDate, author ID, and GUID from a Plex RSS feed.
 
-        Retries up to RSS_MAX_RETRIES times with exponential backoff.
-        Falls back to cached data if all retries fail.
+        Tries the configured URL first. If Plex refuses it outright, retries via
+        the discover.provider mirror for the same feed before giving up. Falls
+        back to cached data when neither responds.
 
         Returns list of tuples: (title, category, pub_date, author_id, guid)
         """
-        # Retry loop with exponential backoff
-        last_error = None
-        for attempt in range(RSS_MAX_RETRIES):
-            try:
-                resp = requests.get(url, timeout=RSS_TIMEOUT)
-                resp.raise_for_status()
-                items = self._parse_rss_response(resp.text)
-                self._save_rss_cache(url, items)  # Cache successful result
-                return items
-            except (requests.RequestException, ET.ParseError) as e:
-                last_error = e
-                if attempt < RSS_MAX_RETRIES - 1:
-                    wait_time = 2 ** attempt  # 1s, 2s, 4s
-                    logging.warning(f"RSS fetch attempt {attempt + 1}/{RSS_MAX_RETRIES} failed: {e}. Retrying in {wait_time}s...")
-                    time.sleep(wait_time)
+        items = self._fetch_rss_from(url, "primary")
 
-        # All retries failed - try cache
-        logging.error(f"Failed to fetch RSS feed after {RSS_MAX_RETRIES} attempts: {last_error}")
+        if items is None:
+            fallback_url = _derive_rss_fallback_url(url)
+            if fallback_url:
+                items = self._fetch_rss_from(fallback_url, "fallback")
+                if items is not None:
+                    logging.info(
+                        "RSS: primary feed URL unavailable, served from Plex's "
+                        "discover endpoint instead"
+                    )
+
+        if items is not None:
+            self._save_rss_cache(url, items)
+            return items
+
+        # Neither URL worked - fall back to the last good copy.
         cached_items = self._load_rss_cache()
         if cached_items:
             return cached_items
 
-        logging.error("No cached RSS data available - remote watchlist items will be missing!")
+        logging.error("RSS feed unreachable and no cached data available - remote watchlist items will be missing")
         return []
 
     def _process_watchlist_show(self, file, watchlist_episodes: int, username: str,

--- a/tests/test_plex_rss_fallback.py
+++ b/tests/test_plex_rss_fallback.py
@@ -1,0 +1,268 @@
+"""Tests for Plex watchlist RSS fetching and its fallback path.
+
+Plex serves watchlist RSS from `rss.plex.tv/<uuid>`. In July 2026 that host
+began returning 401 without a token and 404 with one, while the same feed
+remained reachable via `discover.provider.plex.tv/rss/<uuid>`. Plex's own UI
+still hands out `rss.plex.tv` URLs, so the configured URL stays primary and the
+mirror is only tried when Plex refuses.
+
+Covered here:
+  - URL derivation (only legacy Plex feed URLs are ever rewritten)
+  - token scoping (never sent to a non-Plex host)
+  - primary-first ordering, and no fallback when primary works
+  - auth/not-found responses are not retried
+  - transient errors still retry
+  - cache fallback when nothing responds, plus the staleness warning
+"""
+
+import json
+import logging
+import os
+import sys
+import threading
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import requests
+
+from core.plex_api import (
+    PlexManager,
+    RSS_MAX_RETRIES,
+    RSS_CACHE_STALE_HOURS,
+    _derive_rss_fallback_url,
+    _should_send_plex_token,
+)
+
+
+FEED_ID = "e9744518-296d-4bce-9856-2a8550631974"
+PRIMARY_URL = f"https://rss.plex.tv/{FEED_ID}"
+FALLBACK_URL = f"https://discover.provider.plex.tv/rss/{FEED_ID}"
+
+RSS_BODY = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Plex Watchlist</title>
+<item>
+  <title>The Menu (2022)</title><category>movie</category>
+  <pubDate>Mon, 27 Jul 2026 12:00:00 GMT</pubDate>
+  <author>4016660</author><guid>imdb://tt9764362</guid>
+</item>
+<item>
+  <title>Slow Horses (2022)</title><category>show</category>
+  <pubDate>Mon, 27 Jul 2026 13:00:00 GMT</pubDate>
+  <author>4016660</author><guid>tvdb://397785</guid>
+</item>
+</channel></rss>"""
+
+
+def _resp(status=200, text="", location=None):
+    """Build a mock requests.Response."""
+    r = MagicMock()
+    r.status_code = status
+    r.text = text
+    r.headers = {"Location": location} if location else {}
+    r.is_redirect = location is not None
+    r.is_permanent_redirect = False
+    if status >= 400:
+        err = requests.HTTPError(f"{status} Error")
+        err.response = MagicMock(status_code=status)
+        r.raise_for_status.side_effect = err
+    else:
+        r.raise_for_status.return_value = None
+    return r
+
+
+def _api(tmp_path=None, token="TOKEN123"):
+    api = PlexManager.__new__(PlexManager)
+    api.plex_token = token
+    api._rss_cache_file = str(tmp_path / "rss_cache.json") if tmp_path else None
+    api._token_lock = threading.Lock()
+    return api
+
+
+class TestDeriveFallbackUrl:
+    def test_legacy_url_maps_to_discover(self):
+        assert _derive_rss_fallback_url(PRIMARY_URL) == FALLBACK_URL
+
+    def test_trailing_slash_tolerated(self):
+        assert _derive_rss_fallback_url(PRIMARY_URL + "/") == FALLBACK_URL
+
+    def test_already_migrated_url_not_rewritten(self):
+        assert _derive_rss_fallback_url(FALLBACK_URL) is None
+
+    def test_third_party_url_not_rewritten(self):
+        assert _derive_rss_fallback_url("https://evil.example.com/rss/" + FEED_ID) is None
+
+    def test_bare_host_has_no_feed_id(self):
+        assert _derive_rss_fallback_url("https://rss.plex.tv/") is None
+
+    def test_multi_segment_path_rejected(self):
+        assert _derive_rss_fallback_url("https://rss.plex.tv/a/b") is None
+
+
+class TestTokenScoping:
+    @pytest.mark.parametrize("url", [
+        PRIMARY_URL,
+        FALLBACK_URL,
+        "https://plex.tv/api/v2/user",
+        "https://abc.plex.direct:32400/library",
+    ])
+    def test_plex_hosts_get_token(self, url):
+        assert _should_send_plex_token(url) is True
+
+    @pytest.mark.parametrize("url", [
+        "https://evil.example.com/rss/x",
+        "https://notplex.tv/feed",
+        "https://plex.tv.evil.com/feed",
+        "https://plex-rss-feeds.s3.us-east-1.amazonaws.com/e/x.xml",
+    ])
+    def test_other_hosts_do_not(self, url):
+        assert _should_send_plex_token(url) is False
+
+
+class TestFetchOrdering:
+    def test_primary_success_skips_fallback(self, tmp_path):
+        api = _api(tmp_path)
+        with patch("core.plex_api.requests.get", return_value=_resp(200, RSS_BODY)) as g:
+            items = api._fetch_rss_titles(PRIMARY_URL)
+        assert len(items) == 2
+        assert g.call_count == 1
+        assert g.call_args_list[0][0][0] == PRIMARY_URL
+
+    def test_primary_404_falls_back(self, tmp_path):
+        api = _api(tmp_path)
+        with patch("core.plex_api.requests.get",
+                   side_effect=[_resp(404), _resp(200, RSS_BODY)]) as g:
+            items = api._fetch_rss_titles(PRIMARY_URL)
+        assert len(items) == 2
+        assert [c[0][0] for c in g.call_args_list] == [PRIMARY_URL, FALLBACK_URL]
+
+    def test_primary_401_falls_back(self, tmp_path):
+        api = _api(tmp_path)
+        with patch("core.plex_api.requests.get",
+                   side_effect=[_resp(401), _resp(200, RSS_BODY)]) as g:
+            items = api._fetch_rss_titles(PRIMARY_URL)
+        assert len(items) == 2
+        assert g.call_count == 2
+
+    def test_auth_failures_are_not_retried(self, tmp_path):
+        """401/404 are deterministic - one attempt each, not RSS_MAX_RETRIES."""
+        api = _api(tmp_path)
+        with patch("core.plex_api.requests.get", return_value=_resp(404)) as g:
+            with patch("core.plex_api.time.sleep") as slept:
+                api._fetch_rss_titles(PRIMARY_URL)
+        assert g.call_count == 2  # one primary, one fallback
+        slept.assert_not_called()
+
+    def test_non_plex_url_has_no_fallback(self, tmp_path):
+        api = _api(tmp_path)
+        custom = "https://example.com/my-feed.xml"
+        with patch("core.plex_api.requests.get", return_value=_resp(404)) as g:
+            items = api._fetch_rss_titles(custom)
+        assert items == []
+        assert g.call_count == 1  # nothing to fall back to
+
+    def test_transient_error_still_retries(self, tmp_path):
+        api = _api(tmp_path)
+        with patch("core.plex_api.requests.get",
+                   side_effect=[requests.ConnectionError("boom"), _resp(200, RSS_BODY)]) as g:
+            with patch("core.plex_api.time.sleep"):
+                items = api._fetch_rss_titles(PRIMARY_URL)
+        assert len(items) == 2
+        assert g.call_count == 2
+        assert all(c[0][0] == PRIMARY_URL for c in g.call_args_list)
+
+    def test_persistent_network_error_exhausts_then_falls_back(self, tmp_path):
+        api = _api(tmp_path)
+        calls = [requests.ConnectionError("boom")] * RSS_MAX_RETRIES + [_resp(200, RSS_BODY)]
+        with patch("core.plex_api.requests.get", side_effect=calls) as g:
+            with patch("core.plex_api.time.sleep"):
+                items = api._fetch_rss_titles(PRIMARY_URL)
+        assert len(items) == 2
+        assert g.call_args_list[-1][0][0] == FALLBACK_URL
+
+
+class TestRedirectHandling:
+    def test_token_sent_to_plex_but_not_to_storage_host(self, tmp_path):
+        api = _api(tmp_path)
+        s3 = "https://plex-rss-feeds.s3.us-east-1.amazonaws.com/e/x.xml?sig=abc"
+        with patch("core.plex_api.requests.get",
+                   side_effect=[_resp(302, location=s3), _resp(200, RSS_BODY)]) as g:
+            items = api._fetch_rss_titles(FALLBACK_URL)
+
+        assert len(items) == 2
+        plex_call, s3_call = g.call_args_list
+        assert plex_call[1]["headers"].get("X-Plex-Token") == "TOKEN123"
+        assert s3_call[0][0] == s3
+        # The presigned URL carries its own auth - our token must not ride along.
+        assert "headers" not in s3_call[1] or not s3_call[1].get("headers")
+
+    def test_no_token_configured_sends_no_header(self, tmp_path):
+        api = _api(tmp_path, token="")
+        with patch("core.plex_api.requests.get", return_value=_resp(200, RSS_BODY)) as g:
+            api._fetch_rss_titles(PRIMARY_URL)
+        assert g.call_args_list[0][1]["headers"] == {}
+
+
+class TestCacheFallback:
+    def _seed_cache(self, path, age_hours):
+        ts = (datetime.now() - timedelta(hours=age_hours)).isoformat()
+        path.write_text(json.dumps({
+            "timestamp": ts,
+            "url": PRIMARY_URL,
+            "items": [["Cached Movie", "movie", None, "123", "imdb://tt1"]],
+        }), encoding="utf-8")
+
+    def test_both_urls_fail_uses_cache(self, tmp_path):
+        api = _api(tmp_path)
+        self._seed_cache(tmp_path / "rss_cache.json", age_hours=2)
+        with patch("core.plex_api.requests.get", return_value=_resp(404)):
+            items = api._fetch_rss_titles(PRIMARY_URL)
+        assert len(items) == 1
+        assert items[0][0] == "Cached Movie"
+
+    def test_fresh_cache_does_not_warn(self, tmp_path, caplog):
+        api = _api(tmp_path)
+        self._seed_cache(tmp_path / "rss_cache.json", age_hours=2)
+        with patch("core.plex_api.requests.get", return_value=_resp(404)):
+            with caplog.at_level(logging.WARNING):
+                api._fetch_rss_titles(PRIMARY_URL)
+        assert not [r for r in caplog.records if "hours old" in r.message]
+
+    def test_stale_cache_warns(self, tmp_path, caplog):
+        api = _api(tmp_path)
+        self._seed_cache(tmp_path / "rss_cache.json", age_hours=RSS_CACHE_STALE_HOURS + 5)
+        with patch("core.plex_api.requests.get", return_value=_resp(404)):
+            with caplog.at_level(logging.WARNING):
+                items = api._fetch_rss_titles(PRIMARY_URL)
+        # Stale data is still returned - losing every remote item would be worse.
+        assert len(items) == 1
+        assert any("hours old" in r.message for r in caplog.records)
+
+    def test_no_cache_returns_empty(self, tmp_path):
+        api = _api(tmp_path)
+        with patch("core.plex_api.requests.get", return_value=_resp(404)):
+            assert api._fetch_rss_titles(PRIMARY_URL) == []
+
+    def test_cache_keyed_to_configured_url_after_fallback(self, tmp_path):
+        """Cache records the user's URL, not the mirror, so it stays correct
+        if Plex restores the primary host."""
+        api = _api(tmp_path)
+        with patch("core.plex_api.requests.get",
+                   side_effect=[_resp(404), _resp(200, RSS_BODY)]):
+            api._fetch_rss_titles(PRIMARY_URL)
+        saved = json.loads((tmp_path / "rss_cache.json").read_text(encoding="utf-8"))
+        assert saved["url"] == PRIMARY_URL
+        assert len(saved["items"]) == 2


### PR DESCRIPTION
### What's happening

Plex serves watchlist RSS from `rss.plex.tv/<uuid>`. On 28 Jul 2026 that host started rejecting requests. My own instance went from clean fetches to failures inside a four hour window:

| Run | Result |
|---|---|
| Jul 25 00:30 → Jul 28 08:30 | `RSS feed contains 50 items`, no errors |
| Jul 28 12:30 onward | 3× 401, then cached data |

What it returns now:

```
no token     -> 401  <Error error="Unauthorized" message="You must provide a token!" .../>
with token   -> 404  <Error error="Not Found" .../>
```

The 404 applies to every feed id, including invented ones, so it isn't specific to one account's feed. Everything else on the same token keeps working in the same run: user tokens load, OnDeck runs, and API based watchlists fetch normally.

The same feed is still reachable at `discover.provider.plex.tv/rss/<uuid>`, which redirects to a presigned copy of the identical document. I confirmed it is the same feed rather than a coincidence:

- changing one character of the feed id returns 404, as does an invented id, so it is a keyed lookup and not a generic route
- the redirect target is `plex-rss-feeds.s3.../e/<feed-id>.xml`
- the response diffed against a locally cached copy taken from `rss.plex.tv` earlier the same morning: 50 items, 50 identical titles, no differences

### What this PR does

Plex's settings page still generates `rss.plex.tv` URLs, so the configured URL stays primary and the other endpoint is only tried when Plex refuses it. If the primary host starts working again, runs go back to it with no config change and nothing to undo. The cache entry is keyed to the configured URL for the same reason.

Also in `_fetch_rss_titles`:

- Sends `X-Plex-Token`, scoped to Plex hosts. `remote_watchlist_rss_url` is user supplied, so this keeps the token from being attached to an arbitrary domain. The redirect to storage is followed as a separate request without it, since the presigned URL carries its own credentials.
- Stops retrying 401/403/404. Those answers are deterministic, so three attempts with backoff only delayed the fallback. Transient network errors still retry as before.
- Logs the fallback at INFO and per attempt detail at DEBUG, so a fetch that recovers no longer reports as an error.

`_load_rss_cache()` returned cached items at any age. It still returns them, since losing every remote watchlist item would be worse, but past `RSS_CACHE_STALE_HOURS` (24h) it now warns that the feed has been unreachable and remote changes are not being picked up. This is what makes a prolonged outage visible rather than quietly serving old data.

At normal verbosity the whole thing is one line:

```
INFO - RSS: primary feed URL unavailable, served from Plex's discover endpoint instead
```

### Scope

Affects any install with `remote_watchlist_rss_url` set. Installs that don't use remote watchlists are unaffected. No settings changes are required and no template or UI changes are included, since the URL Plex hands out is still the one to paste in.

### Testing

28 new tests in `tests/test_plex_rss_fallback.py` covering URL derivation, token scoping, primary first ordering, no retry on auth failures, retained retries for transient errors, redirect handling, and the cache paths. Full suite passes.

To verify manually:

1. With a remote watchlist RSS URL configured, run a cache operation and check the log. Remote watchlist items should be found, with the single INFO line above and no ERROR lines.
2. Run with `--verbose` to see the ordering: primary attempted first, one 404, no retry, then the fallback.
3. Point `remote_watchlist_rss_url` at a non Plex URL that 404s and confirm no fallback is attempted and no token is sent.
4. Set the feed URL to something unreachable and confirm cached data is still used, with the staleness warning once the cache is over 24h old.
