### PR TITLE
CI: publish Docker v2 manifests and cancel superseded builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,14 @@ on:
   release:
     types: [published]
 
+# Two merges landing seconds apart each start a build, and whichever finishes
+# last wins the :dev tag — which can leave it pointing at the older commit.
+# Superseding runs on the same ref cancels the stale one so :dev always tracks
+# the newest push. Releases are keyed by their own ref and aren't affected.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -104,8 +112,13 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          push: true
           provenance: false
+          sbom: false
+          # Publish Docker v2 manifests rather than OCI. Unraid's update check
+          # requests only Docker media types, so an OCI-only manifest returns 404
+          # and the container reports "not available" instead of an update status.
+          # provenance: false alone isn't enough — buildx still emits OCI types.
+          outputs: type=image,oci-mediatypes=false,push=true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Two follow-ups to #200, both found while bringing the rolling `:dev` channel online. Worth having before a release goes out — see the note under the first one.

### 1. Publish Docker v2 manifests

Images are pushed with OCI media types. Unraid's update check requests only Docker media types, so the registry returns 404 for the manifest and the container reports **"not available"** instead of an update status.

Verified against the registry with Docker-only Accept headers:

```
studionirin/plexcache-d:dev     -> 404   application/vnd.oci.image.manifest.v1+json
studionirin/plexcache-d:latest  -> 200   application/vnd.docker.distribution.manifest.v2+json
```

That's why `:latest` shows an update status today and the new `:dev` tag doesn't — `:latest` predates whatever buildx change started emitting OCI.

This is a known Unraid issue rather than anything specific to this project. There's a stable-release bug report titled *"[7.0.0] Docker Version not available for containers with application/vnd.oci.image.manifest.v1+json manifest"*, plus several forum threads about ghcr.io images showing "not available".

`provenance: false` was already set and isn't enough on its own, so this also sets `sbom: false` and `oci-mediatypes=false` through the image exporter, which puts buildx back on a plain Docker v2 manifest.

**Scope:** pulling was never affected — Docker has handled OCI manifests for years, so `docker pull` and force-update work either way. This only changes what the *update check* can read. The reason it's worth doing before a release: a user whose update status reads "not available" is never told a new version exists, so they stay on the old image indefinitely.

### 2. Cancel superseded builds

#199 and #200 merged 13 seconds apart. Both started a build:

```
3e7bf29  (#199)  started 02:51:24   finished 02:52:50
3e776fe  (#200)  started 02:51:11   finished 02:52:52   <- 2s later
```

The older commit's build finished last, so it won the `:dev` tag and left it pointing at a commit that was missing the newer merge. I corrected that by re-running the newer build, but nothing prevented a repeat.

A concurrency group keyed on the ref cancels the superseded run so `:dev` always tracks the newest push. Release builds use their own ref and aren't affected.

### Not changed

Which events publish, and which tags they produce. The job condition and all the `type=` tag rules are untouched — `:latest` and semver stay release-only, `:dev` stays on `main`/`dev` pushes.

### Testing

`sbom: false` and `outputs: type=image,oci-mediatypes=false,push=true` are running on my fork already. After the change, `:dev` returns 200 to Docker-only Accept headers where it previously 404'd:

```
before:  dev -> HTTP 404   application/vnd.oci.image.manifest.v1+json
after:   dev -> HTTP 200   application/vnd.docker.distribution.manifest.v2+json
```

To confirm after merge:

1. The merge commit's run publishes `:dev` as normal.
2. `docker manifest inspect ghcr.io/studionirin/plexcache-d:dev` succeeds.
3. On an Unraid box, a container on `:dev` shows a real update status rather than "not available".

Note only newly built tags are corrected — existing tags keep whatever format they were pushed with.
