### PR TITLE
CI: publish the :dev image from main pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
 
   build-and-push:
     needs: test
-    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
+    if: github.event_name == 'release' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -78,8 +78,8 @@ jobs:
             ${{ vars.DOCKERHUB_ENABLED == 'true' && format('{0}/plexcache-d', secrets.DOCKERHUB_USERNAME) || '' }}
             ghcr.io/${{ github.repository_owner }}/plexcache-d
           tags: |
-            # dev tag for dev branch pushes (rolling test channel)
-            type=raw,value=dev,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
+            # dev tag for main/dev pushes (rolling test channel, tracks merged work)
+            type=raw,value=dev,enable=${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
             # semver tags from the published release's tag (v3.2.0 -> 3.2.0, 3.2, 3)
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
### Why

The publish job currently gates on a push to `dev`:

```yaml
if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/dev')
```

There's no `dev` branch in this repo, so that half never fires and a published release is the only thing that produces an image. Merges to `main` run the test job and stop there.

The practical effect: every published tag currently points at the same build.

```
latest -> sha256:48266af1372f7c36db95574536c8c6a821d8d0c2fc536e124c3c7e4d3cebccc9
3.2.0  -> sha256:48266af1...
3.2    -> sha256:48266af1...
3      -> sha256:48266af1...
```

So there's nothing for a user to pull when a fix is merged, and no way to confirm a fix works before it goes into a release. This came up on #197, where the reporter asked how to test the merged fix and Unraid correctly showed no update available.

### What this does

Adds `main` alongside `dev` on the job condition and on the `:dev` tag rule, so every merge publishes a rolling `ghcr.io/<owner>/plexcache-d:dev`.

Release behaviour is untouched. Semver tags and `:latest` stay release-only, so a merge to `main` cannot move the stable tag:

| Event | Publishes |
|---|---|
| merge to `main` | `:dev` |
| push to `dev` | `:dev` (unchanged) |
| full release | semver + `:latest` (unchanged) |
| prerelease | semver only (unchanged) |
| PR, or push to `v3.0` | nothing (unchanged) |

Keeping the `dev` condition means nothing breaks if you create that branch later and want to move the rolling channel onto it.

Two lines, and reverting is just removing `main` from the two conditions.

### Testing

After merge, the merge commit itself is a push to `main`, so the workflow should run and publish `:dev`. To confirm:

1. Check the Actions run for the merge completes both `test` and `build-and-push`.
2. `docker pull ghcr.io/studionirin/plexcache-d:dev`
3. Confirm the `:dev` digest differs from `:latest`, and that `:latest` still resolves to the 3.2.0 build.

If you'd rather the rolling channel live on an actual `dev` branch instead, happy to redo it that way — this was the smaller change of the two.
