### PR TITLE
Remove empty folders left behind by cache eviction

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -26,7 +26,7 @@ except ImportError:
 from core import __version__
 from core.config import ConfigManager
 from core.logging_config import LoggingManager, reset_warning_error_flag
-from core.system_utils import SystemDetector, FileUtils, SingleInstanceLock, get_disk_usage, get_array_direct_path, detect_zfs, set_zfs_prefixes, format_bytes, create_dir_with_ownership
+from core.system_utils import SystemDetector, FileUtils, SingleInstanceLock, get_disk_usage, get_array_direct_path, detect_zfs, set_zfs_prefixes, format_bytes, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary
 from core.plex_api import PlexManager, OnDeckItem
 from core.file_operations import MultiPathModifier, SiblingFileFinder, FileFilter, FileMover, PlexcachedRestorer, CacheTimestampTracker, WatchlistTracker, OnDeckTracker, CachePriorityManager, PlexcachedMigration, get_media_identity, find_matching_plexcached, is_directory_level_file
 from core.pinned_media import PinnedMediaTracker, resolve_pins_to_paths
@@ -2758,6 +2758,9 @@ class PlexCacheApp:
                         continue
                     os.remove(cache_path)
                     logging.debug(f"Deleted cache file: {os.path.basename(cache_path)}")
+                    # Remove folders this eviction emptied (issue #196) — the
+                    # same policy _move_to_array() follows.
+                    self._cleanup_empty_folders_for(cache_path)
                 else:
                     logging.debug(f"Cache file already gone: {os.path.basename(cache_path)}")
 
@@ -2775,6 +2778,29 @@ class PlexCacheApp:
 
         logging.info(f"[EVICTION] Smart eviction complete: freed {bytes_freed/1e9:.2f}GB from {files_evicted} files")
         return (files_evicted, bytes_freed)
+
+    def _cleanup_empty_folders_for(self, cache_path: str) -> int:
+        """Remove folders left empty by removing `cache_path` from cache.
+
+        Honours the `cleanup_empty_folders` setting. The boundary comes from the
+        owning path mapping, so a file on a secondary pool is bounded by its own
+        mapping rather than the primary cache_dir.
+        """
+        if not self.config_manager.cache.cleanup_empty_folders:
+            return 0
+
+        mappings = [
+            {'cache_path': m.cache_path, 'enabled': getattr(m, 'enabled', True)}
+            for m in (self.config_manager.paths.path_mappings or [])
+        ]
+        boundary = resolve_cache_boundary(
+            cache_path, mappings, self.config_manager.paths.cache_dir
+        )
+        if not boundary:
+            logging.debug(f"No cache boundary for {cache_path}, skipping folder cleanup")
+            return 0
+
+        return cleanup_empty_parent_folders(cache_path, boundary)
 
     def _get_fifo_eviction_candidates(self, cached_files: List[str], target_bytes: int) -> List[str]:
         """Get files to evict using FIFO (oldest first) strategy.

--- a/core/app.py
+++ b/core/app.py
@@ -3,6 +3,7 @@ Main PlexCache application.
 Orchestrates all components and provides the main business logic.
 """
 
+import json
 import signal
 import sys
 import threading
@@ -26,14 +27,18 @@ except ImportError:
 from core import __version__
 from core.config import ConfigManager
 from core.logging_config import LoggingManager, reset_warning_error_flag
-from core.system_utils import SystemDetector, FileUtils, SingleInstanceLock, get_disk_usage, get_array_direct_path, detect_zfs, set_zfs_prefixes, format_bytes, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary
+from core.system_utils import SystemDetector, FileUtils, SingleInstanceLock, get_disk_usage, get_array_direct_path, detect_zfs, set_zfs_prefixes, format_bytes, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary, sweep_empty_folders
 from core.plex_api import PlexManager, OnDeckItem
-from core.file_operations import MultiPathModifier, SiblingFileFinder, FileFilter, FileMover, PlexcachedRestorer, CacheTimestampTracker, WatchlistTracker, OnDeckTracker, CachePriorityManager, PlexcachedMigration, get_media_identity, find_matching_plexcached, is_directory_level_file
+from core.file_operations import MultiPathModifier, SiblingFileFinder, FileFilter, FileMover, PlexcachedRestorer, CacheTimestampTracker, WatchlistTracker, OnDeckTracker, CachePriorityManager, PlexcachedMigration, get_media_identity, find_matching_plexcached, is_directory_level_file, save_json_atomically
 from core.pinned_media import PinnedMediaTracker, resolve_pins_to_paths
 
 
 class PlexCacheApp:
     """Main PlexCache application class."""
+
+    # One-time data migrations, keyed by name in data/migrations.json.
+    _MIGRATIONS_FILENAME = "migrations.json"
+    _EMPTY_FOLDER_BACKFILL_KEY = "empty_folder_backfill"  # issue #196
 
     def __init__(self, config_file: str, dry_run: bool = False,
                  quiet: bool = False, verbose: bool = False,
@@ -213,6 +218,9 @@ class PlexCacheApp:
             # Initialize components that depend on config
             logging.debug("Initializing components...")
             self._initialize_components()
+
+            # One-time sweep for folders emptied by pre-fix evictions (issue #196)
+            self._backfill_empty_folder_cleanup()
 
             # Warn if .plexcached backups are disabled
             if not self.config_manager.cache.create_plexcached_backups:
@@ -2778,6 +2786,64 @@ class PlexCacheApp:
 
         logging.info(f"[EVICTION] Smart eviction complete: freed {bytes_freed/1e9:.2f}GB from {files_evicted} files")
         return (files_evicted, bytes_freed)
+
+    def _backfill_empty_folder_cleanup(self) -> None:
+        """One-time sweep for empty folders left by pre-fix evictions (issue #196).
+
+        Eviction used to delete the cache file without removing the folders it
+        emptied, so installs upgrading from an earlier version carry a backlog
+        that the per-file cleanup can never reach — it only ever sees folders it
+        empties itself. Sweep the cache trees once, record a marker, never again.
+
+        Skipped on dry runs and when `cleanup_empty_folders` is off. Failures are
+        non-fatal: this is housekeeping, not part of the caching contract.
+        """
+        if self.dry_run:
+            return
+        if not self.config_manager.cache.cleanup_empty_folders:
+            return
+
+        migrations_file = self.config_manager.get_data_folder() / self._MIGRATIONS_FILENAME
+        migrations = {}
+        try:
+            if migrations_file.exists():
+                with open(migrations_file, 'r', encoding='utf-8') as f:
+                    migrations = json.load(f)
+        except (IOError, json.JSONDecodeError) as e:
+            logging.debug(f"Could not read migrations file, treating as unmigrated: {e}")
+
+        if migrations.get(self._EMPTY_FOLDER_BACKFILL_KEY):
+            return
+
+        cache_dirs = [
+            m.cache_path.rstrip('/\\')
+            for m in (self.config_manager.paths.path_mappings or [])
+            if m.enabled and m.cacheable and m.cache_path
+        ]
+        if not cache_dirs and self.config_manager.paths.cache_dir:
+            cache_dirs = [self.config_manager.paths.cache_dir.rstrip('/\\')]
+
+        excluded = set(self.config_manager.cache.excluded_folders or [])
+
+        try:
+            removed = sweep_empty_folders(cache_dirs, lambda name: name in excluded)
+        except OSError as e:
+            logging.warning(f"Empty-folder backfill failed (non-fatal): {e}")
+            return
+
+        if removed:
+            logging.info(f"[CLEANUP] Removed {removed} empty folder(s) left by earlier evictions")
+        else:
+            logging.debug("Empty-folder backfill found nothing to remove")
+
+        # Record the marker even when nothing was removed — the backlog is
+        # cleared either way, and a clean install shouldn't re-sweep every run.
+        migrations[self._EMPTY_FOLDER_BACKFILL_KEY] = datetime.now().isoformat()
+        try:
+            migrations_file.parent.mkdir(parents=True, exist_ok=True)
+            save_json_atomically(str(migrations_file), migrations, label="migrations")
+        except (IOError, OSError) as e:
+            logging.warning(f"Could not record empty-folder backfill marker: {e}")
 
     def _cleanup_empty_folders_for(self, cache_path: str) -> int:
         """Remove folders left empty by removing `cache_path` from cache.

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -16,7 +16,7 @@ from typing import List, Set, Optional, Tuple, Dict, TYPE_CHECKING, Callable
 import re
 
 from core.logging_config import get_console_lock
-from core.system_utils import resolve_user0_to_disk, get_disk_free_space_bytes, get_disk_number_from_path, get_array_direct_path, format_bytes, create_dir_with_ownership
+from core.system_utils import resolve_user0_to_disk, get_disk_free_space_bytes, get_disk_number_from_path, get_array_direct_path, format_bytes, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary
 
 if TYPE_CHECKING:
     from core.config import PathMapping
@@ -5562,10 +5562,10 @@ class FileMover:
     def _cleanup_empty_parent_folders(self, file_path: str) -> int:
         """Clean up empty parent folders after a file is removed.
 
-        Implements the File and Folder Management Policy: PlexCache only removes
-        folders that it emptied by moving files out. This method walks up the
-        directory tree from the deleted file's parent, removing empty folders
-        until it hits the cache_dir boundary or a non-empty folder.
+        Thin wrapper over the canonical `cleanup_empty_parent_folders()`. The
+        boundary is the mapping's cache_path when one covers this file, so
+        multi-pool setups (`/mnt/cache` plus `/mnt/ssd_cache`) clean up
+        correctly instead of no-opping on everything outside `self.cache_dir`.
 
         Args:
             file_path: Path to the file that was just deleted
@@ -5573,44 +5573,18 @@ class FileMover:
         Returns:
             Number of folders removed
         """
-        folders_removed = 0
-        current_dir = os.path.dirname(file_path)
+        # Legacy FilePathModifier has no `mappings`, so fall back to cache_dir.
+        mappings = [
+            {'cache_path': m.cache_path, 'enabled': getattr(m, 'enabled', True)}
+            for m in (getattr(self.path_modifier, 'mappings', None) or [])
+        ]
+        boundary = resolve_cache_boundary(file_path, mappings, self.cache_dir)
 
-        # Normalize paths for comparison
-        cache_boundary = os.path.normpath(self.cache_dir)
+        if not boundary:
+            logging.debug(f"No cache boundary for {file_path}, skipping folder cleanup")
+            return 0
 
-        while current_dir:
-            normalized_current = os.path.normpath(current_dir)
-
-            # Stop if we've reached or passed the cache boundary
-            # We should never delete the cache_dir itself or anything above it
-            if normalized_current == cache_boundary or not normalized_current.startswith(cache_boundary):
-                break
-
-            try:
-                # Check if directory is empty
-                if not os.path.exists(current_dir):
-                    break
-
-                contents = os.listdir(current_dir)
-                if contents:
-                    # Folder not empty, stop climbing
-                    logging.debug(f"Folder not empty, stopping cleanup: {current_dir}")
-                    break
-
-                # Folder is empty, remove it
-                os.rmdir(current_dir)
-                logging.debug(f"Removed empty folder (PlexCache cleanup): {current_dir}")
-                folders_removed += 1
-
-                # Move up to parent
-                current_dir = os.path.dirname(current_dir)
-
-            except OSError as e:
-                logging.debug(f"Could not remove folder {current_dir}: {type(e).__name__}: {e}")
-                break
-
-        return folders_removed
+        return cleanup_empty_parent_folders(file_path, boundary)
 
     def _create_symlink(self, symlink_path: str, target_path: str) -> bool:
         """Create a symlink at symlink_path pointing to target_path.

--- a/core/system_utils.py
+++ b/core/system_utils.py
@@ -506,6 +506,55 @@ def cleanup_empty_parent_folders(file_path: str, boundary_dir: str) -> int:
     return folders_removed
 
 
+def sweep_empty_folders(cache_dirs: List[str],
+                        should_skip_dir: Optional[Callable[[str], bool]] = None) -> int:
+    """Remove every empty folder under `cache_dirs`.
+
+    The canonical full sweep — use it instead of writing another os.walk/rmdir
+    pass. Unlike `cleanup_empty_parent_folders()`, which walks up from one
+    removed file, this scans whole trees. That makes it the tool for clearing a
+    historical backlog, not for per-file cleanup during a run.
+
+    The `cache_dirs` roots are never removed: os.walk only ever yields them as
+    `root`, never inside a `dirs` list.
+
+    Args:
+        cache_dirs: Cache roots to scan (typically enabled mapping cache_paths).
+        should_skip_dir: Optional predicate taking a bare directory *name*.
+            Return True to leave it alone. Dot-directories (.Trash,
+            .Recycle.Bin) are always skipped regardless.
+
+    Returns:
+        Number of folders removed.
+    """
+    removed = 0
+
+    for cache_dir in cache_dirs or []:
+        if not cache_dir or not os.path.exists(cache_dir):
+            continue
+
+        # topdown=False so children are visited before parents — a folder whose
+        # only contents were empty folders becomes empty in the same pass.
+        for root, dirs, _files in os.walk(cache_dir, topdown=False):
+            for name in dirs:
+                if name.startswith('.'):
+                    continue
+                if should_skip_dir and should_skip_dir(name):
+                    continue
+
+                dir_path = os.path.join(root, name)
+                try:
+                    if os.listdir(dir_path):
+                        continue
+                    os.rmdir(dir_path)
+                    logging.debug(f"Removed empty folder (PlexCache sweep): {dir_path}")
+                    removed += 1
+                except OSError as e:
+                    logging.debug(f"Could not remove folder {dir_path}: {type(e).__name__}: {e}")
+
+    return removed
+
+
 def resolve_cache_boundary(cache_path: str, path_mappings: list, fallback_dir: str = "") -> Optional[str]:
     """Find the cache root that `cache_path` lives under.
 

--- a/core/system_utils.py
+++ b/core/system_utils.py
@@ -448,6 +448,110 @@ def remove_from_timestamps_file(timestamps_file_path, cache_path: str) -> None:
         logging.warning(f"Could not update timestamps file: {e}")
 
 
+def cleanup_empty_parent_folders(file_path: str, boundary_dir: str) -> int:
+    """Remove folders left empty after a file was moved or deleted.
+
+    This is the canonical implementation — use it everywhere instead of writing
+    another rmdir walk. Implements the File and Folder Management Policy:
+    PlexCache only removes folders it emptied itself, walking up from the
+    removed file's parent and stopping at the first non-empty folder or at
+    `boundary_dir`.
+
+    Args:
+        file_path: Path to the file that was just removed. It does not need to
+            still exist — only its parent chain is inspected.
+        boundary_dir: Directory to stop at (typically the cache root or the
+            mapping's cache_path). Never removed, and nothing above it is
+            touched. A `file_path` outside this boundary is a no-op.
+
+    Returns:
+        Number of folders removed.
+    """
+    if not file_path or not boundary_dir:
+        return 0
+
+    folders_removed = 0
+    current_dir = os.path.dirname(file_path)
+    boundary = os.path.normpath(boundary_dir)
+
+    while current_dir:
+        normalized_current = os.path.normpath(current_dir)
+
+        # Never remove the boundary itself, and never climb above it. The
+        # separator guard stops "/mnt/cache_downloads" from being treated as
+        # living inside "/mnt/cache".
+        if normalized_current == boundary:
+            break
+        if not normalized_current.startswith(boundary.rstrip(os.sep) + os.sep):
+            break
+
+        try:
+            if not os.path.exists(current_dir):
+                break
+
+            if os.listdir(current_dir):
+                logging.debug(f"Folder not empty, stopping cleanup: {current_dir}")
+                break
+
+            os.rmdir(current_dir)
+            logging.debug(f"Removed empty folder (PlexCache cleanup): {current_dir}")
+            folders_removed += 1
+
+            current_dir = os.path.dirname(current_dir)
+
+        except OSError as e:
+            logging.debug(f"Could not remove folder {current_dir}: {type(e).__name__}: {e}")
+            break
+
+    return folders_removed
+
+
+def resolve_cache_boundary(cache_path: str, path_mappings: list, fallback_dir: str = "") -> Optional[str]:
+    """Find the cache root that `cache_path` lives under.
+
+    Empty-folder cleanup must never climb past the cache root it started in, and
+    multi-path setups can spread mappings across separate pools (`/mnt/cache`,
+    `/mnt/ssd_cache`, ...), so a single global cache_dir is not a safe boundary
+    for every file.
+
+    Args:
+        cache_path: The cache file whose boundary is being resolved.
+        path_mappings: Settings path_mappings list (dicts with `cache_path`).
+        fallback_dir: Legacy single cache_dir, used when no mapping matches.
+
+    Returns:
+        The longest matching enabled mapping cache_path, else `fallback_dir` if
+        it contains the file, else None (caller should skip cleanup).
+    """
+    if not cache_path:
+        return None
+
+    normalized = os.path.normpath(cache_path)
+    best = None
+
+    for mapping in path_mappings or []:
+        if not mapping.get('enabled', True):
+            continue
+        prefix = (mapping.get('cache_path') or '').rstrip('/\\')
+        if not prefix:
+            continue
+        normalized_prefix = os.path.normpath(prefix)
+        if normalized.startswith(normalized_prefix.rstrip(os.sep) + os.sep):
+            # Longest match wins so nested mappings pick the deepest root.
+            if best is None or len(normalized_prefix) > len(best):
+                best = normalized_prefix
+
+    if best:
+        return best
+
+    if fallback_dir:
+        normalized_fallback = os.path.normpath(fallback_dir)
+        if normalized.startswith(normalized_fallback.rstrip(os.sep) + os.sep):
+            return normalized_fallback
+
+    return None
+
+
 def get_disk_free_space_bytes(path: str) -> int:
     """Get free space in bytes for the filesystem containing the given path.
 

--- a/tests/test_empty_folder_backfill.py
+++ b/tests/test_empty_folder_backfill.py
@@ -1,0 +1,216 @@
+"""One-time backfill sweep for pre-fix empty folders (issue #196).
+
+Per-file cleanup only ever sees folders it empties itself, so installs upgrading
+from a version where eviction skipped cleanup carry a backlog it can never
+reach. `_backfill_empty_folder_cleanup()` sweeps the cache trees once, records a
+marker in data/migrations.json, and never runs again.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.app import PlexCacheApp
+from core.system_utils import sweep_empty_folders
+
+
+class _Mapping:
+    def __init__(self, cache_path, enabled=True, cacheable=True):
+        self.cache_path = str(cache_path)
+        self.enabled = enabled
+        self.cacheable = cacheable
+
+
+def _make_app(tmp_path, mappings, cleanup=True, excluded=None, dry_run=False):
+    """Build a PlexCacheApp shell with just the config the backfill reads."""
+    app = PlexCacheApp.__new__(PlexCacheApp)
+    app.dry_run = dry_run
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    config_manager = MagicMock()
+    config_manager.cache.cleanup_empty_folders = cleanup
+    config_manager.cache.excluded_folders = excluded or []
+    config_manager.paths.path_mappings = mappings
+    config_manager.paths.cache_dir = ""
+    config_manager.get_data_folder.return_value = data_dir
+    app.config_manager = config_manager
+
+    return app, data_dir
+
+
+def _stage_backlog(cache_root):
+    """Empty folders of the kind pre-fix eviction left behind."""
+    (cache_root / "Movies" / "Evicted (2020)").mkdir(parents=True)
+    (cache_root / "Movies" / "Also Evicted (2021)").mkdir(parents=True)
+    (cache_root / "TV Shows" / "Old Show" / "Season 01").mkdir(parents=True)
+
+    kept = cache_root / "Movies" / "Still Cached (2022)"
+    kept.mkdir(parents=True)
+    (kept / "Film.mkv").write_bytes(b"\0" * 16)
+    return kept
+
+
+@pytest.fixture
+def cache_root(tmp_path):
+    root = tmp_path / "cache"
+    root.mkdir()
+    return root
+
+
+class TestBackfillSweep:
+    def test_clears_backlog_and_keeps_populated_folders(self, tmp_path, cache_root):
+        kept = _stage_backlog(cache_root)
+        app, _ = _make_app(tmp_path, [_Mapping(cache_root)])
+
+        app._backfill_empty_folder_cleanup()
+
+        assert not (cache_root / "Movies" / "Evicted (2020)").exists()
+        assert not (cache_root / "Movies" / "Also Evicted (2021)").exists()
+        assert not (cache_root / "TV Shows").exists()
+        assert kept.exists()
+        assert (kept / "Film.mkv").exists()
+        assert cache_root.exists()
+
+    def test_writes_marker_after_running(self, tmp_path, cache_root):
+        _stage_backlog(cache_root)
+        app, data_dir = _make_app(tmp_path, [_Mapping(cache_root)])
+
+        app._backfill_empty_folder_cleanup()
+
+        marker = data_dir / "migrations.json"
+        assert marker.exists()
+        recorded = json.loads(marker.read_text(encoding="utf-8"))
+        assert recorded["empty_folder_backfill"]
+
+    def test_marker_written_even_when_nothing_removed(self, tmp_path, cache_root):
+        app, data_dir = _make_app(tmp_path, [_Mapping(cache_root)])
+
+        app._backfill_empty_folder_cleanup()
+
+        recorded = json.loads((data_dir / "migrations.json").read_text(encoding="utf-8"))
+        assert recorded["empty_folder_backfill"]
+
+    def test_does_not_run_twice(self, tmp_path, cache_root):
+        app, data_dir = _make_app(tmp_path, [_Mapping(cache_root)])
+        (data_dir / "migrations.json").write_text(
+            json.dumps({"empty_folder_backfill": "2026-08-01T00:00:00"}, indent=2),
+            encoding="utf-8",
+        )
+        stale = cache_root / "Movies" / "Left Alone (2020)"
+        stale.mkdir(parents=True)
+
+        app._backfill_empty_folder_cleanup()
+
+        assert stale.exists(), "already-migrated install must not re-sweep"
+
+    def test_skipped_on_dry_run(self, tmp_path, cache_root):
+        _stage_backlog(cache_root)
+        app, data_dir = _make_app(tmp_path, [_Mapping(cache_root)], dry_run=True)
+
+        app._backfill_empty_folder_cleanup()
+
+        assert (cache_root / "Movies" / "Evicted (2020)").exists()
+        assert not (data_dir / "migrations.json").exists()
+
+    def test_skipped_when_setting_disabled(self, tmp_path, cache_root):
+        _stage_backlog(cache_root)
+        app, data_dir = _make_app(tmp_path, [_Mapping(cache_root)], cleanup=False)
+
+        app._backfill_empty_folder_cleanup()
+
+        assert (cache_root / "Movies" / "Evicted (2020)").exists()
+        assert not (data_dir / "migrations.json").exists()
+
+    def test_disabled_and_non_cacheable_mappings_untouched(self, tmp_path, cache_root):
+        other = cache_root.parent / "other_pool"
+        (other / "Movies" / "Untouched").mkdir(parents=True)
+        _stage_backlog(cache_root)
+
+        app, _ = _make_app(tmp_path, [
+            _Mapping(cache_root),
+            _Mapping(other, enabled=False),
+        ])
+        app._backfill_empty_folder_cleanup()
+
+        assert (other / "Movies" / "Untouched").exists()
+        assert not (cache_root / "Movies" / "Evicted (2020)").exists()
+
+    def test_sweeps_every_enabled_pool(self, tmp_path, cache_root):
+        second = cache_root.parent / "ssd_cache"
+        (second / "Movies" / "Evicted (2019)").mkdir(parents=True)
+        _stage_backlog(cache_root)
+
+        app, _ = _make_app(tmp_path, [_Mapping(cache_root), _Mapping(second)])
+        app._backfill_empty_folder_cleanup()
+
+        assert not (second / "Movies" / "Evicted (2019)").exists()
+        assert not (cache_root / "Movies" / "Evicted (2020)").exists()
+
+    def test_logs_summary_line(self, tmp_path, cache_root, caplog):
+        import logging
+        _stage_backlog(cache_root)
+        app, _ = _make_app(tmp_path, [_Mapping(cache_root)])
+
+        with caplog.at_level(logging.INFO):
+            app._backfill_empty_folder_cleanup()
+
+        assert any("[CLEANUP] Removed" in rec.message for rec in caplog.records)
+
+    def test_excluded_folder_names_are_respected(self, tmp_path, cache_root):
+        (cache_root / "Movies" / "KeepMe").mkdir(parents=True)
+        app, _ = _make_app(tmp_path, [_Mapping(cache_root)], excluded=["KeepMe"])
+
+        app._backfill_empty_folder_cleanup()
+
+        assert (cache_root / "Movies" / "KeepMe").exists()
+
+
+class TestSweepEmptyFolders:
+    """Direct coverage for the shared sweep helper."""
+
+    def test_skips_hidden_directories(self, cache_root):
+        (cache_root / ".Trash").mkdir()
+        (cache_root / "Movies" / "Gone").mkdir(parents=True)
+
+        removed = sweep_empty_folders([str(cache_root)])
+
+        assert (cache_root / ".Trash").exists()
+        assert not (cache_root / "Movies" / "Gone").exists()
+        assert removed >= 1
+
+    def test_collapses_nested_empty_chain_in_one_pass(self, cache_root):
+        (cache_root / "TV" / "Show" / "Season 01").mkdir(parents=True)
+
+        removed = sweep_empty_folders([str(cache_root)])
+
+        assert removed == 3
+        assert not (cache_root / "TV").exists()
+
+    def test_never_removes_the_root(self, cache_root):
+        sweep_empty_folders([str(cache_root)])
+        assert cache_root.exists()
+
+    def test_missing_root_is_skipped(self, tmp_path):
+        assert sweep_empty_folders([str(tmp_path / "nope")]) == 0
+
+    def test_empty_input_is_safe(self):
+        assert sweep_empty_folders([]) == 0
+        assert sweep_empty_folders(None) == 0

--- a/tests/test_empty_folder_cleanup.py
+++ b/tests/test_empty_folder_cleanup.py
@@ -1,0 +1,182 @@
+"""Tests for empty-folder cleanup after cache files are removed (issue #196).
+
+Reported upstream: evicting files manually from the Cached Files page left the
+movie / show / season folders behind on the cache drive. Only the normal
+move-to-array path cleaned up; both eviction paths deleted the file and stopped.
+
+Covers the shared helpers in core.system_utils plus the boundary resolution that
+keeps a multi-pool setup (/mnt/cache + /mnt/ssd_cache) from being skipped.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.system_utils import cleanup_empty_parent_folders, resolve_cache_boundary
+
+
+@pytest.fixture
+def cache_root(tmp_path):
+    root = tmp_path / "cache"
+    root.mkdir()
+    return root
+
+
+class TestCleanupEmptyParentFolders:
+    """Walk up from a removed file, stopping at the boundary or a non-empty dir."""
+
+    def test_removes_single_empty_folder(self, cache_root):
+        movie_dir = cache_root / "Movies" / "Sonic the Hedgehog 3 (2024)"
+        movie_dir.mkdir(parents=True)
+        film = movie_dir / "Sonic.mkv"
+        film.write_text("x")
+        film.unlink()
+
+        removed = cleanup_empty_parent_folders(str(film), str(cache_root))
+
+        assert removed == 2  # the movie folder and the now-empty Movies folder
+        assert not movie_dir.exists()
+        assert cache_root.exists()
+
+    def test_climbs_multiple_empty_levels(self, cache_root):
+        season = cache_root / "TV Shows" / "Slow Horses" / "Season 01"
+        season.mkdir(parents=True)
+        ep = season / "S01E01.mkv"
+        ep.write_text("x")
+        ep.unlink()
+
+        removed = cleanup_empty_parent_folders(str(ep), str(cache_root))
+
+        assert removed == 3
+        assert not (cache_root / "TV Shows").exists()
+
+    def test_stops_at_non_empty_folder(self, cache_root):
+        season = cache_root / "TV Shows" / "Slow Horses" / "Season 01"
+        season.mkdir(parents=True)
+        gone = season / "S01E01.mkv"
+        gone.write_text("x")
+        keep = season / "S01E02.mkv"
+        keep.write_text("x")
+        gone.unlink()
+
+        removed = cleanup_empty_parent_folders(str(gone), str(cache_root))
+
+        assert removed == 0
+        assert season.exists()
+        assert keep.exists()
+
+    def test_stops_partway_up_when_sibling_remains(self, cache_root):
+        show = cache_root / "TV Shows" / "Slow Horses"
+        season1 = show / "Season 01"
+        season2 = show / "Season 02"
+        season1.mkdir(parents=True)
+        season2.mkdir(parents=True)
+        (season2 / "S02E01.mkv").write_text("x")
+        ep = season1 / "S01E01.mkv"
+        ep.write_text("x")
+        ep.unlink()
+
+        removed = cleanup_empty_parent_folders(str(ep), str(cache_root))
+
+        assert removed == 1  # Season 01 only — the show folder still has Season 02
+        assert not season1.exists()
+        assert show.exists()
+
+    def test_never_removes_the_boundary_itself(self, cache_root):
+        orphan = cache_root / "Movie.mkv"
+        orphan.write_text("x")
+        orphan.unlink()
+
+        removed = cleanup_empty_parent_folders(str(orphan), str(cache_root))
+
+        assert removed == 0
+        assert cache_root.exists()
+
+    def test_file_outside_boundary_is_a_noop(self, tmp_path):
+        outside = tmp_path / "elsewhere" / "Movies" / "Film"
+        outside.mkdir(parents=True)
+        f = outside / "Film.mkv"
+        f.write_text("x")
+        f.unlink()
+
+        removed = cleanup_empty_parent_folders(str(f), str(tmp_path / "cache"))
+
+        assert removed == 0
+        assert outside.exists()
+
+    def test_sibling_prefix_is_not_treated_as_inside(self, tmp_path):
+        """/mnt/cache_downloads must not count as living inside /mnt/cache."""
+        boundary = tmp_path / "cache"
+        boundary.mkdir()
+        lookalike = tmp_path / "cache_downloads" / "Movies"
+        lookalike.mkdir(parents=True)
+        f = lookalike / "Film.mkv"
+        f.write_text("x")
+        f.unlink()
+
+        removed = cleanup_empty_parent_folders(str(f), str(boundary))
+
+        assert removed == 0
+        assert lookalike.exists()
+
+    def test_missing_arguments_are_safe(self):
+        assert cleanup_empty_parent_folders("", "/mnt/cache") == 0
+        assert cleanup_empty_parent_folders("/mnt/cache/x.mkv", "") == 0
+
+
+class TestResolveCacheBoundary:
+    """Pick the cache root a file belongs to, across multi-pool setups."""
+
+    MAPPINGS = [
+        {"cache_path": "/mnt/cache/data/media", "enabled": True},
+        {"cache_path": "/mnt/ssd_cache/data/media", "enabled": True},
+        {"cache_path": "/mnt/old_cache/data", "enabled": False},
+    ]
+
+    def test_matches_the_owning_mapping(self):
+        boundary = resolve_cache_boundary(
+            "/mnt/ssd_cache/data/media/movies/Film (2020)/Film.mkv", self.MAPPINGS
+        )
+        assert boundary == os.path.normpath("/mnt/ssd_cache/data/media")
+
+    def test_secondary_pool_is_not_bounded_by_primary(self):
+        """The bug this guards: one global cache_dir skips other pools entirely."""
+        boundary = resolve_cache_boundary(
+            "/mnt/ssd_cache/data/media/movies/Film.mkv",
+            self.MAPPINGS,
+            fallback_dir="/mnt/cache",
+        )
+        assert boundary == os.path.normpath("/mnt/ssd_cache/data/media")
+
+    def test_longest_match_wins(self):
+        mappings = [
+            {"cache_path": "/mnt/cache", "enabled": True},
+            {"cache_path": "/mnt/cache/data/media", "enabled": True},
+        ]
+        boundary = resolve_cache_boundary("/mnt/cache/data/media/movies/F.mkv", mappings)
+        assert boundary == os.path.normpath("/mnt/cache/data/media")
+
+    def test_disabled_mapping_is_ignored(self):
+        boundary = resolve_cache_boundary("/mnt/old_cache/data/movies/F.mkv", self.MAPPINGS)
+        assert boundary is None
+
+    def test_falls_back_to_cache_dir(self):
+        boundary = resolve_cache_boundary(
+            "/mnt/cache/Movies/F.mkv", [], fallback_dir="/mnt/cache"
+        )
+        assert boundary == os.path.normpath("/mnt/cache")
+
+    def test_returns_none_when_nothing_contains_the_file(self):
+        boundary = resolve_cache_boundary(
+            "/mnt/somewhere_else/F.mkv", self.MAPPINGS, fallback_dir="/mnt/cache"
+        )
+        assert boundary is None
+
+    def test_no_boundary_for_empty_path(self):
+        assert resolve_cache_boundary("", self.MAPPINGS) is None

--- a/tests/test_evict_folder_cleanup.py
+++ b/tests/test_evict_folder_cleanup.py
@@ -1,0 +1,195 @@
+"""CacheService.evict_file() removes folders it empties (issue #196).
+
+Manual eviction from the Cached Files page deleted the file and stopped, so the
+movie folder (and the show/season chain for TV) stayed on the cache drive. The
+normal move-to-array path had always cleaned up; the evict paths never did.
+
+Exercises the real evict_file() against a temp filesystem — the .plexcached
+backup is restored, the cache copy removed, and the emptied folders go with it.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# conftest.py handles the fcntl mock and sys.path setup
+
+
+def _settings(cache_root, array_root, cleanup=True):
+    # Build prefixes with the OS separator so evict_file's startswith() prefix
+    # match behaves the same on Windows as on Linux.
+    return {
+        "path_mappings": [
+            {
+                "name": "Movies",
+                "plex_path": "/plex/movies",
+                "real_path": str(array_root / "Movies"),
+                "cache_path": str(cache_root / "Movies"),
+                "cacheable": True,
+                "enabled": True,
+            },
+            {
+                "name": "TV Shows",
+                "plex_path": "/plex/tv",
+                "real_path": str(array_root / "TV Shows"),
+                "cache_path": str(cache_root / "TV Shows"),
+                "cacheable": True,
+                "enabled": True,
+            },
+        ],
+        "cache_dir": str(cache_root),
+        "cleanup_empty_folders": cleanup,
+        "cache_eviction_mode": "smart",
+    }
+
+
+def _make_service(tmp_path, settings):
+    settings_file = tmp_path / "plexcache_settings.json"
+    settings_file.write_text(json.dumps(settings), encoding="utf-8")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    with patch("web.services.cache_service.SETTINGS_FILE", settings_file), \
+         patch("web.services.cache_service.CONFIG_DIR", tmp_path), \
+         patch("web.services.cache_service.DATA_DIR", data_dir):
+        from web.services.cache_service import CacheService
+        svc = CacheService()
+
+    svc.settings_file = settings_file
+    svc.exclude_file = tmp_path / "plexcache_cached_files.txt"
+    svc.timestamps_file = data_dir / "timestamps.json"
+    svc._get_pinned_cache_paths = lambda: set()
+    svc._get_pinned_cache_path_map = lambda: {}
+    return svc
+
+
+def _stage(cache_file, array_file):
+    """Put a cache copy in place with its .plexcached backup on the array."""
+    os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+    os.makedirs(os.path.dirname(array_file), exist_ok=True)
+    Path(cache_file).write_bytes(b"\0" * 1024)
+    Path(array_file + ".plexcached").write_bytes(b"\0" * 1024)
+
+
+@pytest.fixture
+def roots(tmp_path):
+    cache_root = tmp_path / "cache"
+    array_root = tmp_path / "array"
+    cache_root.mkdir()
+    array_root.mkdir()
+    return cache_root, array_root
+
+
+class TestEvictRemovesEmptyFolders:
+    def test_movie_folder_removed_after_evict(self, roots):
+        cache_root, array_root = roots
+        settings = _settings(cache_root, array_root)
+        svc = _make_service(cache_root.parent, settings)
+
+        movie_dir = cache_root / "Movies" / "Sonic the Hedgehog 3 (2024)"
+        cache_file = str(movie_dir / "Sonic.mkv")
+        array_file = str(array_root / "Movies" / "Sonic the Hedgehog 3 (2024)" / "Sonic.mkv")
+        _stage(cache_file, array_file)
+        svc.exclude_file.write_text(cache_file + "\n", encoding="utf-8")
+
+        result = svc.evict_file(cache_file)
+
+        assert result["success"], result["message"]
+        assert not os.path.exists(cache_file)
+        assert not movie_dir.exists(), "movie folder left behind on cache (issue #196)"
+        assert os.path.exists(array_file), "array copy must survive"
+
+    def test_season_and_show_folders_removed_for_last_episode(self, roots):
+        cache_root, array_root = roots
+        settings = _settings(cache_root, array_root)
+        svc = _make_service(cache_root.parent, settings)
+
+        season_dir = cache_root / "TV Shows" / "Slow Horses" / "Season 01"
+        cache_file = str(season_dir / "S01E01.mkv")
+        array_file = str(array_root / "TV Shows" / "Slow Horses" / "Season 01" / "S01E01.mkv")
+        _stage(cache_file, array_file)
+        svc.exclude_file.write_text(cache_file + "\n", encoding="utf-8")
+
+        result = svc.evict_file(cache_file)
+
+        assert result["success"], result["message"]
+        assert not season_dir.exists()
+        assert not (cache_root / "TV Shows" / "Slow Horses").exists()
+
+    def test_season_folder_kept_when_other_episodes_remain(self, roots):
+        cache_root, array_root = roots
+        settings = _settings(cache_root, array_root)
+        svc = _make_service(cache_root.parent, settings)
+
+        season_dir = cache_root / "TV Shows" / "Slow Horses" / "Season 01"
+        cache_file = str(season_dir / "S01E01.mkv")
+        array_file = str(array_root / "TV Shows" / "Slow Horses" / "Season 01" / "S01E01.mkv")
+        _stage(cache_file, array_file)
+        sibling = season_dir / "S01E02.mkv"
+        sibling.write_bytes(b"\0" * 1024)
+        svc.exclude_file.write_text(cache_file + "\n", encoding="utf-8")
+
+        result = svc.evict_file(cache_file)
+
+        assert result["success"], result["message"]
+        assert season_dir.exists()
+        assert sibling.exists()
+
+    def test_cache_root_itself_is_never_removed(self, roots):
+        cache_root, array_root = roots
+        settings = _settings(cache_root, array_root)
+        svc = _make_service(cache_root.parent, settings)
+
+        movie_dir = cache_root / "Movies" / "Only (2024)"
+        cache_file = str(movie_dir / "Only.mkv")
+        array_file = str(array_root / "Movies" / "Only (2024)" / "Only.mkv")
+        _stage(cache_file, array_file)
+        svc.exclude_file.write_text(cache_file + "\n", encoding="utf-8")
+
+        svc.evict_file(cache_file)
+
+        assert cache_root.exists()
+
+    def test_cleanup_setting_off_leaves_folders(self, roots):
+        cache_root, array_root = roots
+        settings = _settings(cache_root, array_root, cleanup=False)
+        svc = _make_service(cache_root.parent, settings)
+
+        movie_dir = cache_root / "Movies" / "Kept (2024)"
+        cache_file = str(movie_dir / "Kept.mkv")
+        array_file = str(array_root / "Movies" / "Kept (2024)" / "Kept.mkv")
+        _stage(cache_file, array_file)
+        svc.exclude_file.write_text(cache_file + "\n", encoding="utf-8")
+
+        result = svc.evict_file(cache_file)
+
+        assert result["success"], result["message"]
+        assert not os.path.exists(cache_file)
+        assert movie_dir.exists(), "cleanup_empty_folders=false must be honoured"
+
+    def test_bulk_evict_cleans_every_folder(self, roots):
+        cache_root, array_root = roots
+        settings = _settings(cache_root, array_root)
+        svc = _make_service(cache_root.parent, settings)
+
+        paths = []
+        for title in ("Alpha (2020)", "Beta (2021)", "Gamma (2022)"):
+            cache_file = str(cache_root / "Movies" / title / f"{title}.mkv")
+            array_file = str(array_root / "Movies" / title / f"{title}.mkv")
+            _stage(cache_file, array_file)
+            paths.append(cache_file)
+        svc.exclude_file.write_text("\n".join(paths) + "\n", encoding="utf-8")
+
+        result = svc.evict_files(paths)
+
+        assert result["evicted_count"] == 3, result["errors"]
+        for title in ("Alpha (2020)", "Beta (2021)", "Gamma (2022)"):
+            assert not (cache_root / "Movies" / title).exists()
+        # The mapping's own cache_path is the boundary — emptying it must not
+        # delete it, or the next caching run has no destination folder.
+        assert (cache_root / "Movies").exists()
+        assert cache_root.exists()

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass
 
 from web.config import DATA_DIR, CONFIG_DIR, SETTINGS_FILE
-from core.system_utils import get_disk_usage, detect_zfs, get_array_direct_path, parse_size_bytes, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file, create_dir_with_ownership
+from core.system_utils import get_disk_usage, detect_zfs, get_array_direct_path, parse_size_bytes, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary
 from core.file_operations import get_media_identity, find_matching_plexcached, save_json_atomically, SUBTITLE_EXTENSIONS, is_video_file
 
 
@@ -1742,10 +1742,16 @@ class CacheService:
             if os.path.exists(cache_path):
                 os.remove(cache_path)
 
-            # Step 3: Remove from exclude file
+            # Step 3: Remove folders this eviction just emptied (issue #196).
+            # Same File and Folder Management Policy the normal move-to-array
+            # path follows — without it, manual evictions leave the show/season
+            # and movie folders behind on the cache drive.
+            self._cleanup_empty_folders(cache_path, settings)
+
+            # Step 4: Remove from exclude file
             self._remove_from_exclude_file(cache_path)
 
-            # Step 4: Remove from timestamps
+            # Step 5: Remove from timestamps
             self._remove_from_timestamps(cache_path)
 
             result["success"] = True
@@ -2110,6 +2116,29 @@ class CacheService:
     def _remove_from_timestamps(self, cache_path: str):
         """Remove a path from the timestamps file"""
         remove_from_timestamps_file(self.timestamps_file, cache_path)
+
+    def _cleanup_empty_folders(self, cache_path: str, settings: Optional[Dict] = None) -> int:
+        """Remove folders left empty by removing `cache_path`.
+
+        Honours the `cleanup_empty_folders` setting and resolves the boundary
+        from path_mappings, so a file on a secondary pool is bounded by its own
+        mapping rather than the primary cache_dir.
+        """
+        if settings is None:
+            settings = self._load_settings()
+        if not settings.get('cleanup_empty_folders', True):
+            return 0
+
+        boundary = resolve_cache_boundary(
+            cache_path,
+            settings.get('path_mappings', []),
+            settings.get('cache_dir', ''),
+        )
+        if not boundary:
+            logger.debug(f"No cache boundary for {cache_path}, skipping folder cleanup")
+            return 0
+
+        return cleanup_empty_parent_folders(cache_path, boundary)
 
     def _get_pinned_cache_paths(self) -> set:
         """Return the current set of pinned cache-form paths.

--- a/web/services/maintenance_service.py
+++ b/web/services/maintenance_service.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set, Any, Tuple
 
 from web.config import DATA_DIR, CONFIG_DIR, SETTINGS_FILE
-from core.system_utils import get_array_direct_path, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file, create_dir_with_ownership
+from core.system_utils import get_array_direct_path, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file, create_dir_with_ownership, sweep_empty_folders
 from core.file_operations import PLEXCACHED_EXTENSION, VIDEO_EXTENSIONS, SUBTITLE_EXTENSIONS, MEDIA_EXTENSIONS
 
 
@@ -2354,24 +2354,15 @@ class MaintenanceService:
             )
 
     def _cleanup_empty_directories(self):
-        """Remove empty directories from cache paths"""
+        """Remove empty directories from cache paths.
+
+        Thin wrapper over the canonical `sweep_empty_folders()`.
+        """
         settings = self._load_settings()
         if not settings.get('cleanup_empty_folders', True):
             return
         cache_dirs, _ = self._get_paths()
-        for cache_dir in cache_dirs:
-            if os.path.exists(cache_dir):
-                for root, dirs, files in os.walk(cache_dir, topdown=False):
-                    for d in dirs:
-                        # Don't delete excluded directories
-                        if self._should_skip_directory(d):
-                            continue
-                        dir_path = os.path.join(root, d)
-                        try:
-                            if not os.listdir(dir_path):
-                                os.rmdir(dir_path)
-                        except OSError:
-                            pass
+        sweep_empty_folders(cache_dirs, self._should_skip_directory)
 
     def _remove_from_exclude_file(self, cache_path: str):
         """Remove a path from the exclude file"""


### PR DESCRIPTION
Closes #196

Reported in https://github.com/StudioNirin/PlexCache-D/issues/196#issuecomment-5180986909: evicting files leaves the folders behind on the cache drive.

Turns out only the normal move-to-array path was cleaning up after itself. Three other paths deleted the cache file and stopped there:

- the per-file and bulk Evict buttons on the Cached Files page
- the maintenance Evict action (delegates to the same service method)
- automatic smart/FIFO eviction during a run

The last one is probably the bigger source of the backlog, since it runs unattended on every run that crosses the threshold, so it has been quietly accumulating.

While wiring this up I found two other things worth mentioning:

Multi-pool setups were being skipped even on the working path. The boundary for the walk-up was the single `cache_dir`, checked with `startswith`. If a mapping lives on a different pool (say `/mnt/ssd_cache` while `cache_dir` is `/mnt/cache`) that check fails immediately, so cleanup silently did nothing there. The boundary now comes from the owning path mapping instead.

The `startswith` had no separator guard, so `/mnt/cache_downloads` counted as being inside `/mnt/cache`. That is a cleanup walking into a directory it does not own. It now requires a separator match.

One deliberate behavior change: a mapping's own `cache_path` is preserved even when it ends up empty. It is a configured caching destination rather than a folder PlexCache created, and removing it would leave the next run without somewhere to write.

Since per-file cleanup only ever sees folders it empties itself, existing installs keep whatever backlog they already have. Rather than ask everyone to clear it by hand, `_backfill_empty_folder_cleanup()` sweeps the cache mappings once on the first run after upgrade, records a marker in `data/migrations.json`, and never runs again. It logs one summary line and is skipped on dry runs and when `cleanup_empty_folders` is off. Sweep and marker failures are logged but non-fatal, since housekeeping should not be able to fail a run.

Also consolidated the duplicate sweep logic: `cleanup_empty_parent_folders()` and `sweep_empty_folders()` now live in `core/system_utils.py`, and `FileMover._cleanup_empty_parent_folders()` plus `MaintenanceService._cleanup_empty_directories()` are thin wrappers over them.

## Test steps

Manual eviction:

1. Cache a movie, confirm the folder exists under the cache path.
2. Evict it from the Cached Files page (or select several and use bulk evict).
3. The movie folder should be gone from the cache drive, and the file should still be on the array.

TV, to check the walk-up:

1. Cache one episode of a show that has nothing else cached.
2. Evict it. Both the season and show folders should go.
3. Cache two episodes, evict one. The season folder should stay, along with the other episode.

Backfill:

1. On an install that already has empty folders on the cache drive, start a run.
2. The log should show `[CLEANUP] Removed N empty folder(s) left by earlier evictions` shortly after startup, and `data/migrations.json` should gain an `empty_folder_backfill` key.
3. Start another run. No cleanup line, and the marker is unchanged.

Opting out:

1. Turn off `cleanup_empty_folders` in Settings, then evict a file. The folder should stay.
2. A dry run should not sweep or write the marker.

Should be safe to leave alone: dot-directories like `.Trash` and `.Recycle.Bin`, anything in `excluded_folders`, disabled or non-cacheable mappings, and the mapping roots themselves.

Adds 36 tests across `tests/test_empty_folder_cleanup.py`, `tests/test_evict_folder_cleanup.py` and `tests/test_empty_folder_backfill.py`.
