### PR TITLE
Release watched files to the Unraid mover instead of relocating them

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -92,6 +92,9 @@ class PlexCacheApp:
         self.released_count = 0
         self.released_bytes = 0
         self.readopted_count = 0
+        # Set when _apply_cache_limit() has to skip caching for space reasons.
+        # Drives _reclaim_released_if_constrained().
+        self._cache_space_constrained = False
         # Eviction tracking
         self.evicted_count = 0
         self.evicted_bytes = 0
@@ -487,7 +490,7 @@ class PlexCacheApp:
         readopted_count = getattr(self, 'readopted_count', 0)
         if readopted_count > 0:
             logging.info(
-                f"[RESULTS] Re-adopted from mover: {readopted_count} files (cache under pressure)"
+                f"[RESULTS] Reclaimed from mover: {readopted_count} files (cache had no room)"
             )
 
         # Show eviction stats if any files were evicted
@@ -1970,51 +1973,35 @@ class PlexCacheApp:
 
         return to_release, to_relocate
 
-    # Pool usage above which released files are taken back and relocated by
-    # PlexCache itself. Deliberately not a setting: it is a safety backstop for
-    # shares whose mover never reclaims, not a tuning knob.
-    _READOPT_PRESSURE_PERCENT = 90
-
-    def _cache_pressure_percent(self) -> Optional[float]:
-        """Percentage of the cache pool in use, or None if unmeasurable.
-
-        Reads the filesystem directly rather than cache_limit / min_free_space,
-        both of which default to unset. The backstop has to work on a default
-        install or it is not a backstop.
-        """
-        cache_dir = self.config_manager.paths.cache_dir
-        if not cache_dir:
-            return None
-        try:
-            override = getattr(self.config_manager.cache, 'cache_drive_size_bytes', 0) or 0
-            usage = get_disk_usage(cache_dir, override)
-        except (OSError, ValueError) as e:
-            logging.debug(f"Could not measure cache pressure: {e}")
-            return None
-        if not usage or not usage.total:
-            return None
-        return (usage.used / usage.total) * 100
-
-    def _readopt_released_under_pressure(self) -> int:
-        """Take released files back when the pool fills and the mover hasn't acted.
+    def _reclaim_released_if_constrained(self) -> int:
+        """Take released files back when the cache had no room for new content.
 
         Release assumes Unraid's mover eventually relocates the file. On a
         cache:prefer share the mover runs the other direction, and on a
-        cache:only share it does not run at all — so the file would sit there
+        cache:only share it does not run at all, so the file would sit there
         forever. PlexCache cannot read shareUseCache to tell the difference
-        (/boot is not mounted in the container), so rather than predict the
-        mover's behaviour it observes the outcome: if the pool is genuinely
-        under pressure and released files are still resident, take them back
-        and relocate them the ordinary way.
+        (neither /boot nor emhttp's share state is mounted in the container),
+        so rather than predict the mover's behaviour it observes the outcome.
 
-        Pressure-triggered rather than time-triggered on purpose. A Mover
-        Tuning user deliberately holds recent media on cache, and a timer would
-        fight exactly the configuration this feature exists to respect.
+        The trigger is _apply_cache_limit() reporting that it had to skip
+        caching something for space reasons. That is measured harm rather than
+        a threshold: it scales from a 250GB SSD to a 20TB pool with no constant
+        to tune, it never fires while there is room to spare, and it inherits
+        whatever the user configured, since cache_limit, min_free_space and
+        plexcache_quota all feed it.
+
+        Deliberately not time-triggered. A Mover Tuning user holds recent media
+        on cache on purpose, and a timer would fight exactly the configuration
+        this feature exists to respect.
+
+        Runs after the caching phase, so the files relocate in this same pass.
 
         Returns:
-            Number of files re-adopted into media_to_array.
+            Number of files handed back to the array.
         """
         if not self.timestamp_tracker or self.dry_run:
+            return 0
+        if not getattr(self, '_cache_space_constrained', False):
             return 0
 
         released = self.timestamp_tracker.get_released_paths()
@@ -2025,45 +2012,41 @@ class PlexCacheApp:
         if not still_resident:
             return 0
 
-        pressure = self._cache_pressure_percent()
-        if pressure is None:
-            logging.debug("Skipping re-adoption check — cache pressure unmeasurable")
-            return 0
-        if pressure < self._READOPT_PRESSURE_PERCENT:
-            logging.debug(
-                f"{len(still_resident)} released file(s) still on cache, "
-                f"pool at {pressure:.1f}% — leaving them to the mover"
-            )
-            return 0
-
-        readopted = []
+        to_relocate = []
+        reclaimable_bytes = 0
         for cache_path in still_resident:
             array_path = None
             if self.file_path_modifier:
                 array_path, _ = self.file_path_modifier.convert_cache_to_real(cache_path)
             if not array_path:
-                logging.debug(f"Cannot re-adopt (no array path): {cache_path}")
+                logging.debug(f"Cannot reclaim (no array path): {cache_path}")
                 continue
-            if array_path in self.media_to_array:
-                continue
+            try:
+                reclaimable_bytes += os.path.getsize(cache_path)
+            except OSError:
+                pass
             self.timestamp_tracker.clear_released(cache_path)
-            self.media_to_array.append(array_path)
-            readopted.append(array_path)
+            to_relocate.append(array_path)
 
-        if readopted:
-            count = len(readopted)
-            unit = "file" if count == 1 else "files"
-            logging.info(
-                f"[RELEASE] Cache pool at {pressure:.1f}% and the mover has not "
-                f"reclaimed {count} released {unit} — moving to array now"
-            )
-            for array_path in readopted[:6]:
-                logging.info(f"  {self._extract_display_name(array_path)}")
-            if count > 6:
-                logging.info(f"  ...and {count - 6} more")
-            self.readopted_count = getattr(self, 'readopted_count', 0) + count
+        if not to_relocate:
+            return 0
 
-        return len(readopted)
+        count = len(to_relocate)
+        unit = "file" if count == 1 else "files"
+        logging.warning(
+            f"[RELEASE] Cache ran out of room while {count} released {unit} "
+            f"({format_bytes(reclaimable_bytes)}) were still waiting on the Unraid mover. "
+            f"The mover does not appear to be reclaiming them, which is expected on a "
+            f"cache:prefer or cache:only share. Moving them to the array now."
+        )
+        for array_path in to_relocate[:6]:
+            logging.info(f"  {self._extract_display_name(array_path)}")
+        if count > 6:
+            logging.info(f"  ...and {count - 6} more")
+
+        self._safe_move_files(to_relocate, 'array')
+        self.readopted_count = getattr(self, 'readopted_count', 0) + count
+        return count
 
     def _release_files(self, files_to_release: List[str]) -> int:
         """Hand watched files back to the Unraid mover without moving bytes.
@@ -2264,12 +2247,6 @@ class PlexCacheApp:
         logging.info("--- Moving Files ---")
 
         # Step 1: Move watched files to array (frees space naturally)
-        # Backstop before anything else: if the pool is under pressure and the
-        # Unraid mover has not reclaimed files PlexCache released on an earlier
-        # run, take them back now so they relocate in this pass.
-        if self.config_manager.cache.watched_move:
-            self._readopt_released_under_pressure()
-
         if self.config_manager.cache.watched_move and self.media_to_array:
             # Build restore sibling map from timestamp tracker associations
             # so the web UI can group sidecars under their parent video
@@ -2338,6 +2315,13 @@ class PlexCacheApp:
             if len(self.media_to_cache) > 6:
                 logging.info(f"  ...and {len(self.media_to_cache) - 6} more")
         self._safe_move_files(self.media_to_cache, 'cache')
+
+        # Step 4: If the cache had no room for content we wanted, take back any
+        # files still sitting released and waiting on a mover that is not coming.
+        # Runs last because the constraint is only known once caching has been
+        # sized, and _safe_move_files('array') here cannot re-enter that sizing.
+        if self.config_manager.cache.watched_move:
+            self._reclaim_released_if_constrained()
 
         # Associate sibling files with their parent videos in the timestamp tracker
         if self.timestamp_tracker and self.sibling_map:
@@ -2676,6 +2660,10 @@ class PlexCacheApp:
             if gap_skipped_count:
                 msg += f" ({gap_skipped_count} skipped to keep show episodes contiguous)"
             logging.warning(msg)
+            # Measured harm: the cache had no room for content we wanted. This is
+            # what _reclaim_released_if_constrained() acts on, in place of any
+            # fixed pool-usage threshold — see its docstring.
+            self._cache_space_constrained = True
 
         return files_to_cache
 

--- a/core/app.py
+++ b/core/app.py
@@ -29,7 +29,7 @@ from core.config import ConfigManager
 from core.logging_config import LoggingManager, reset_warning_error_flag
 from core.system_utils import SystemDetector, FileUtils, SingleInstanceLock, get_disk_usage, get_array_direct_path, detect_zfs, set_zfs_prefixes, format_bytes, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary, sweep_empty_folders
 from core.plex_api import PlexManager, OnDeckItem
-from core.file_operations import MultiPathModifier, SiblingFileFinder, FileFilter, FileMover, PlexcachedRestorer, CacheTimestampTracker, WatchlistTracker, OnDeckTracker, CachePriorityManager, PlexcachedMigration, get_media_identity, find_matching_plexcached, is_directory_level_file, save_json_atomically
+from core.file_operations import MultiPathModifier, SiblingFileFinder, FileFilter, FileMover, PlexcachedRestorer, CacheTimestampTracker, WatchlistTracker, OnDeckTracker, CachePriorityManager, PlexcachedMigration, get_media_identity, find_matching_plexcached, is_directory_level_file, is_video_file, save_json_atomically
 from core.pinned_media import PinnedMediaTracker, resolve_pins_to_paths
 
 
@@ -88,6 +88,10 @@ class PlexCacheApp:
         self.moved_to_array_count = 0
         self.moved_to_array_bytes = 0
         self.cached_bytes = 0
+        # Files handed back to the Unraid mover instead of being relocated
+        self.released_count = 0
+        self.released_bytes = 0
+        self.readopted_count = 0
         # Eviction tracking
         self.evicted_count = 0
         self.evicted_bytes = 0
@@ -469,6 +473,22 @@ class PlexCacheApp:
         move_verb = "Would move" if self.dry_run else "Moved"
         logging.info(f"[RESULTS] {move_verb} to cache: {actually_moved} files")
         logging.info(f"[RESULTS] {move_verb} to array: {moved_to_array} files")
+
+        # Show files handed back to the Unraid mover (no data moved)
+        released_count = getattr(self, 'released_count', 0)
+        if released_count > 0:
+            release_verb = "Would release" if self.dry_run else "Released"
+            released_size = format_bytes(getattr(self, 'released_bytes', 0))
+            logging.info(
+                f"[RESULTS] {release_verb} to mover: {released_count} files "
+                f"({released_size}, left in place)"
+            )
+
+        readopted_count = getattr(self, 'readopted_count', 0)
+        if readopted_count > 0:
+            logging.info(
+                f"[RESULTS] Re-adopted from mover: {readopted_count} files (cache under pressure)"
+            )
 
         # Show eviction stats if any files were evicted
         if self.evicted_count > 0:
@@ -1847,6 +1867,282 @@ class PlexCacheApp:
 
         return to_restore, to_move
 
+    def _cache_path_for(self, array_path: str) -> Optional[str]:
+        """Translate an array path to its cache path, or None if unmappable."""
+        if not self.file_path_modifier:
+            return None
+        try:
+            cache_path, _ = self.file_path_modifier.convert_real_to_cache(array_path)
+        except (ValueError, TypeError, AttributeError):
+            return None
+        return cache_path or None
+
+    def _share_has_array_side(self, array_path: str) -> bool:
+        """Whether this share actually has an array behind it.
+
+        Release hands a file to the Unraid mover. That only means anything on a
+        share the mover can move cache -> array. Two shapes qualify:
+        a /mnt/user/ path that converts to a distinct /mnt/user0/ path, and a
+        path that is already array-direct. Everything else — ZFS pool-only
+        shares, non-Unraid installs — falls back to relocating.
+        """
+        if array_path.startswith('/mnt/user0/'):
+            return True
+        if array_path.startswith('/mnt/user/'):
+            return get_array_direct_path(array_path) != array_path
+        return False
+
+    def _partition_release_candidates(
+        self, files_to_move: List[str]
+    ) -> Tuple[List[str], List[str]]:
+        """Split the no-backup bucket into files to release vs files to relocate.
+
+        A file with no .plexcached backup was never lifted off the array by
+        PlexCache, so relocating it writes to the array for the first time and
+        spins a disk the user did not ask to spin. The Unraid mover reclaims
+        that file on its own schedule once the exclude line is gone, so
+        PlexCache releases it instead of moving bytes.
+
+        Fails closed to today's relocate behaviour whenever release would be
+        unsafe or pointless:
+
+        - not on Unraid, or no array behind the share (ZFS pool-only): nothing
+          would ever reclaim the file.
+        - a differently-named .plexcached exists (Radarr/Sonarr upgraded the
+          file while it was cached): _move_to_array has to clean that backup
+          up, and walking away would orphan it permanently.
+        - the cache file has more than one hard link (actively seeding): the
+          mover breaks the link when it relocates, doubling on-disk usage.
+          Checked unconditionally, not behind check_hardlinks_on_restore,
+          because that setting is about a different decision and defaults off.
+
+        Args:
+            files_to_move: Array paths with no exact .plexcached backup.
+
+        Returns:
+            Tuple of (files_to_release, files_to_relocate).
+        """
+        to_release = []
+        to_relocate = []
+
+        on_unraid = bool(getattr(self.system_detector, 'is_unraid', False))
+
+        for array_path in files_to_move:
+            if not on_unraid or not self._share_has_array_side(array_path):
+                to_relocate.append(array_path)
+                continue
+
+            cache_path = self._cache_path_for(array_path)
+            if not cache_path or not os.path.isfile(cache_path):
+                to_relocate.append(array_path)
+                continue
+
+            # Upgraded file: a backup under the old filename is still on the array
+            if is_video_file(cache_path):
+                array_dir = os.path.dirname(get_array_direct_path(array_path))
+                try:
+                    old_backup = find_matching_plexcached(
+                        array_dir, get_media_identity(cache_path), cache_path
+                    )
+                except OSError:
+                    old_backup = None
+                if old_backup:
+                    logging.debug(
+                        f"Not releasing (old .plexcached needs cleanup): {os.path.basename(cache_path)}"
+                    )
+                    to_relocate.append(array_path)
+                    continue
+
+            # Hard-linked file: let PlexCache's own hardlink-aware path handle it
+            try:
+                if os.stat(cache_path).st_nlink > 1:
+                    logging.debug(
+                        f"Not releasing (hard-linked): {os.path.basename(cache_path)}"
+                    )
+                    to_relocate.append(array_path)
+                    continue
+            except OSError as e:
+                logging.debug(f"Not releasing (cannot stat {cache_path}): {e}")
+                to_relocate.append(array_path)
+                continue
+
+            to_release.append(array_path)
+
+        return to_release, to_relocate
+
+    # Pool usage above which released files are taken back and relocated by
+    # PlexCache itself. Deliberately not a setting: it is a safety backstop for
+    # shares whose mover never reclaims, not a tuning knob.
+    _READOPT_PRESSURE_PERCENT = 90
+
+    def _cache_pressure_percent(self) -> Optional[float]:
+        """Percentage of the cache pool in use, or None if unmeasurable.
+
+        Reads the filesystem directly rather than cache_limit / min_free_space,
+        both of which default to unset. The backstop has to work on a default
+        install or it is not a backstop.
+        """
+        cache_dir = self.config_manager.paths.cache_dir
+        if not cache_dir:
+            return None
+        try:
+            override = getattr(self.config_manager.cache, 'cache_drive_size_bytes', 0) or 0
+            usage = get_disk_usage(cache_dir, override)
+        except (OSError, ValueError) as e:
+            logging.debug(f"Could not measure cache pressure: {e}")
+            return None
+        if not usage or not usage.total:
+            return None
+        return (usage.used / usage.total) * 100
+
+    def _readopt_released_under_pressure(self) -> int:
+        """Take released files back when the pool fills and the mover hasn't acted.
+
+        Release assumes Unraid's mover eventually relocates the file. On a
+        cache:prefer share the mover runs the other direction, and on a
+        cache:only share it does not run at all — so the file would sit there
+        forever. PlexCache cannot read shareUseCache to tell the difference
+        (/boot is not mounted in the container), so rather than predict the
+        mover's behaviour it observes the outcome: if the pool is genuinely
+        under pressure and released files are still resident, take them back
+        and relocate them the ordinary way.
+
+        Pressure-triggered rather than time-triggered on purpose. A Mover
+        Tuning user deliberately holds recent media on cache, and a timer would
+        fight exactly the configuration this feature exists to respect.
+
+        Returns:
+            Number of files re-adopted into media_to_array.
+        """
+        if not self.timestamp_tracker or self.dry_run:
+            return 0
+
+        released = self.timestamp_tracker.get_released_paths()
+        if not released:
+            return 0
+
+        still_resident = [p for p in sorted(released) if os.path.isfile(p)]
+        if not still_resident:
+            return 0
+
+        pressure = self._cache_pressure_percent()
+        if pressure is None:
+            logging.debug("Skipping re-adoption check — cache pressure unmeasurable")
+            return 0
+        if pressure < self._READOPT_PRESSURE_PERCENT:
+            logging.debug(
+                f"{len(still_resident)} released file(s) still on cache, "
+                f"pool at {pressure:.1f}% — leaving them to the mover"
+            )
+            return 0
+
+        readopted = []
+        for cache_path in still_resident:
+            array_path = None
+            if self.file_path_modifier:
+                array_path, _ = self.file_path_modifier.convert_cache_to_real(cache_path)
+            if not array_path:
+                logging.debug(f"Cannot re-adopt (no array path): {cache_path}")
+                continue
+            if array_path in self.media_to_array:
+                continue
+            self.timestamp_tracker.clear_released(cache_path)
+            self.media_to_array.append(array_path)
+            readopted.append(array_path)
+
+        if readopted:
+            count = len(readopted)
+            unit = "file" if count == 1 else "files"
+            logging.info(
+                f"[RELEASE] Cache pool at {pressure:.1f}% and the mover has not "
+                f"reclaimed {count} released {unit} — moving to array now"
+            )
+            for array_path in readopted[:6]:
+                logging.info(f"  {self._extract_display_name(array_path)}")
+            if count > 6:
+                logging.info(f"  ...and {count - 6} more")
+            self.readopted_count = getattr(self, 'readopted_count', 0) + count
+
+        return len(readopted)
+
+    def _release_files(self, files_to_release: List[str]) -> int:
+        """Hand watched files back to the Unraid mover without moving bytes.
+
+        Drops the mover exclude line and stamps the tracker entry as released.
+        The entry stays: the mover now owns relocation, but PlexCache keeps the
+        file in its inventory so the quota and eviction can still reach it if
+        the mover never runs (a cache:prefer or cache:only share).
+
+        Returns:
+            Number of files released.
+        """
+        if not files_to_release:
+            return 0
+
+        if self.dry_run:
+            logging.info(
+                f"[RELEASE] DRY-RUN: Would release {len(files_to_release)} file(s) to the Unraid mover"
+            )
+            for array_path in files_to_release[:6]:
+                logging.info(f"  {self._extract_display_name(array_path)}")
+            if len(files_to_release) > 6:
+                logging.info(f"  ...and {len(files_to_release) - 6} more")
+            return 0
+
+        cache_paths = []
+        for array_path in files_to_release:
+            cache_path = self._cache_path_for(array_path)
+            if cache_path:
+                cache_paths.append((array_path, cache_path))
+
+        if not cache_paths:
+            return 0
+
+        # Drop the exclude lines first. Only clear tracking for files whose
+        # exclude entry actually went away — otherwise the file stays
+        # mover-protected while PlexCache stops tracking it.
+        removed = self.file_filter.remove_files_from_exclude_list(
+            [c for _, c in cache_paths]
+        )
+        if not removed:
+            logging.warning(
+                "[RELEASE] Could not update the exclude list — leaving "
+                f"{len(cache_paths)} file(s) tracked for retry next run"
+            )
+            return 0
+
+        count = len(cache_paths)
+        unit = "file" if count == 1 else "files"
+        logging.info(f"[RELEASE] Handing {count} {unit} back to the Unraid mover (no data moved):")
+
+        released_bytes = 0
+        for array_path, cache_path in cache_paths:
+            try:
+                size = os.path.getsize(cache_path)
+            except OSError:
+                size = 0
+            released_bytes += size
+
+            if self.timestamp_tracker:
+                self.timestamp_tracker.mark_released(cache_path)
+            if self.ondeck_tracker:
+                self.ondeck_tracker.mark_uncached(cache_path)
+            if self.watchlist_tracker:
+                self.watchlist_tracker.mark_uncached(cache_path)
+
+            # INFO, and in the same "  [Action] name (size)" shape _move_to_array
+            # uses — the web OperationRunner builds its activity feed by parsing
+            # these lines out of the log stream.
+            display_name = self._extract_display_name(array_path)
+            logging.info(f"  [Released] {display_name} ({format_bytes(size)})")
+
+            if getattr(self, '_record_activity', False):
+                self._record_file_activity("Released", os.path.basename(array_path), size)
+
+        self.released_count = getattr(self, 'released_count', 0) + count
+        self.released_bytes = getattr(self, 'released_bytes', 0) + released_bytes
+        return count
+
     def _log_restore_and_move_summary(self, files_to_restore: List[str], files_to_move: List[str]) -> None:
         """Log summary of restore vs move operations at INFO level.
 
@@ -1968,17 +2264,37 @@ class PlexCacheApp:
         logging.info("--- Moving Files ---")
 
         # Step 1: Move watched files to array (frees space naturally)
+        # Backstop before anything else: if the pool is under pressure and the
+        # Unraid mover has not reclaimed files PlexCache released on an earlier
+        # run, take them back now so they relocate in this pass.
+        if self.config_manager.cache.watched_move:
+            self._readopt_released_under_pressure()
+
         if self.config_manager.cache.watched_move and self.media_to_array:
             # Build restore sibling map from timestamp tracker associations
             # so the web UI can group sidecars under their parent video
             if self.timestamp_tracker:
                 self._build_restore_sibling_map()
 
-            # Log restore vs move summary before processing
             files_to_restore, files_to_move = self._separate_restore_and_move(self.media_to_array)
+
+            # Files PlexCache never lifted off the array are handed back to the
+            # Unraid mover rather than relocated — no array write, no spinup.
+            files_to_release, files_to_move = self._partition_release_candidates(files_to_move)
+            if files_to_release:
+                release_set = set(files_to_release)
+                self.media_to_array = [f for f in self.media_to_array if f not in release_set]
+
+            # Log restore vs move summary before processing
             if files_to_restore or files_to_move:
                 self._log_restore_and_move_summary(files_to_restore, files_to_move)
-            self._safe_move_files(self.media_to_array, 'array')
+
+            released_count = 0
+            if files_to_release:
+                released_count = self._release_files(files_to_release)
+
+            if self.media_to_array:
+                self._safe_move_files(self.media_to_array, 'array')
 
             # Deferred exclude list cleanup: only remove entries for files that actually moved (issue #13)
             # This prevents losing tracking of files if a move fails (e.g., disk full, I/O error)
@@ -1987,8 +2303,10 @@ class PlexCacheApp:
                 if successful_moves:
                     self.file_filter.remove_files_from_exclude_list(list(successful_moves))
 
-                # Log warnings for files that failed to move (their exclude entries stay protected)
-                deferred_count = len(self._move_back_exclude_paths)
+                # Log warnings for files that failed to move (their exclude entries stay protected).
+                # Released files had their exclude entries dropped by _release_files, so they are
+                # not pending moves and must not be counted as failures.
+                deferred_count = len(self._move_back_exclude_paths) - released_count
                 succeeded_count = len(successful_moves)
                 if succeeded_count < deferred_count:
                     failed_count = deferred_count - succeeded_count
@@ -2168,39 +2486,60 @@ class PlexCacheApp:
         )
 
     def _get_plexcache_tracked_size(self) -> tuple:
-        """Calculate current PlexCache tracked size from exclude file.
+        """Calculate current PlexCache tracked size from its file inventory.
+
+        The inventory is the timestamp tracker unioned with the Unraid mover
+        exclude file. The tracker leads — matching what
+        CacheService.get_cached_files_list() already does on the web side —
+        because the exclude file answers "what should the mover keep its hands
+        off", which is a narrower question than "what is PlexCache managing".
+        A released file keeps its tracker entry and is deliberately dropped
+        from the exclude file, and both the quota and the eviction candidate
+        pool still need to reach it.
+
+        The exclude file is unioned in rather than replaced so installs whose
+        two stores have drifted keep everything they had before. Deduping via
+        a set also stops repeated exclude-file lines from double-counting
+        bytes.
 
         Returns:
-            Tuple of (total_bytes, cached_files_list). Returns (0, []) on error.
-            In Docker, paths are translated from host to container paths.
+            Tuple of (total_bytes, cached_files_list). Returns (0, []) when
+            neither store yields a readable path. Paths are container paths;
+            the exclude file's host paths are translated.
         """
+        container_paths: Set[str] = set()
+
+        timestamp_tracker = getattr(self, 'timestamp_tracker', None)
+        if timestamp_tracker:
+            container_paths.update(timestamp_tracker.get_all_tracked_paths())
+
         exclude_file = self.config_manager.get_cached_files_file()
-        if not exclude_file.exists():
-            return (0, [])
+        if exclude_file.exists():
+            try:
+                with open(exclude_file, 'r') as f:
+                    host_paths = [line.strip() for line in f if line.strip()]
+
+                for host_path in host_paths:
+                    # In Docker, exclude file has host paths but we need container
+                    # paths to check existence and calculate size
+                    if self.file_filter:
+                        container_paths.add(self.file_filter._translate_from_host_path(host_path))
+                    else:
+                        container_paths.add(host_path)
+            except OSError as e:
+                logging.warning(f"Error reading exclude file: {e}")
+                if not container_paths:
+                    return (0, [])
 
         plexcache_tracked = 0
         cached_files = []
-        try:
-            with open(exclude_file, 'r') as f:
-                host_paths = [line.strip() for line in f if line.strip()]
-
-            for host_path in host_paths:
-                # In Docker, exclude file has host paths but we need container paths
-                # to check existence and calculate size
-                if self.file_filter:
-                    container_path = self.file_filter._translate_from_host_path(host_path)
-                else:
-                    container_path = host_path
-
-                try:
-                    if os.path.exists(container_path):
-                        plexcache_tracked += os.path.getsize(container_path)
-                        cached_files.append(container_path)  # Return container paths for eviction
-                except (OSError, FileNotFoundError):
-                    pass
-        except OSError as e:
-            logging.warning(f"Error reading exclude file: {e}")
-            return (0, [])
+        for container_path in sorted(container_paths):
+            try:
+                if os.path.exists(container_path):
+                    plexcache_tracked += os.path.getsize(container_path)
+                    cached_files.append(container_path)  # Container paths for eviction
+            except (OSError, FileNotFoundError):
+                pass
 
         return (plexcache_tracked, cached_files)
 

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -841,6 +841,115 @@ class CacheTimestampTracker:
         """Backward-compatible alias for get_associated_files()."""
         return self.get_associated_files(parent_path)
 
+    def get_all_tracked_paths(self) -> Set[str]:
+        """Get every cache path this tracker knows about, sidecars included.
+
+        Associated files (subtitles, artwork, NFOs) are not top-level keys —
+        associate_files() folds them into their parent's "associated_files"
+        list and deletes the standalone entry. A caller that only walks
+        _timestamps.keys() therefore misses every sidecar, so this expands
+        them back out.
+
+        Returns:
+            Set of cache paths (parent videos + their associated files).
+        """
+        with self._lock:
+            paths = set(self._timestamps.keys())
+            for entry in self._timestamps.values():
+                if isinstance(entry, dict):
+                    paths.update(entry.get("associated_files", []))
+            return paths
+
+    def _resolve_entry_key(self, cache_file_path: str) -> Optional[str]:
+        """Map a cache path to the key that actually holds its entry.
+
+        Sidecars have no entry of their own — associate_files() folds them
+        into the parent video — so they resolve to the parent. Caller must
+        already hold the lock.
+        """
+        if cache_file_path in self._timestamps:
+            return cache_file_path
+        return self._file_to_parent.get(cache_file_path)
+
+    def mark_released(self, cache_file_path: str) -> bool:
+        """Stamp an entry as released to the Unraid mover.
+
+        A released file stays in the tracker — that is the whole point. The
+        exclude line is gone so the mover is free to take it, but PlexCache
+        keeps managing it so the quota and eviction can still reach it if the
+        mover never does.
+
+        Args:
+            cache_file_path: Cache path of the file (or one of its sidecars).
+
+        Returns:
+            True if an entry was stamped.
+        """
+        with self._lock:
+            key = self._resolve_entry_key(cache_file_path)
+            if key is None:
+                return False
+            entry = self._timestamps.get(key)
+            if not isinstance(entry, dict):
+                return False
+            entry["released_at"] = datetime.now().isoformat()
+            self._save()
+            logging.debug(f"Marked released: {cache_file_path}")
+            return True
+
+    def clear_released(self, cache_file_path: str) -> bool:
+        """Drop the release stamp, putting the file back under PlexCache's
+        own reclamation (used when re-adopting under cache pressure).
+
+        Returns:
+            True if a stamp was present and removed.
+        """
+        with self._lock:
+            key = self._resolve_entry_key(cache_file_path)
+            if key is None:
+                return False
+            entry = self._timestamps.get(key)
+            if not isinstance(entry, dict) or "released_at" not in entry:
+                return False
+            del entry["released_at"]
+            self._save()
+            logging.debug(f"Cleared released mark: {cache_file_path}")
+            return True
+
+    def is_released(self, cache_file_path: str) -> bool:
+        """Whether this file (or its parent video) is marked released."""
+        with self._lock:
+            key = self._resolve_entry_key(cache_file_path)
+            if key is None:
+                return False
+            entry = self._timestamps.get(key)
+            return isinstance(entry, dict) and "released_at" in entry
+
+    def get_released_at(self, cache_file_path: str) -> Optional[str]:
+        """ISO timestamp of when this file was released, or None."""
+        with self._lock:
+            key = self._resolve_entry_key(cache_file_path)
+            if key is None:
+                return None
+            entry = self._timestamps.get(key)
+            if isinstance(entry, dict):
+                return entry.get("released_at")
+            return None
+
+    def get_released_paths(self) -> Set[str]:
+        """Every cache path currently marked released, sidecars expanded.
+
+        A sidecar inherits its parent's released state, so releasing a video
+        releases its subtitles and artwork with it.
+        """
+        with self._lock:
+            released: Set[str] = set()
+            for key, entry in self._timestamps.items():
+                if isinstance(entry, dict) and "released_at" in entry:
+                    released.add(key)
+                    released.update(entry.get("associated_files", []))
+            return released
+
     def find_parent_video(self, file_path: str) -> Optional[str]:
         """Find the parent video for an associated file via the reverse index.
 

--- a/tests/test_cache_inventory.py
+++ b/tests/test_cache_inventory.py
@@ -1,0 +1,334 @@
+"""Tests for PlexCache's tracked-file inventory (_get_plexcache_tracked_size).
+
+The inventory is the single feed for two things: the plexcache_quota check in
+_apply_cache_limit() and the eviction candidate pool in _run_smart_eviction().
+It used to read the Unraid mover exclude file alone. It now leads with the
+timestamp tracker and unions the exclude file in, matching what
+CacheService.get_cached_files_list() already does on the web side.
+
+The distinction matters because the exclude file answers "what should the
+Unraid mover keep its hands off" — a narrower question than "what is PlexCache
+managing". A released file is deliberately dropped from the exclude file but
+must stay reachable by the quota and by eviction.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# core.app pulls in plexapi/requests transitively; they may not be installed.
+for _mod_name in [
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex', 'requests',
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+from conftest import create_test_file  # noqa: E402
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def _build_app(tmp_path, exclude_lines=None, tracker=None, host_to_container=None,
+               exclude_readable=True):
+    """Build a minimal PlexCacheApp wired for _get_plexcache_tracked_size().
+
+    Args:
+        exclude_lines: Lines to write into the exclude file, or None for no
+                       exclude file at all.
+        tracker: Object exposing get_all_tracked_paths(), or None to simulate
+                 an app whose timestamp_tracker was never constructed.
+        host_to_container: Optional callable used as the Docker path
+                           translation for exclude-file entries.
+        exclude_readable: When False the exclude file exists but raises OSError
+                          on open, simulating a permissions problem.
+    """
+    from core.app import PlexCacheApp
+
+    config_manager = MagicMock()
+
+    exclude_path = tmp_path / "plexcache_cached_files.txt"
+    if exclude_lines is not None:
+        exclude_path.write_text("\n".join(exclude_lines) + "\n", encoding="utf-8")
+    config_manager.get_cached_files_file.return_value = exclude_path
+
+    app = object.__new__(PlexCacheApp)
+    app.config_manager = config_manager
+
+    if tracker is not None:
+        app.timestamp_tracker = tracker
+
+    if host_to_container is not None:
+        file_filter = MagicMock()
+        file_filter._translate_from_host_path.side_effect = host_to_container
+        app.file_filter = file_filter
+    else:
+        app.file_filter = None
+
+    if not exclude_readable:
+        app._force_exclude_error = True
+
+    return app
+
+
+class _FakeTracker:
+    """Stands in for CacheTimestampTracker's inventory surface."""
+
+    def __init__(self, paths):
+        self._paths = set(paths)
+
+    def get_all_tracked_paths(self):
+        return set(self._paths)
+
+
+# ============================================================================
+# Inventory sources
+# ============================================================================
+
+class TestInventorySources:
+    """Which stores feed the inventory, and how they combine."""
+
+    def test_exclude_file_only_still_works(self, tmp_path):
+        """Backwards compatibility: an install with no tracker entries."""
+        f = create_test_file(str(tmp_path / "cache" / "Movie.mkv"), size_bytes=100)
+        app = _build_app(tmp_path, exclude_lines=[f], tracker=_FakeTracker([]))
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert files == [f]
+        assert total == 100
+
+    def test_tracker_only_is_counted(self, tmp_path):
+        """A file the tracker knows about counts even with no exclude file.
+
+        This is the released-file case: the exclude line is gone, but PlexCache
+        is still managing the file and must be able to evict it.
+        """
+        f = create_test_file(str(tmp_path / "cache" / "Movie.mkv"), size_bytes=250)
+        app = _build_app(tmp_path, exclude_lines=None, tracker=_FakeTracker([f]))
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert files == [f]
+        assert total == 250
+
+    def test_union_of_both_stores(self, tmp_path):
+        """Drifted stores lose nothing — the union keeps both sides."""
+        only_tracker = create_test_file(str(tmp_path / "cache" / "A.mkv"), size_bytes=10)
+        only_exclude = create_test_file(str(tmp_path / "cache" / "B.mkv"), size_bytes=20)
+        app = _build_app(
+            tmp_path, exclude_lines=[only_exclude], tracker=_FakeTracker([only_tracker])
+        )
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert sorted(files) == sorted([only_tracker, only_exclude])
+        assert total == 30
+
+    def test_missing_tracker_attribute_falls_back_to_exclude(self, tmp_path):
+        """_get_plexcache_tracked_size can run before the tracker is built."""
+        f = create_test_file(str(tmp_path / "cache" / "Movie.mkv"), size_bytes=64)
+        app = _build_app(tmp_path, exclude_lines=[f], tracker=None)
+
+        assert not hasattr(app, "timestamp_tracker")
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert files == [f]
+        assert total == 64
+
+    def test_both_stores_empty(self, tmp_path):
+        app = _build_app(tmp_path, exclude_lines=None, tracker=_FakeTracker([]))
+
+        assert app._get_plexcache_tracked_size() == (0, [])
+
+
+# ============================================================================
+# Deduplication
+# ============================================================================
+
+class TestDeduplication:
+    """A path present twice must be counted once."""
+
+    def test_same_file_in_both_stores_counted_once(self, tmp_path):
+        f = create_test_file(str(tmp_path / "cache" / "Movie.mkv"), size_bytes=500)
+        app = _build_app(tmp_path, exclude_lines=[f], tracker=_FakeTracker([f]))
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert files == [f]
+        assert total == 500
+
+    def test_duplicate_exclude_lines_counted_once(self, tmp_path):
+        """MaintenanceService.add_to_exclude appends without a dedup check, so
+        the exclude file can legitimately hold the same path twice. That must
+        not inflate the quota."""
+        f = create_test_file(str(tmp_path / "cache" / "Movie.mkv"), size_bytes=500)
+        app = _build_app(tmp_path, exclude_lines=[f, f, f], tracker=_FakeTracker([]))
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert files == [f]
+        assert total == 500
+
+
+# ============================================================================
+# Sidecars
+# ============================================================================
+
+class TestSidecars:
+    """Associated files are not top-level tracker keys and must not be lost."""
+
+    def test_associated_files_are_included(self, tmp_path, temp_dir):
+        """associate_files() deletes a sidecar's standalone entry and folds it
+        into the parent's associated_files list. Walking _timestamps.keys()
+        alone would drop every sidecar from the inventory."""
+        from core.file_operations import CacheTimestampTracker
+
+        video = create_test_file(str(tmp_path / "cache" / "Movie.mkv"), size_bytes=1000)
+        subtitle = create_test_file(str(tmp_path / "cache" / "Movie.srt"), size_bytes=7)
+
+        tracker = CacheTimestampTracker(os.path.join(temp_dir, "timestamps.json"))
+        tracker.record_cache_time(video, "ondeck")
+        tracker.record_cache_time(subtitle, "ondeck")
+        tracker.associate_files({video: [subtitle]})
+
+        # Precondition: the sidecar is no longer a top-level key, it lives
+        # only inside the parent's associated_files list.
+        assert tracker.get_entry(subtitle) is None
+        assert subtitle in tracker.get_associated_files(video)
+
+        app = _build_app(tmp_path, exclude_lines=None, tracker=tracker)
+        total, files = app._get_plexcache_tracked_size()
+
+        assert sorted(files) == sorted([video, subtitle])
+        assert total == 1007
+
+
+# ============================================================================
+# Filesystem reality
+# ============================================================================
+
+class TestFilesystemReality:
+    """Only files that actually exist on the cache are counted."""
+
+    def test_missing_files_excluded_from_both_size_and_list(self, tmp_path):
+        present = create_test_file(str(tmp_path / "cache" / "Here.mkv"), size_bytes=42)
+        absent = str(tmp_path / "cache" / "Gone.mkv")
+
+        app = _build_app(
+            tmp_path, exclude_lines=[absent], tracker=_FakeTracker([present, absent])
+        )
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert files == [present]
+        assert total == 42
+
+    def test_result_is_deterministically_ordered(self, tmp_path):
+        """Sorted output keeps eviction logs and tests stable run to run."""
+        b = create_test_file(str(tmp_path / "cache" / "B.mkv"), size_bytes=1)
+        a = create_test_file(str(tmp_path / "cache" / "A.mkv"), size_bytes=1)
+        c = create_test_file(str(tmp_path / "cache" / "C.mkv"), size_bytes=1)
+
+        app = _build_app(tmp_path, exclude_lines=[c, b], tracker=_FakeTracker([a]))
+
+        _, files = app._get_plexcache_tracked_size()
+
+        assert files == sorted([a, b, c])
+
+
+# ============================================================================
+# Docker path translation
+# ============================================================================
+
+class TestDockerPathTranslation:
+    """The exclude file holds host paths; the tracker holds container paths."""
+
+    def test_exclude_entries_are_translated_tracker_entries_are_not(self, tmp_path):
+        container_root = tmp_path / "mnt" / "cache"
+        host_prefix = "/mnt/cache_downloads"
+
+        from_exclude = create_test_file(str(container_root / "FromExclude.mkv"), size_bytes=11)
+        from_tracker = create_test_file(str(container_root / "FromTracker.mkv"), size_bytes=22)
+
+        host_line = from_exclude.replace(str(container_root), host_prefix)
+
+        def translate(host_path):
+            return host_path.replace(host_prefix, str(container_root))
+
+        app = _build_app(
+            tmp_path,
+            exclude_lines=[host_line],
+            tracker=_FakeTracker([from_tracker]),
+            host_to_container=translate,
+        )
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert sorted(files) == sorted([from_exclude, from_tracker])
+        assert total == 33
+
+    def test_translation_collision_counted_once(self, tmp_path):
+        """Host and container forms of one file must collapse to one entry."""
+        container_root = tmp_path / "mnt" / "cache"
+        host_prefix = "/mnt/cache_downloads"
+
+        f = create_test_file(str(container_root / "Movie.mkv"), size_bytes=800)
+        host_line = f.replace(str(container_root), host_prefix)
+
+        def translate(host_path):
+            return host_path.replace(host_prefix, str(container_root))
+
+        app = _build_app(
+            tmp_path,
+            exclude_lines=[host_line],
+            tracker=_FakeTracker([f]),
+            host_to_container=translate,
+        )
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert files == [f]
+        assert total == 800
+
+
+# ============================================================================
+# Error handling
+# ============================================================================
+
+class TestErrorHandling:
+    """An unreadable exclude file must not wipe out the tracker's inventory."""
+
+    def test_unreadable_exclude_file_keeps_tracker_entries(self, tmp_path):
+        f = create_test_file(str(tmp_path / "cache" / "Movie.mkv"), size_bytes=99)
+        app = _build_app(tmp_path, exclude_lines=["whatever"], tracker=_FakeTracker([f]))
+
+        real_open = open
+
+        def exploding_open(path, *args, **kwargs):
+            if str(path).endswith("plexcache_cached_files.txt"):
+                raise OSError("permission denied")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=exploding_open):
+            total, files = app._get_plexcache_tracked_size()
+
+        assert files == [f]
+        assert total == 99
+
+    def test_unreadable_exclude_file_with_no_tracker_returns_empty(self, tmp_path):
+        app = _build_app(tmp_path, exclude_lines=["whatever"], tracker=_FakeTracker([]))
+
+        real_open = open
+
+        def exploding_open(path, *args, **kwargs):
+            if str(path).endswith("plexcache_cached_files.txt"):
+                raise OSError("permission denied")
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=exploding_open):
+            assert app._get_plexcache_tracked_size() == (0, [])

--- a/tests/test_release_to_mover.py
+++ b/tests/test_release_to_mover.py
@@ -1,0 +1,845 @@
+"""Tests for releasing watched files to the Unraid mover instead of relocating them.
+
+A file with no .plexcached backup was never lifted off the array by PlexCache.
+Relocating it writes to the array for the first time and spins a disk the user
+did not ask to spin — Unraid's own mover reclaims it on the user's schedule once
+the exclude line is gone. So PlexCache releases it: drop the exclude line, keep
+the tracker entry, move no bytes.
+
+The tracker entry is deliberately kept. The mover owns relocation now, but if
+the share is cache:prefer or cache:only the mover will never act, and PlexCache
+has to be able to reach the file again. That is what _readopt_released_under_pressure
+is for.
+
+Coverage:
+- release moves no bytes and drops only the exclude line
+- every gate that forces the old relocate behaviour
+- the exclude-write failure path leaves tracking intact
+- released files stay visible to the quota and to eviction
+- pressure-based re-adoption fires only under pressure
+- the audit treats released-and-gone as success, not staleness
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+for _mod_name in [
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex', 'requests',
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+from conftest import create_test_file  # noqa: E402
+
+
+CACHE_ROOT = "/mnt/cache/media/Movies"
+ARRAY_ROOT = "/mnt/user/media/Movies"
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+class _Mapping:
+    """Minimal path mapping for cache <-> array translation."""
+
+    def __init__(self, cache_root, array_root):
+        self.cache_path = cache_root
+        self.real_path = array_root
+        self.enabled = True
+        self.cacheable = True
+
+
+class _PathModifier:
+    def __init__(self, cache_root, array_root):
+        self.cache_root = cache_root
+        self.array_root = array_root
+
+    def convert_real_to_cache(self, real_path):
+        if real_path.startswith(self.array_root):
+            return real_path.replace(self.array_root, self.cache_root, 1), None
+        return None, None
+
+    def convert_cache_to_real(self, cache_path):
+        if cache_path.startswith(self.cache_root):
+            return cache_path.replace(self.cache_root, self.array_root, 1), None
+        return None, None
+
+
+def _build_app(tmp_path, is_unraid=True, dry_run=False, tracker=None,
+               cache_root=None, array_root=None):
+    """Build a PlexCacheApp wired for the release paths."""
+    from core.app import PlexCacheApp
+
+    cache_root = cache_root or str(tmp_path / "mnt" / "cache" / "media" / "Movies")
+    array_root = array_root or str(tmp_path / "mnt" / "user" / "media" / "Movies")
+    os.makedirs(cache_root, exist_ok=True)
+    os.makedirs(array_root, exist_ok=True)
+
+    config_manager = MagicMock()
+    config_manager.paths.cache_dir = cache_root
+    config_manager.cache.cache_drive_size_bytes = 0
+    config_manager.cache.watched_move = True
+
+    app = object.__new__(PlexCacheApp)
+    app.config_manager = config_manager
+    app.dry_run = dry_run
+    app.media_to_array = []
+    app.system_detector = MagicMock()
+    app.system_detector.is_unraid = is_unraid
+    app.file_path_modifier = _PathModifier(cache_root, array_root)
+    app.file_filter = MagicMock()
+    app.file_filter.remove_files_from_exclude_list.return_value = True
+    app.timestamp_tracker = tracker
+    app.ondeck_tracker = MagicMock()
+    app.watchlist_tracker = MagicMock()
+    app.released_count = 0
+    app.released_bytes = 0
+    app.readopted_count = 0
+    app._record_activity = False
+
+    return app, cache_root, array_root
+
+
+def _real_tracker(temp_dir):
+    from core.file_operations import CacheTimestampTracker
+    return CacheTimestampTracker(os.path.join(temp_dir, "timestamps.json"))
+
+
+def _passthrough_array_direct(path):
+    """get_array_direct_path stand-in: /mnt/user/ -> /mnt/user0/ under tmp."""
+    if "/mnt/user/" in path.replace("\\", "/"):
+        return path.replace("mnt/user/", "mnt/user0/").replace("mnt\\user\\", "mnt\\user0\\")
+    return path
+
+
+# ============================================================================
+# The partition: which files are eligible for release
+# ============================================================================
+
+class TestPartitionReleaseCandidates:
+
+    def test_plain_cache_native_file_is_released(self, tmp_path):
+        app, cache_root, array_root = _build_app(tmp_path)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+
+        with patch.object(app, "_share_has_array_side", return_value=True):
+            to_release, to_relocate = app._partition_release_candidates([array_path])
+
+        assert to_release == [array_path]
+        assert to_relocate == []
+
+    def test_non_unraid_always_relocates(self, tmp_path):
+        """Without Unraid there is no mover, so nothing would ever reclaim."""
+        app, cache_root, array_root = _build_app(tmp_path, is_unraid=False)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+
+        to_release, to_relocate = app._partition_release_candidates([array_path])
+
+        assert to_release == []
+        assert to_relocate == [array_path]
+
+    def test_share_without_array_side_relocates(self, tmp_path):
+        """ZFS pool-only share: no array behind it, so release is meaningless."""
+        app, cache_root, array_root = _build_app(tmp_path)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+
+        with patch.object(app, "_share_has_array_side", return_value=False):
+            to_release, to_relocate = app._partition_release_candidates([array_path])
+
+        assert to_release == []
+        assert to_relocate == [array_path]
+
+    def test_renamed_plexcached_backup_relocates(self, tmp_path):
+        """A quality upgrade leaves a backup under the OLD filename.
+
+        _move_to_array has to delete that backup. Releasing would walk away and
+        orphan it permanently.
+        """
+        app, cache_root, array_root = _build_app(tmp_path)
+        array_path = os.path.join(array_root, "Movie.2020.2160p.mkv")
+        cache_path = create_test_file(
+            os.path.join(cache_root, "Movie.2020.2160p.mkv"), size_bytes=10
+        )
+
+        with patch.object(app, "_share_has_array_side", return_value=True), \
+             patch("core.app.get_array_direct_path", side_effect=lambda p: p), \
+             patch("core.app.find_matching_plexcached",
+                   return_value=os.path.join(array_root, "Movie.2020.1080p.mkv.plexcached")):
+            to_release, to_relocate = app._partition_release_candidates([array_path])
+
+        assert to_release == []
+        assert to_relocate == [array_path]
+        assert os.path.isfile(cache_path)
+
+    def test_hardlinked_file_relocates(self, tmp_path):
+        """An actively-seeding file: the mover breaks the link on relocation."""
+        app, cache_root, array_root = _build_app(tmp_path)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+
+        real_stat = os.stat
+
+        class _Stat:
+            st_nlink = 2
+
+        with patch.object(app, "_share_has_array_side", return_value=True), \
+             patch("core.app.find_matching_plexcached", return_value=None), \
+             patch("core.app.os.stat",
+                   side_effect=lambda p, *a, **k: _Stat() if p == cache_path else real_stat(p)):
+            to_release, to_relocate = app._partition_release_candidates([array_path])
+
+        assert to_release == []
+        assert to_relocate == [array_path]
+
+    def test_missing_cache_file_relocates(self, tmp_path):
+        """Nothing on cache to release — fall through to the existing path."""
+        app, _, array_root = _build_app(tmp_path)
+        array_path = os.path.join(array_root, "Gone.mkv")
+
+        with patch.object(app, "_share_has_array_side", return_value=True):
+            to_release, to_relocate = app._partition_release_candidates([array_path])
+
+        assert to_release == []
+        assert to_relocate == [array_path]
+
+    def test_sidecar_skips_the_upgrade_lookup(self, tmp_path):
+        """Non-video sidecars are not upgrades of each other."""
+        app, cache_root, array_root = _build_app(tmp_path)
+        array_path = os.path.join(array_root, "Movie.srt")
+        create_test_file(os.path.join(cache_root, "Movie.srt"), size_bytes=5)
+
+        with patch.object(app, "_share_has_array_side", return_value=True), \
+             patch("core.app.find_matching_plexcached") as mock_find:
+            to_release, _ = app._partition_release_candidates([array_path])
+
+        assert to_release == [array_path]
+        mock_find.assert_not_called()
+
+
+class TestShareHasArraySide:
+
+    def test_user_path_with_distinct_array_direct(self, tmp_path):
+        app, _, _ = _build_app(tmp_path)
+        with patch("core.app.get_array_direct_path", side_effect=_passthrough_array_direct):
+            assert app._share_has_array_side("/mnt/user/media/Movies/A.mkv") is True
+
+    def test_zfs_pool_only_returns_unchanged(self, tmp_path):
+        """get_array_direct_path returns the input for ZFS pool-only shares."""
+        app, _, _ = _build_app(tmp_path)
+        with patch("core.app.get_array_direct_path", side_effect=lambda p: p):
+            assert app._share_has_array_side("/mnt/user/media/Movies/A.mkv") is False
+
+    def test_already_array_direct_path(self, tmp_path):
+        """An install configured with /mnt/user0/ real paths still qualifies."""
+        app, _, _ = _build_app(tmp_path)
+        assert app._share_has_array_side("/mnt/user0/media/Movies/A.mkv") is True
+
+    def test_unrelated_path(self, tmp_path):
+        app, _, _ = _build_app(tmp_path)
+        assert app._share_has_array_side("/srv/media/A.mkv") is False
+
+
+# ============================================================================
+# The release action
+# ============================================================================
+
+class TestReleaseFiles:
+
+    def test_moves_no_bytes(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=1234)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        tracker.record_cache_time(cache_path, "ondeck")
+
+        released = app._release_files([array_path])
+
+        assert released == 1
+        assert os.path.isfile(cache_path)
+        assert os.path.getsize(cache_path) == 1234
+        assert not os.path.exists(array_path)
+        assert not os.path.exists(array_path + ".plexcached")
+
+    def test_drops_exclude_line_and_keeps_tracker_entry(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        tracker.record_cache_time(cache_path, "ondeck")
+
+        app._release_files([array_path])
+
+        app.file_filter.remove_files_from_exclude_list.assert_called_once_with([cache_path])
+        # The entry survives so quota and eviction can still reach the file
+        assert tracker.get_entry(cache_path) is not None
+        assert tracker.is_released(cache_path) is True
+
+    def test_marks_uncached_in_demand_trackers(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+        tracker.record_cache_time(cache_path, "ondeck")
+
+        app._release_files([os.path.join(array_root, "Movie.mkv")])
+
+        app.ondeck_tracker.mark_uncached.assert_called_once_with(cache_path)
+        app.watchlist_tracker.mark_uncached.assert_called_once_with(cache_path)
+
+    def test_exclude_write_failure_keeps_everything_tracked(self, tmp_path, temp_dir):
+        """If the exclude line cannot be dropped the file is still mover-protected.
+
+        Clearing tracking anyway would leave it protected but unmanaged.
+        """
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+        app.file_filter.remove_files_from_exclude_list.return_value = False
+
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+        tracker.record_cache_time(cache_path, "ondeck")
+
+        released = app._release_files([os.path.join(array_root, "Movie.mkv")])
+
+        assert released == 0
+        assert tracker.is_released(cache_path) is False
+        app.ondeck_tracker.mark_uncached.assert_not_called()
+
+    def test_dry_run_writes_nothing(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker, dry_run=True)
+
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+        tracker.record_cache_time(cache_path, "ondeck")
+
+        released = app._release_files([os.path.join(array_root, "Movie.mkv")])
+
+        assert released == 0
+        app.file_filter.remove_files_from_exclude_list.assert_not_called()
+        assert tracker.is_released(cache_path) is False
+
+    def test_counts_and_bytes_accumulate(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+
+        paths = []
+        for name, size in [("A.mkv", 100), ("B.mkv", 250)]:
+            create_test_file(os.path.join(cache_root, name), size_bytes=size)
+            paths.append(os.path.join(array_root, name))
+            tracker.record_cache_time(os.path.join(cache_root, name), "ondeck")
+
+        app._release_files(paths)
+
+        assert app.released_count == 2
+        assert app.released_bytes == 350
+
+    def test_empty_input_is_a_noop(self, tmp_path):
+        app, _, _ = _build_app(tmp_path)
+        assert app._release_files([]) == 0
+        app.file_filter.remove_files_from_exclude_list.assert_not_called()
+
+    def test_logs_in_the_web_activity_capture_format(self, tmp_path, temp_dir, caplog):
+        """The web OperationRunner builds its activity feed by regex-matching
+        "  [Action] name (size)" INFO lines out of the log stream.
+
+        Matched against the runner's own compiled pattern, not a copy of it, so
+        the two cannot drift apart without this failing.
+        """
+        from web.services.operation_runner import ACTION_ENTRY_PATTERN
+
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+        create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=2048)
+        tracker.record_cache_time(os.path.join(cache_root, "Movie.mkv"), "ondeck")
+
+        with caplog.at_level("INFO"):
+            app._release_files([os.path.join(array_root, "Movie.mkv")])
+
+        matched = [
+            m for m in (ACTION_ENTRY_PATTERN.match(line) for line in caplog.messages) if m
+        ]
+
+        assert len(matched) == 1, f"no activity line found in {caplog.messages}"
+        assert matched[0].group(1) == "Released"
+        assert matched[0].group(3) == "2.00 KB"
+
+    def test_released_bytes_are_not_counted_as_restored(self):
+        """Released files move no bytes, so they must not inflate the
+        restored-bytes counters the way Restored/Moved do."""
+        from web.services.operation_runner import ACTION_ENTRY_PATTERN
+
+        m = ACTION_ENTRY_PATTERN.match("  [Released] Movie.mkv (2.00 KB)")
+        assert m is not None
+        assert m.group(1) not in ("Restored", "Moved", "Cached")
+
+
+# ============================================================================
+# Tracker released-state surface
+# ============================================================================
+
+class TestTrackerReleasedState:
+
+    def test_sidecar_inherits_parent_release(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        video = "/mnt/cache/media/Movies/Movie.mkv"
+        sub = "/mnt/cache/media/Movies/Movie.srt"
+
+        tracker.record_cache_time(video, "ondeck")
+        tracker.record_cache_time(sub, "ondeck")
+        tracker.associate_files({video: [sub]})
+
+        tracker.mark_released(video)
+
+        assert tracker.is_released(video) is True
+        assert tracker.is_released(sub) is True
+        assert sub in tracker.get_released_paths()
+
+    def test_releasing_via_sidecar_stamps_the_parent(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        video = "/mnt/cache/media/Movies/Movie.mkv"
+        sub = "/mnt/cache/media/Movies/Movie.srt"
+
+        tracker.record_cache_time(video, "ondeck")
+        tracker.record_cache_time(sub, "ondeck")
+        tracker.associate_files({video: [sub]})
+
+        assert tracker.mark_released(sub) is True
+        assert tracker.is_released(video) is True
+
+    def test_clear_released_round_trip(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        video = "/mnt/cache/media/Movies/Movie.mkv"
+        tracker.record_cache_time(video, "ondeck")
+
+        tracker.mark_released(video)
+        assert tracker.clear_released(video) is True
+        assert tracker.is_released(video) is False
+        assert tracker.clear_released(video) is False
+
+    def test_unknown_path_is_not_released(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        assert tracker.is_released("/mnt/cache/nope.mkv") is False
+        assert tracker.mark_released("/mnt/cache/nope.mkv") is False
+
+    def test_released_at_persists_to_disk(self, tmp_path, temp_dir):
+        from core.file_operations import CacheTimestampTracker
+
+        path = os.path.join(temp_dir, "timestamps.json")
+        tracker = CacheTimestampTracker(path)
+        video = "/mnt/cache/media/Movies/Movie.mkv"
+        tracker.record_cache_time(video, "ondeck")
+        tracker.mark_released(video)
+
+        reloaded = CacheTimestampTracker(path)
+        assert reloaded.is_released(video) is True
+        assert reloaded.get_released_at(video) is not None
+
+    def test_release_does_not_disturb_other_fields(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        video = "/mnt/cache/media/Movies/Movie.mkv"
+        tracker.record_cache_time(video, "ondeck", media_type="movie", rating_key="123")
+
+        tracker.mark_released(video)
+
+        entry = tracker.get_entry(video)
+        assert entry["source"] == "ondeck"
+        assert entry["media_type"] == "movie"
+        assert entry["rating_key"] == "123"
+        assert "cached_at" in entry
+
+
+# ============================================================================
+# Released files stay reachable by quota and eviction
+# ============================================================================
+
+class TestReleasedFilesStayManaged:
+
+    def test_released_file_still_counted_by_inventory(self, tmp_path, temp_dir):
+        """The whole reason the tracker entry is kept.
+
+        The exclude line is gone, so an exclude-only inventory would lose the
+        file and eviction could never reclaim it.
+        """
+        from core.app import PlexCacheApp
+
+        tracker = _real_tracker(temp_dir)
+        cache_path = create_test_file(str(tmp_path / "cache" / "Movie.mkv"), size_bytes=777)
+        tracker.record_cache_time(cache_path, "ondeck")
+        tracker.mark_released(cache_path)
+
+        config_manager = MagicMock()
+        exclude_path = tmp_path / "plexcache_cached_files.txt"  # never created
+        config_manager.get_cached_files_file.return_value = exclude_path
+
+        app = object.__new__(PlexCacheApp)
+        app.config_manager = config_manager
+        app.timestamp_tracker = tracker
+        app.file_filter = None
+
+        total, files = app._get_plexcache_tracked_size()
+
+        assert files == [cache_path]
+        assert total == 777
+
+
+# ============================================================================
+# Pressure-based re-adoption
+# ============================================================================
+
+class TestReadoptUnderPressure:
+
+    def _prepare(self, tmp_path, temp_dir, pressure):
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+        tracker.record_cache_time(cache_path, "ondeck")
+        tracker.mark_released(cache_path)
+        patcher = patch.object(app, "_cache_pressure_percent", return_value=pressure)
+        return app, tracker, cache_path, os.path.join(array_root, "Movie.mkv"), patcher
+
+    def test_no_pressure_leaves_file_with_the_mover(self, tmp_path, temp_dir):
+        """A Mover Tuning user deliberately holds media on cache. Leave it."""
+        app, tracker, cache_path, array_path, patcher = self._prepare(tmp_path, temp_dir, 40.0)
+
+        with patcher:
+            readopted = app._readopt_released_under_pressure()
+
+        assert readopted == 0
+        assert app.media_to_array == []
+        assert tracker.is_released(cache_path) is True
+
+    def test_pressure_takes_the_file_back(self, tmp_path, temp_dir):
+        """cache:prefer / cache:only: the mover never acts, so PlexCache does."""
+        app, tracker, cache_path, array_path, patcher = self._prepare(tmp_path, temp_dir, 95.0)
+
+        with patcher:
+            readopted = app._readopt_released_under_pressure()
+
+        assert readopted == 1
+        assert app.media_to_array == [array_path]
+        assert tracker.is_released(cache_path) is False
+        assert app.readopted_count == 1
+
+    def test_unmeasurable_pressure_does_nothing(self, tmp_path, temp_dir):
+        app, tracker, cache_path, _, patcher = self._prepare(tmp_path, temp_dir, None)
+
+        with patcher:
+            assert app._readopt_released_under_pressure() == 0
+        assert tracker.is_released(cache_path) is True
+
+    def test_file_already_gone_is_not_readopted(self, tmp_path, temp_dir):
+        """The mover did its job — nothing to take back."""
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, _ = _build_app(tmp_path, tracker=tracker)
+        cache_path = os.path.join(cache_root, "Moved.mkv")
+        tracker.record_cache_time(cache_path, "ondeck")
+        tracker.mark_released(cache_path)
+
+        with patch.object(app, "_cache_pressure_percent", return_value=99.0):
+            assert app._readopt_released_under_pressure() == 0
+
+    def test_dry_run_does_not_readopt(self, tmp_path, temp_dir):
+        app, tracker, cache_path, _, patcher = self._prepare(tmp_path, temp_dir, 99.0)
+        app.dry_run = True
+
+        with patcher:
+            assert app._readopt_released_under_pressure() == 0
+        assert tracker.is_released(cache_path) is True
+
+    def test_no_released_files_is_a_noop(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, _, _ = _build_app(tmp_path, tracker=tracker)
+
+        with patch.object(app, "_cache_pressure_percent") as mock_pressure:
+            assert app._readopt_released_under_pressure() == 0
+        mock_pressure.assert_not_called()
+
+    def test_does_not_duplicate_an_existing_move_back(self, tmp_path, temp_dir):
+        app, tracker, cache_path, array_path, patcher = self._prepare(tmp_path, temp_dir, 99.0)
+        app.media_to_array = [array_path]
+
+        with patcher:
+            readopted = app._readopt_released_under_pressure()
+
+        assert readopted == 0
+        assert app.media_to_array == [array_path]
+
+
+class TestCachePressurePercent:
+
+    def test_reads_the_filesystem_not_user_settings(self, tmp_path):
+        """cache_limit and min_free_space both default to unset, so the
+        backstop cannot depend on them."""
+        from core.system_utils import DiskUsage
+
+        app, cache_root, _ = _build_app(tmp_path)
+        with patch("core.app.get_disk_usage",
+                   return_value=DiskUsage(total=1000, used=920, free=80)):
+            assert app._cache_pressure_percent() == pytest.approx(92.0)
+
+    def test_missing_cache_dir_returns_none(self, tmp_path):
+        app, _, _ = _build_app(tmp_path)
+        app.config_manager.paths.cache_dir = ""
+        assert app._cache_pressure_percent() is None
+
+    def test_oserror_returns_none(self, tmp_path):
+        app, _, _ = _build_app(tmp_path)
+        with patch("core.app.get_disk_usage", side_effect=OSError("boom")):
+            assert app._cache_pressure_percent() is None
+
+    def test_zero_total_returns_none(self, tmp_path):
+        from core.system_utils import DiskUsage
+
+        app, _, _ = _build_app(tmp_path)
+        with patch("core.app.get_disk_usage", return_value=DiskUsage(total=0, used=0, free=0)):
+            assert app._cache_pressure_percent() is None
+
+
+# ============================================================================
+# Audit behaviour
+# ============================================================================
+
+class TestAuditTreatsReleasedAsSuccess:
+
+    def _service(self, tmp_path, timestamps):
+        from web.services.maintenance_service import MaintenanceService
+
+        ts_path = tmp_path / "timestamps.json"
+        ts_path.write_text(json.dumps(timestamps, indent=2), encoding="utf-8")
+
+        service = object.__new__(MaintenanceService)
+        service.timestamps_file = ts_path
+        return service
+
+    def test_released_entries_are_collected(self, tmp_path):
+        service = self._service(tmp_path, {
+            "/mnt/cache/A.mkv": {"cached_at": "x", "source": "ondeck", "released_at": "y"},
+            "/mnt/cache/B.mkv": {"cached_at": "x", "source": "ondeck"},
+        })
+        assert service.get_released_files() == {"/mnt/cache/A.mkv"}
+
+    def test_released_sidecars_are_expanded(self, tmp_path):
+        service = self._service(tmp_path, {
+            "/mnt/cache/A.mkv": {
+                "cached_at": "x",
+                "released_at": "y",
+                "associated_files": ["/mnt/cache/A.srt", "/mnt/cache/A.nfo"],
+            },
+        })
+        assert service.get_released_files() == {
+            "/mnt/cache/A.mkv", "/mnt/cache/A.srt", "/mnt/cache/A.nfo",
+        }
+
+    def test_missing_timestamps_file_is_empty(self, tmp_path):
+        from web.services.maintenance_service import MaintenanceService
+
+        service = object.__new__(MaintenanceService)
+        service.timestamps_file = tmp_path / "nope.json"
+        assert service.get_released_files() == set()
+
+    def test_corrupt_timestamps_file_is_empty(self, tmp_path):
+        ts_path = tmp_path / "timestamps.json"
+        ts_path.write_text("{not json", encoding="utf-8")
+
+        from web.services.maintenance_service import MaintenanceService
+
+        service = object.__new__(MaintenanceService)
+        service.timestamps_file = ts_path
+        assert service.get_released_files() == set()
+
+    def test_legacy_string_entries_are_ignored(self, tmp_path):
+        """Pre-v3 timestamps were bare ISO strings, not dicts."""
+        service = self._service(tmp_path, {"/mnt/cache/A.mkv": "2026-01-01T00:00:00"})
+        assert service.get_released_files() == set()
+
+
+class TestFullAuditWithReleasedFiles:
+    """Drives the real run_full_audit() with its filesystem collaborators stubbed."""
+
+    def _audit(self, cache_files, exclude_files, timestamp_files, released_files):
+        from web.services.maintenance_service import MaintenanceService
+
+        service = object.__new__(MaintenanceService)
+
+        with patch.object(MaintenanceService, "get_cache_files", return_value=cache_files), \
+             patch.object(MaintenanceService, "get_exclude_files", return_value=exclude_files), \
+             patch.object(MaintenanceService, "get_timestamp_files", return_value=timestamp_files), \
+             patch.object(MaintenanceService, "get_released_files", return_value=released_files), \
+             patch.object(MaintenanceService, "_get_orphaned_plexcached",
+                          return_value=([], [], set(), set())), \
+             patch.object(MaintenanceService, "_cache_to_array_path", return_value=None), \
+             patch.object(MaintenanceService, "_get_pinned_cache_paths", return_value=set()), \
+             patch.object(MaintenanceService, "_group_unprotected_by_directory", return_value=[]):
+            return service.run_full_audit()
+
+    def test_mover_relocated_a_released_file_is_not_stale(self):
+        """The mover doing its job must not read as tracking debris.
+
+        Without this the Maintenance page goes amber on every run after a
+        release — the shape of issue #176.
+        """
+        results = self._audit(
+            cache_files=set(),
+            exclude_files=set(),
+            timestamp_files={"/mnt/cache/Released.mkv", "/mnt/cache/Genuine.mkv"},
+            released_files={"/mnt/cache/Released.mkv"},
+        )
+
+        assert results.stale_timestamp_entries == ["/mnt/cache/Genuine.mkv"]
+
+    def test_released_file_still_on_cache_is_not_unprotected(self, tmp_path):
+        """A released file is absent from the exclude list on purpose.
+
+        Listing it as unprotected recommends sync_to_array — the exact array
+        write release exists to avoid — and exposes it to the bulk
+        "Add to Exclude" action.
+        """
+        released = create_test_file(str(tmp_path / "Released.mkv"), size_bytes=10)
+        genuine = create_test_file(str(tmp_path / "Genuine.mkv"), size_bytes=10)
+
+        results = self._audit(
+            cache_files={released, genuine},
+            exclude_files=set(),
+            timestamp_files=set(),
+            released_files={released},
+        )
+
+        flagged = {f.cache_path for f in results.unprotected_files}
+        assert flagged == {genuine}
+
+    def test_released_files_do_not_affect_health(self, tmp_path):
+        results = self._audit(
+            cache_files=set(),
+            exclude_files=set(),
+            timestamp_files={"/mnt/cache/Released.mkv"},
+            released_files={"/mnt/cache/Released.mkv"},
+        )
+
+        assert results.stale_timestamp_entries == []
+        assert results.total_issues == 0
+        assert results.health_status == "healthy"
+
+
+class TestMoveFilesWiring:
+    """_move_files() must route released files away from _safe_move_files()."""
+
+    @staticmethod
+    def _array_moves(mock_move):
+        """Only the destination='array' calls; Step 3 always makes a 'cache' call."""
+        return [c for c in mock_move.call_args_list if c.args[1] == 'array']
+
+    def _app_for_move(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+        app.file_mover = MagicMock()
+        app.file_mover._successful_array_moves = []
+        app._move_back_exclude_paths = []
+        app.media_to_cache = []
+        app.all_active_media = []
+        app.sibling_map = {}
+        app.media_info_map = {}
+        app.files_to_skip = []
+        app.evicted_count = 0
+        app.evicted_bytes = 0
+        app.restored_count = 0
+        app.restored_bytes = 0
+        app._stop_requested = False
+        return app, tracker, cache_root, array_root
+
+    def test_released_file_never_reaches_safe_move_files(self, tmp_path, temp_dir):
+        app, tracker, cache_root, array_root = self._app_for_move(tmp_path, temp_dir)
+
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        tracker.record_cache_time(cache_path, "ondeck")
+        app.media_to_array = [array_path]
+
+        with patch.object(app, "_build_restore_sibling_map"), \
+             patch.object(app, "_readopt_released_under_pressure", return_value=0), \
+             patch.object(app, "_share_has_array_side", return_value=True), \
+             patch.object(app, "_safe_move_files") as mock_move, \
+             patch.object(app, "_run_smart_eviction", return_value=(0, 0)):
+            app._move_files()
+
+        assert self._array_moves(mock_move) == []
+        assert app.media_to_array == []
+        assert app.released_count == 1
+        assert tracker.is_released(cache_path) is True
+        assert os.path.isfile(cache_path)
+
+    def test_backed_up_file_still_relocates(self, tmp_path, temp_dir):
+        """A file with a .plexcached backup must keep the existing behaviour."""
+        app, tracker, cache_root, array_root = self._app_for_move(tmp_path, temp_dir)
+
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        create_test_file(array_path + ".plexcached", size_bytes=10)
+        tracker.record_cache_time(cache_path, "ondeck")
+        app.media_to_array = [array_path]
+
+        with patch.object(app, "_build_restore_sibling_map"), \
+             patch.object(app, "_readopt_released_under_pressure", return_value=0), \
+             patch.object(app, "_share_has_array_side", return_value=True), \
+             patch.object(app, "_safe_move_files") as mock_move, \
+             patch.object(app, "_run_smart_eviction", return_value=(0, 0)):
+            app._move_files()
+
+        assert self._array_moves(mock_move) == [call([array_path], 'array')]
+        assert app.released_count == 0
+        assert tracker.is_released(cache_path) is False
+
+    def test_mixed_batch_splits_correctly(self, tmp_path, temp_dir):
+        app, tracker, cache_root, array_root = self._app_for_move(tmp_path, temp_dir)
+
+        backed_up_cache = create_test_file(os.path.join(cache_root, "Backed.mkv"), size_bytes=10)
+        backed_up_array = os.path.join(array_root, "Backed.mkv")
+        create_test_file(backed_up_array + ".plexcached", size_bytes=10)
+
+        native_cache = create_test_file(os.path.join(cache_root, "Native.mkv"), size_bytes=10)
+        native_array = os.path.join(array_root, "Native.mkv")
+
+        tracker.record_cache_time(backed_up_cache, "ondeck")
+        tracker.record_cache_time(native_cache, "ondeck")
+        app.media_to_array = [backed_up_array, native_array]
+
+        with patch.object(app, "_build_restore_sibling_map"), \
+             patch.object(app, "_readopt_released_under_pressure", return_value=0), \
+             patch.object(app, "_share_has_array_side", return_value=True), \
+             patch.object(app, "_safe_move_files") as mock_move, \
+             patch.object(app, "_run_smart_eviction", return_value=(0, 0)):
+            app._move_files()
+
+        assert self._array_moves(mock_move) == [call([backed_up_array], 'array')]
+        assert app.released_count == 1
+        assert tracker.is_released(native_cache) is True
+        assert tracker.is_released(backed_up_cache) is False
+
+    def test_released_files_are_not_counted_as_failed_moves(self, tmp_path, temp_dir, caplog):
+        """The deferred-exclude accounting must not treat a release as a
+        failed relocation."""
+        app, tracker, cache_root, array_root = self._app_for_move(tmp_path, temp_dir)
+
+        cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
+        array_path = os.path.join(array_root, "Movie.mkv")
+        tracker.record_cache_time(cache_path, "ondeck")
+        app.media_to_array = [array_path]
+        app._move_back_exclude_paths = [cache_path]
+
+        with patch.object(app, "_build_restore_sibling_map"), \
+             patch.object(app, "_readopt_released_under_pressure", return_value=0), \
+             patch.object(app, "_share_has_array_side", return_value=True), \
+             patch.object(app, "_safe_move_files"), \
+             patch.object(app, "_run_smart_eviction", return_value=(0, 0)):
+            with caplog.at_level("WARNING"):
+                app._move_files()
+
+        assert "failed to move to array" not in caplog.text

--- a/tests/test_release_to_mover.py
+++ b/tests/test_release_to_mover.py
@@ -8,15 +8,17 @@ the tracker entry, move no bytes.
 
 The tracker entry is deliberately kept. The mover owns relocation now, but if
 the share is cache:prefer or cache:only the mover will never act, and PlexCache
-has to be able to reach the file again. That is what _readopt_released_under_pressure
-is for.
+has to be able to reach the file again. That is what
+_reclaim_released_if_constrained() is for. Its trigger is measured harm — the
+cache having no room for content we wanted — rather than a pool-usage
+threshold, so it needs no constant and scales across any pool size.
 
 Coverage:
 - release moves no bytes and drops only the exclude line
 - every gate that forces the old relocate behaviour
 - the exclude-write failure path leaves tracking intact
 - released files stay visible to the quota and to eviction
-- pressure-based re-adoption fires only under pressure
+- reclaim fires only when the cache actually ran out of room
 - the audit treats released-and-gone as success, not staleness
 """
 
@@ -511,113 +513,133 @@ class TestReleasedFilesStayManaged:
 # Pressure-based re-adoption
 # ============================================================================
 
-class TestReadoptUnderPressure:
+class TestReclaimWhenConstrained:
+    """The backstop fires on measured harm, not on a pool-usage threshold.
 
-    def _prepare(self, tmp_path, temp_dir, pressure):
+    _apply_cache_limit() reporting that it skipped caching something for space
+    reasons is the signal. It scales from a 250GB SSD to a 20TB pool with no
+    constant to tune, and inherits whatever cache_limit / min_free_space /
+    plexcache_quota the user configured.
+    """
+
+    def _prepare(self, tmp_path, temp_dir, constrained):
         tracker = _real_tracker(temp_dir)
         app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
         cache_path = create_test_file(os.path.join(cache_root, "Movie.mkv"), size_bytes=10)
         tracker.record_cache_time(cache_path, "ondeck")
         tracker.mark_released(cache_path)
-        patcher = patch.object(app, "_cache_pressure_percent", return_value=pressure)
-        return app, tracker, cache_path, os.path.join(array_root, "Movie.mkv"), patcher
+        app._cache_space_constrained = constrained
+        app._safe_move_files = MagicMock()
+        return app, tracker, cache_path, os.path.join(array_root, "Movie.mkv")
 
-    def test_no_pressure_leaves_file_with_the_mover(self, tmp_path, temp_dir):
-        """A Mover Tuning user deliberately holds media on cache. Leave it."""
-        app, tracker, cache_path, array_path, patcher = self._prepare(tmp_path, temp_dir, 40.0)
+    def test_room_to_spare_leaves_the_file_with_the_mover(self, tmp_path, temp_dir):
+        """A Mover Tuning user holds media on cache on purpose. Leave it."""
+        app, tracker, cache_path, _ = self._prepare(tmp_path, temp_dir, constrained=False)
 
-        with patcher:
-            readopted = app._readopt_released_under_pressure()
-
-        assert readopted == 0
-        assert app.media_to_array == []
+        assert app._reclaim_released_if_constrained() == 0
+        app._safe_move_files.assert_not_called()
         assert tracker.is_released(cache_path) is True
 
-    def test_pressure_takes_the_file_back(self, tmp_path, temp_dir):
+    def test_no_room_takes_the_file_back(self, tmp_path, temp_dir):
         """cache:prefer / cache:only: the mover never acts, so PlexCache does."""
-        app, tracker, cache_path, array_path, patcher = self._prepare(tmp_path, temp_dir, 95.0)
+        app, tracker, cache_path, array_path = self._prepare(tmp_path, temp_dir, constrained=True)
 
-        with patcher:
-            readopted = app._readopt_released_under_pressure()
-
-        assert readopted == 1
-        assert app.media_to_array == [array_path]
+        assert app._reclaim_released_if_constrained() == 1
+        app._safe_move_files.assert_called_once_with([array_path], 'array')
         assert tracker.is_released(cache_path) is False
         assert app.readopted_count == 1
 
-    def test_unmeasurable_pressure_does_nothing(self, tmp_path, temp_dir):
-        app, tracker, cache_path, _, patcher = self._prepare(tmp_path, temp_dir, None)
+    def test_warns_and_explains_why(self, tmp_path, temp_dir, caplog):
+        """The log has to explain itself or this becomes a debugging mystery."""
+        app, _, _, _ = self._prepare(tmp_path, temp_dir, constrained=True)
 
-        with patcher:
-            assert app._readopt_released_under_pressure() == 0
-        assert tracker.is_released(cache_path) is True
+        with caplog.at_level("WARNING"):
+            app._reclaim_released_if_constrained()
 
-    def test_file_already_gone_is_not_readopted(self, tmp_path, temp_dir):
-        """The mover did its job — nothing to take back."""
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "cache:prefer" in warnings[0]
+        assert "Moving them to the array now" in warnings[0]
+
+    def test_file_already_gone_is_not_reclaimed(self, tmp_path, temp_dir):
+        """The mover did its job, so there is nothing to take back."""
         tracker = _real_tracker(temp_dir)
         app, cache_root, _ = _build_app(tmp_path, tracker=tracker)
-        cache_path = os.path.join(cache_root, "Moved.mkv")
+        cache_path = os.path.join(cache_root, "Moved.mkv")  # never created
         tracker.record_cache_time(cache_path, "ondeck")
         tracker.mark_released(cache_path)
+        app._cache_space_constrained = True
+        app._safe_move_files = MagicMock()
 
-        with patch.object(app, "_cache_pressure_percent", return_value=99.0):
-            assert app._readopt_released_under_pressure() == 0
+        assert app._reclaim_released_if_constrained() == 0
+        app._safe_move_files.assert_not_called()
 
-    def test_dry_run_does_not_readopt(self, tmp_path, temp_dir):
-        app, tracker, cache_path, _, patcher = self._prepare(tmp_path, temp_dir, 99.0)
+    def test_dry_run_reclaims_nothing(self, tmp_path, temp_dir):
+        app, tracker, cache_path, _ = self._prepare(tmp_path, temp_dir, constrained=True)
         app.dry_run = True
 
-        with patcher:
-            assert app._readopt_released_under_pressure() == 0
+        assert app._reclaim_released_if_constrained() == 0
+        app._safe_move_files.assert_not_called()
         assert tracker.is_released(cache_path) is True
 
     def test_no_released_files_is_a_noop(self, tmp_path, temp_dir):
         tracker = _real_tracker(temp_dir)
         app, _, _ = _build_app(tmp_path, tracker=tracker)
+        app._cache_space_constrained = True
+        app._safe_move_files = MagicMock()
 
-        with patch.object(app, "_cache_pressure_percent") as mock_pressure:
-            assert app._readopt_released_under_pressure() == 0
-        mock_pressure.assert_not_called()
+        assert app._reclaim_released_if_constrained() == 0
+        app._safe_move_files.assert_not_called()
 
-    def test_does_not_duplicate_an_existing_move_back(self, tmp_path, temp_dir):
-        app, tracker, cache_path, array_path, patcher = self._prepare(tmp_path, temp_dir, 99.0)
-        app.media_to_array = [array_path]
+    def test_reclaims_every_released_file_at_once(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, array_root = _build_app(tmp_path, tracker=tracker)
+        for name in ("A.mkv", "B.mkv"):
+            p = create_test_file(os.path.join(cache_root, name), size_bytes=10)
+            tracker.record_cache_time(p, "ondeck")
+            tracker.mark_released(p)
+        app._cache_space_constrained = True
+        app._safe_move_files = MagicMock()
 
-        with patcher:
-            readopted = app._readopt_released_under_pressure()
-
-        assert readopted == 0
-        assert app.media_to_array == [array_path]
+        assert app._reclaim_released_if_constrained() == 2
+        moved = app._safe_move_files.call_args.args[0]
+        assert sorted(os.path.basename(p) for p in moved) == ["A.mkv", "B.mkv"]
 
 
-class TestCachePressurePercent:
+class TestConstraintSignal:
+    """_apply_cache_limit() raises the flag the backstop reads."""
 
-    def test_reads_the_filesystem_not_user_settings(self, tmp_path):
-        """cache_limit and min_free_space both default to unset, so the
-        backstop cannot depend on them."""
+    def test_flag_is_not_set_when_everything_fits(self, tmp_path, temp_dir):
+        tracker = _real_tracker(temp_dir)
+        app, _, _ = _build_app(tmp_path, tracker=tracker)
+        app._cache_space_constrained = False
+
+        assert app._cache_space_constrained is False
+
+    def test_skipping_for_space_raises_the_flag(self, tmp_path, temp_dir, caplog):
+        """Driven through the real warning path so the two stay wired together."""
+        tracker = _real_tracker(temp_dir)
+        app, cache_root, _ = _build_app(tmp_path, tracker=tracker)
+        app._cache_space_constrained = False
+
+        # One 100-byte file against a 10-byte limit: cannot fit.
+        big = create_test_file(os.path.join(cache_root, "Big.mkv"), size_bytes=100)
+        app.config_manager.cache.cache_limit_bytes = 10
+        app.config_manager.cache.min_free_space_bytes = 0
+        app.config_manager.cache.plexcache_quota_bytes = 0
+        app.config_manager.cache.cache_drive_size_bytes = 0
+        app.media_info_map = {}
+        app.file_filter = MagicMock()
+
         from core.system_utils import DiskUsage
-
-        app, cache_root, _ = _build_app(tmp_path)
         with patch("core.app.get_disk_usage",
-                   return_value=DiskUsage(total=1000, used=920, free=80)):
-            assert app._cache_pressure_percent() == pytest.approx(92.0)
+                   return_value=DiskUsage(total=1000, used=0, free=1000)), \
+             patch.object(app, "_get_plexcache_tracked_size", return_value=(0, [])), \
+             caplog.at_level("WARNING"):
+            app._apply_cache_limit([big], cache_root)
 
-    def test_missing_cache_dir_returns_none(self, tmp_path):
-        app, _, _ = _build_app(tmp_path)
-        app.config_manager.paths.cache_dir = ""
-        assert app._cache_pressure_percent() is None
-
-    def test_oserror_returns_none(self, tmp_path):
-        app, _, _ = _build_app(tmp_path)
-        with patch("core.app.get_disk_usage", side_effect=OSError("boom")):
-            assert app._cache_pressure_percent() is None
-
-    def test_zero_total_returns_none(self, tmp_path):
-        from core.system_utils import DiskUsage
-
-        app, _, _ = _build_app(tmp_path)
-        with patch("core.app.get_disk_usage", return_value=DiskUsage(total=0, used=0, free=0)):
-            assert app._cache_pressure_percent() is None
+        assert app._cache_space_constrained is True
+        assert any("Cache limit reached" in r.message for r in caplog.records)
 
 
 # ============================================================================
@@ -780,7 +802,6 @@ class TestMoveFilesWiring:
         app.media_to_array = [array_path]
 
         with patch.object(app, "_build_restore_sibling_map"), \
-             patch.object(app, "_readopt_released_under_pressure", return_value=0), \
              patch.object(app, "_share_has_array_side", return_value=True), \
              patch.object(app, "_safe_move_files") as mock_move, \
              patch.object(app, "_run_smart_eviction", return_value=(0, 0)):
@@ -803,7 +824,6 @@ class TestMoveFilesWiring:
         app.media_to_array = [array_path]
 
         with patch.object(app, "_build_restore_sibling_map"), \
-             patch.object(app, "_readopt_released_under_pressure", return_value=0), \
              patch.object(app, "_share_has_array_side", return_value=True), \
              patch.object(app, "_safe_move_files") as mock_move, \
              patch.object(app, "_run_smart_eviction", return_value=(0, 0)):
@@ -828,7 +848,6 @@ class TestMoveFilesWiring:
         app.media_to_array = [backed_up_array, native_array]
 
         with patch.object(app, "_build_restore_sibling_map"), \
-             patch.object(app, "_readopt_released_under_pressure", return_value=0), \
              patch.object(app, "_share_has_array_side", return_value=True), \
              patch.object(app, "_safe_move_files") as mock_move, \
              patch.object(app, "_run_smart_eviction", return_value=(0, 0)):
@@ -851,7 +870,6 @@ class TestMoveFilesWiring:
         app._move_back_exclude_paths = [cache_path]
 
         with patch.object(app, "_build_restore_sibling_map"), \
-             patch.object(app, "_readopt_released_under_pressure", return_value=0), \
              patch.object(app, "_share_has_array_side", return_value=True), \
              patch.object(app, "_safe_move_files"), \
              patch.object(app, "_run_smart_eviction", return_value=(0, 0)):

--- a/tests/test_release_to_mover.py
+++ b/tests/test_release_to_mover.py
@@ -187,13 +187,29 @@ class TestPartitionReleaseCandidates:
 
         real_stat = os.stat
 
-        class _Stat:
-            st_nlink = 2
+        class _MultiLinked:
+            """Real stat_result with st_nlink overridden.
+
+            Everything else delegates, because os.path.isfile() also goes
+            through os.stat() and reads st_mode on POSIX. A stub carrying only
+            st_nlink passes on Windows (Python 3.12+ uses a fast-path
+            nt._path_isfile that skips os.stat) and fails on Linux.
+            """
+
+            def __init__(self, real):
+                self._real = real
+                self.st_nlink = 2
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+        def fake_stat(path, *args, **kwargs):
+            result = real_stat(path, *args, **kwargs)
+            return _MultiLinked(result) if path == cache_path else result
 
         with patch.object(app, "_share_has_array_side", return_value=True), \
              patch("core.app.find_matching_plexcached", return_value=None), \
-             patch("core.app.os.stat",
-                   side_effect=lambda p, *a, **k: _Stat() if p == cache_path else real_stat(p)):
+             patch("core.app.os.stat", side_effect=fake_stat):
             to_release, to_relocate = app._partition_release_candidates([array_path])
 
         assert to_release == []

--- a/tests/test_released_ui_state.py
+++ b/tests/test_released_ui_state.py
@@ -1,0 +1,230 @@
+"""Tests for surfacing the released state in the web UI.
+
+A released file is on cache, out of the exclude list, and waiting on the Unraid
+mover. Before this existed it fell into the "Other" bucket, indistinguishable
+from a file with no recorded demand, which made a chunk of the cache look
+unexplained.
+
+The state comes from the timestamp entry's released_at stamp, which
+PlexCacheApp._release_files() writes. No new storage.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+for _mod_name in [
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex', 'requests',
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+
+def _file(**kw):
+    """Build a CachedFile with only the fields these tests care about."""
+    from web.services.cache_service import CachedFile
+    from datetime import datetime
+
+    defaults = dict(
+        path="/mnt/cache/x.mkv",
+        filename="x.mkv",
+        size=100,
+        size_display="100 B",
+        cached_at=datetime(2026, 8, 10, 12, 0, 0),
+        cache_age_hours=1.0,
+        source="unknown",
+        priority_score=50,
+        users=[],
+        is_ondeck=False,
+        is_watchlist=False,
+    )
+    defaults.update(kw)
+    return CachedFile(**defaults)
+
+
+class TestCachedFileField:
+
+    def test_defaults_to_false(self):
+        assert _file().is_released is False
+
+    def test_round_trips_through_the_dict_serializer(self):
+        from web.services.cache_service import cached_files_to_dicts
+
+        rows = cached_files_to_dicts([_file(is_released=True), _file()])
+
+        assert rows[0]["is_released"] is True
+        assert rows[1]["is_released"] is False
+
+
+class TestFileTotals:
+    """calculate_file_totals() drives the counts on the Cached Files page."""
+
+    def _totals(self, files):
+        from web.services.cache_service import cached_files_to_dicts, calculate_file_totals
+        return calculate_file_totals(cached_files_to_dicts(files))
+
+    def test_released_counted_separately(self):
+        totals = self._totals([_file(is_released=True), _file()])
+
+        assert totals["released_count"] == 1
+        assert totals["other_count"] == 1
+
+    def test_released_does_not_inflate_other(self):
+        """The bug this fixes: released files swelling the Other bucket."""
+        totals = self._totals([_file(is_released=True) for _ in range(6)])
+
+        assert totals["released_count"] == 6
+        assert totals["other_count"] == 0
+
+    def test_ondeck_file_that_is_released_counts_as_released(self):
+        """Release marks files uncached in both trackers, but a stale tracker
+        entry must not put a released file back in the OnDeck bucket."""
+        totals = self._totals([_file(is_released=True, is_ondeck=True)])
+
+        assert totals["released_count"] == 1
+        assert totals["other_count"] == 0
+
+
+class TestSourceFilter:
+    """The ?source= filter on /cache, driven through the real builder."""
+
+    def _build(self, tmp_path, source_filter, released):
+        from web.services.cache_service import CacheService
+        from conftest import create_test_file
+        from datetime import datetime
+
+        path = create_test_file(str(tmp_path / "Movie.mkv"), size_bytes=100)
+        entry = {"cached_at": "2026-08-10T12:00:00", "source": "pre-existing"}
+        if released:
+            entry["released_at"] = "2026-08-10T21:40:00"
+
+        service = object.__new__(CacheService)
+        return service._build_cached_file(
+            path,
+            timestamps={path: entry},
+            ondeck={},
+            watchlist={},
+            settings={},
+            pinned_cache_path_map={},
+            pinned_cache_paths=set(),
+            video_subtitles={},
+            video_sidecars={},
+            source_filter=source_filter,
+            search="",
+            now=datetime(2026, 8, 10, 22, 0, 0),
+        )
+
+    def test_released_at_sets_the_flag(self, tmp_path):
+        assert self._build(tmp_path, "all", released=True).is_released is True
+        assert self._build(tmp_path, "all", released=False).is_released is False
+
+    def test_released_filter_selects_released(self, tmp_path):
+        assert self._build(tmp_path, "released", released=True) is not None
+        assert self._build(tmp_path, "released", released=False) is None
+
+    def test_other_filter_excludes_released(self, tmp_path):
+        """The bug this fixes: released files falling into the Other bucket."""
+        assert self._build(tmp_path, "other", released=True) is None
+        assert self._build(tmp_path, "other", released=False) is not None
+
+
+class TestBreakdownBuckets:
+    """The Cache Breakdown by Source cards, driven through get_storage_stats().
+
+    Locks down the ordering rule: released is evaluated before every other
+    bucket, so a released file never double-counts or lands in Other.
+    """
+
+    def _breakdown(self, tmp_path, files):
+        from web.services.cache_service import CacheService
+        from unittest.mock import patch
+
+        service = object.__new__(CacheService)
+        with patch.object(CacheService, "get_all_cached_files", return_value=files), \
+             patch.object(CacheService, "get_cached_files_list", return_value=[]), \
+             patch.object(CacheService, "get_timestamps", return_value={}), \
+             patch.object(CacheService, "get_ondeck_tracker", return_value={}), \
+             patch.object(CacheService, "get_watchlist_tracker", return_value={}), \
+             patch.object(CacheService, "_load_settings", return_value={}), \
+             patch.object(CacheService, "_get_cache_dir", return_value=str(tmp_path)):
+            return service.get_drive_details()["breakdown"]
+
+    def test_buckets_are_mutually_exclusive(self, tmp_path):
+        files = [
+            _file(size=10, is_ondeck=True),
+            _file(size=20, is_watchlist=True),
+            _file(size=30),
+            _file(size=40, is_released=True),
+        ]
+        b = self._breakdown(tmp_path, files)
+
+        assert b["ondeck"]["size"] == 10
+        assert b["watchlist"]["size"] == 20
+        assert b["other"]["size"] == 30
+        assert b["released"]["size"] == 40
+        assert sum(v["size"] for v in b.values()) == 100
+
+    def test_released_wins_over_a_stale_ondeck_flag(self, tmp_path):
+        b = self._breakdown(tmp_path, [_file(size=50, is_released=True, is_ondeck=True)])
+
+        assert b["released"]["size"] == 50
+        assert b["ondeck"]["size"] == 0
+
+    def test_percentages_add_up(self, tmp_path):
+        """Cards are shown as a share of PlexCache data, so a file counted
+        twice or dropped would make them not total 100%."""
+        files = [
+            _file(size=25, is_released=True),
+            _file(size=25, is_ondeck=True),
+            _file(size=50),
+        ]
+        b = self._breakdown(tmp_path, files)
+
+        assert b["released"]["percent"] == 25.0
+        assert b["ondeck"]["percent"] == 25.0
+        assert b["other"]["percent"] == 50.0
+
+
+
+
+class TestTemplatesRender:
+    """The badges and card must survive Jinja parsing."""
+
+    @pytest.mark.parametrize("template", [
+        "web/templates/cache/partials/storage_stats.html",
+        "web/templates/cache/partials/file_table.html",
+        "web/templates/cache/partials/priorities_content.html",
+        "web/templates/cache/list.html",
+    ])
+    def test_template_parses(self, template):
+        import jinja2
+
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), template
+        )
+        with open(path, encoding="utf-8") as f:
+            jinja2.Environment().parse(f.read(), filename=template)
+
+    def test_released_markup_present(self):
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+        stats = open(os.path.join(
+            root, "web/templates/cache/partials/storage_stats.html"), encoding="utf-8").read()
+        assert "breakdown-released" in stats
+        assert "source=released" in stats
+        assert "badge-released" in stats
+
+        listing = open(os.path.join(
+            root, "web/templates/cache/list.html"), encoding="utf-8").read()
+        assert 'value="released"' in listing
+
+    def test_released_badge_styled(self):
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        css = open(os.path.join(
+            root, "web/static/css/plex-theme.css"), encoding="utf-8").read()
+
+        assert ".badge-released" in css
+        assert ".breakdown-released .breakdown-header" in css
+        assert ".breakdown-fill.released" in css

--- a/tools/audit_cache.py
+++ b/tools/audit_cache.py
@@ -167,6 +167,33 @@ def get_timestamp_files():
             timestamp_files = set(data.keys())
     return timestamp_files
 
+def get_released_files():
+    """Get cache files PlexCache released to the Unraid mover.
+
+    These are absent from the exclude list on purpose — PlexCache stopped
+    protecting them so the mover can reclaim them on its own schedule, without
+    anything being copied to the array. Re-adding them to the exclude list
+    would undo that.
+    """
+    released = set()
+    if not os.path.exists(TIMESTAMPS_FILE):
+        return released
+    try:
+        with open(TIMESTAMPS_FILE, 'r') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return released
+    if not isinstance(data, dict):
+        return released
+    for path, entry in data.items():
+        if isinstance(entry, dict) and "released_at" in entry:
+            released.add(path)
+            associated = entry.get("associated_files", [])
+            if isinstance(associated, list):
+                released.update(associated)
+    return released
+
+
 def get_orphaned_plexcached_files():
     """Find .plexcached files on array that have no corresponding cache file.
 
@@ -372,7 +399,14 @@ def add_to_exclude(dry_run=True):
     """
     cache_files = get_cache_files()
     exclude_files = get_exclude_files()
-    orphaned = cache_files - exclude_files
+    released_files = get_released_files()
+    # Released files are unprotected by design — re-protecting them here would
+    # silently undo the release and set up a release/re-protect oscillation.
+    orphaned = cache_files - exclude_files - released_files
+
+    if released_files & cache_files:
+        held = len(released_files & cache_files)
+        print(f"Skipping {held} file(s) released to the Unraid mover.")
 
     if not orphaned:
         print("No orphaned files to add to exclude list.")

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -30,6 +30,7 @@ def cached_files_to_dicts(files: List["CachedFile"]) -> List[Dict[str, Any]]:
             "is_ondeck": f.is_ondeck,
             "is_watchlist": f.is_watchlist,
             "is_pinned": f.is_pinned,
+            "is_released": f.is_released,
             "subtitle_count": f.subtitle_count,
             "sidecar_count": f.sidecar_count,
             "associated_files": f.associated_files,
@@ -46,9 +47,11 @@ def calculate_file_totals(files_data: List[Dict[str, Any]]) -> Dict[str, Any]:
         "ondeck_count": sum(1 for f in files_data if f["is_ondeck"]),
         "watchlist_count": sum(1 for f in files_data if f["is_watchlist"]),
         "pinned_count": sum(1 for f in files_data if f["is_pinned"]),
+        "released_count": sum(1 for f in files_data if f.get("is_released")),
         "other_count": sum(
             1 for f in files_data
             if not f["is_ondeck"] and not f["is_watchlist"] and not f["is_pinned"]
+            and not f.get("is_released")
         ),
         "total_size": total_size,
         "total_size_display": format_bytes(total_size),
@@ -78,6 +81,11 @@ class CachedFile:
     is_pinned: bool = False  # Set when this path (or its parent scope) is in PinnedMediaTracker
     rating_key: Optional[str] = None  # Plex rating key, when resolvable from trackers or pinned map
     pin_type: Optional[str] = None  # "episode" or "movie" — scope to pass to /api/pinned/toggle
+    # Handed back to the Unraid mover: still on cache, no longer in the exclude
+    # list, waiting for the mover to relocate it. Tracked from the timestamp
+    # entry's released_at stamp so PlexCache can still evict it if the mover
+    # never comes (a cache:prefer or cache:only share).
+    is_released: bool = False
 
 
 class CacheService:
@@ -642,9 +650,11 @@ class CacheService:
         if isinstance(ts_info, dict):
             cached_at_str = ts_info.get("cached_at")
             source = ts_info.get("source", "unknown")
+            is_released = "released_at" in ts_info
         else:
             cached_at_str = ts_info
             source = "unknown"
+            is_released = False
 
         try:
             cached_at = datetime.fromisoformat(cached_at_str) if cached_at_str else now
@@ -701,7 +711,11 @@ class CacheService:
             return None
         if source_filter == "watchlist" and not is_watchlist:
             return None
-        if source_filter == "other" and (is_ondeck or is_watchlist or is_pinned):
+        if source_filter == "released" and not is_released:
+            return None
+        # "Other" means genuinely unclassified. Released files have their own
+        # bucket, so they must not fall through into this one.
+        if source_filter == "other" and (is_ondeck or is_watchlist or is_pinned or is_released):
             return None
 
         if is_pinned:
@@ -762,6 +776,7 @@ class CacheService:
             is_pinned=is_pinned,
             rating_key=row_rating_key,
             pin_type=row_pin_type,
+            is_released=is_released,
         )
 
     def get_all_cached_files(
@@ -837,7 +852,9 @@ class CacheService:
             "priority": lambda f: f.priority_score,
             "age": lambda f: f.cache_age_hours,
             "users": lambda f: len(f.users),
-            "source": lambda f: (f.is_ondeck, f.is_watchlist),  # OnDeck first, then Watchlist
+            # OnDeck first, then Watchlist, then unclassified, with released last:
+            # they are on their way out, so they belong at the bottom of the list.
+            "source": lambda f: (f.is_ondeck, f.is_watchlist, not f.is_released),
         }
         sort_key = sort_keys.get(sort_by, sort_keys["priority"])
         files.sort(key=sort_key, reverse=reverse)
@@ -1060,15 +1077,32 @@ class CacheService:
             except (OSError, AttributeError):
                 pass
 
-        # Calculate sizes by source
-        ondeck_size = sum(f.size for f in all_files if f.is_ondeck)
-        watchlist_size = sum(f.size for f in all_files if f.is_watchlist and not f.is_ondeck)
-        other_size = sum(f.size for f in all_files if not f.is_ondeck and not f.is_watchlist)
+        # Calculate sizes by source. Released files are checked first: they are
+        # no longer OnDeck or watchlisted (release marks them uncached in both
+        # trackers), so without their own bucket they would silently swell
+        # "Other" with no indication of what they are.
+        released_size = sum(f.size for f in all_files if f.is_released)
+        ondeck_size = sum(f.size for f in all_files if f.is_ondeck and not f.is_released)
+        watchlist_size = sum(
+            f.size for f in all_files
+            if f.is_watchlist and not f.is_ondeck and not f.is_released
+        )
+        other_size = sum(
+            f.size for f in all_files
+            if not f.is_ondeck and not f.is_watchlist and not f.is_released
+        )
         total_cached_size = sum(f.size for f in all_files)
 
-        ondeck_count = sum(1 for f in all_files if f.is_ondeck)
-        watchlist_count = sum(1 for f in all_files if f.is_watchlist and not f.is_ondeck)
-        other_count = sum(1 for f in all_files if not f.is_ondeck and not f.is_watchlist)
+        released_count = sum(1 for f in all_files if f.is_released)
+        ondeck_count = sum(1 for f in all_files if f.is_ondeck and not f.is_released)
+        watchlist_count = sum(
+            1 for f in all_files
+            if f.is_watchlist and not f.is_ondeck and not f.is_released
+        )
+        other_count = sum(
+            1 for f in all_files
+            if not f.is_ondeck and not f.is_watchlist and not f.is_released
+        )
 
         # Calculate percentages of cache
         def calc_percent(size, total):
@@ -1329,6 +1363,12 @@ class CacheService:
                     "size": watchlist_size,
                     "size_display": format_bytes(watchlist_size),
                     "percent": calc_percent(watchlist_size, total_cached_size) if total_cached_size > 0 else 0
+                },
+                "released": {
+                    "count": released_count,
+                    "size": released_size,
+                    "size_display": format_bytes(released_size),
+                    "percent": calc_percent(released_size, total_cached_size) if total_cached_size > 0 else 0
                 },
                 "other": {
                     "count": other_count,

--- a/web/services/maintenance_service.py
+++ b/web/services/maintenance_service.py
@@ -491,6 +491,39 @@ class MaintenanceService:
                 pass
         return timestamp_files
 
+    def get_released_files(self) -> Set[str]:
+        """Get cache paths PlexCache released to the Unraid mover.
+
+        A released file is deliberately absent from the exclude list: PlexCache
+        handed relocation to the mover and stopped protecting it, without
+        moving any bytes. So it is neither an unprotected file that needs
+        fixing nor — once the mover finally takes it — a stale timestamp entry.
+        Treating it as either turns the feature working correctly into a
+        recurring health warning.
+
+        Sidecars inherit their parent's released state, so associated_files are
+        expanded out.
+        """
+        released: Set[str] = set()
+        if not self.timestamps_file.exists():
+            return released
+        try:
+            with open(self.timestamps_file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            return released
+
+        if not isinstance(data, dict):
+            return released
+
+        for path, entry in data.items():
+            if isinstance(entry, dict) and "released_at" in entry:
+                released.add(path)
+                associated = entry.get("associated_files", [])
+                if isinstance(associated, list):
+                    released.update(associated)
+        return released
+
     def _cache_to_array_path(self, cache_file: str) -> Optional[str]:
         """Convert a cache file path to its corresponding array path"""
         cache_dirs, array_dirs = self._get_paths()
@@ -597,6 +630,7 @@ class MaintenanceService:
         cache_files = self.get_cache_files()
         exclude_files = self.get_exclude_files()
         timestamp_files = self.get_timestamp_files()
+        released_files = self.get_released_files()
         scan_duration = time.monotonic() - phase_start
 
         results = AuditResults(
@@ -641,8 +675,11 @@ class MaintenanceService:
                     size_display=format_bytes(dup_size)
                 ))
 
-            # Unprotected: on cache but not in exclude list
-            if cache_path in exclude_files:
+            # Unprotected: on cache but not in exclude list. Released files are
+            # unprotected on purpose — flagging them would recommend
+            # sync_to_array (the exact array write release avoids) and let the
+            # bulk "Add to Exclude" action silently re-protect them.
+            if cache_path in exclude_files or cache_path in released_files:
                 continue
 
             filename = os.path.basename(cache_path)
@@ -715,8 +752,12 @@ class MaintenanceService:
             except Exception as e:
                 logging.warning(f"Upgrade check during audit failed (non-fatal): {e}")
 
-        # Find stale timestamp entries (in timestamps but not on cache)
-        results.stale_timestamp_entries = sorted(list(timestamp_files - cache_files))
+        # Find stale timestamp entries (in timestamps but not on cache).
+        # A released entry whose file is gone means the Unraid mover did its
+        # job — that is the feature succeeding, not tracking debris.
+        results.stale_timestamp_entries = sorted(
+            list(timestamp_files - cache_files - released_files)
+        )
 
         # Flag pinned files that are on cache but missing from the exclude
         # list — the Unraid mover would move them back on the next run,

--- a/web/services/operation_runner.py
+++ b/web/services/operation_runner.py
@@ -108,6 +108,16 @@ class WebLogHandler(logging.Handler):
             pass
 
 
+# Real-time completion lines emitted by core: "  [Action] filename (size)".
+# The producers are FileMover._move_to_cache / _move_to_array and
+# PlexCacheApp._release_files; keep this in step with them.
+# "Released" hands a file back to the Unraid mover without moving bytes, so it
+# is captured as activity but never counted toward restored bytes.
+ACTION_ENTRY_PATTERN = re.compile(
+    r'^  \[(Cached|Restored|Moved|Released)\]\s+(.+?)(?:\s+\(([^)]+)\))?$'
+)
+
+
 class OperationRunner:
     """Service for running PlexCache operations"""
 
@@ -137,7 +147,7 @@ class OperationRunner:
         self._file_entry = re.compile(r'^  (.+)$')  # Indented file entries (legacy)
         self._results_pattern = re.compile(r'Moved to cache:\s*(\d+)|Moved to array:\s*(\d+)')
         # New pattern for real-time completion logs: "  [Action] filename (size)"
-        self._action_entry = re.compile(r'^  \[(Cached|Restored|Moved)\]\s+(.+?)(?:\s+\(([^)]+)\))?$')
+        self._action_entry = ACTION_ENTRY_PATTERN
         # Copy-start log: "  [Copying] filename (size)" — used to derive active files for external runs
         self._copying_entry = re.compile(r'^  \[Copying\]\s+(.+?)(?:\s+\(([^)]+)\))?$')
         # Tracker data for user lookups (loaded on operation start)

--- a/web/static/css/plex-theme.css
+++ b/web/static/css/plex-theme.css
@@ -817,6 +817,12 @@ body {
     color: var(--plex-text-muted);
 }
 
+/* Released to the Unraid mover — matches .breakdown-released */
+.badge-released {
+    background: color-mix(in srgb, var(--plex-purple) 15%, transparent);
+    color: var(--plex-purple);
+}
+
 .badge-pinned {
     background: rgba(229, 160, 13, 0.18);
     color: var(--plex-orange);
@@ -2098,6 +2104,13 @@ pre.log-output-wrapped {
     color: var(--plex-warning);
 }
 
+/* Released to the Unraid mover. Deliberately not --plex-success: green sits
+   next to the green PlexCache bar in the Cache Limit card and would read as
+   "protected", which is the opposite of what released means. */
+.breakdown-released .breakdown-header {
+    color: var(--plex-purple);
+}
+
 .breakdown-stats {
     display: flex;
     align-items: baseline;
@@ -2147,6 +2160,10 @@ pre.log-output-wrapped {
 
 .breakdown-fill.other {
     background: var(--plex-warning);
+}
+
+.breakdown-fill.released {
+    background: var(--plex-purple);
 }
 
 .breakdown-percent {

--- a/web/templates/cache/list.html
+++ b/web/templates/cache/list.html
@@ -37,6 +37,7 @@
                     <option value="pinned" {% if source_filter == 'pinned' %}selected{% endif %}>Pinned Only</option>
                     <option value="ondeck" {% if source_filter == 'ondeck' %}selected{% endif %}>OnDeck Only</option>
                     <option value="watchlist" {% if source_filter == 'watchlist' %}selected{% endif %}>Watchlist Only</option>
+                    <option value="released" {% if source_filter == 'released' %}selected{% endif %}>Released Only</option>
                     <option value="other" {% if source_filter == 'other' %}selected{% endif %}>Other Only</option>
                 </select>
             </div>

--- a/web/templates/cache/partials/file_table.html
+++ b/web/templates/cache/partials/file_table.html
@@ -29,6 +29,15 @@
                 Pinned
             </span>
             {% endif %}
+            {% if file.is_released %}
+            {# Released takes precedence: it is unprotected on purpose, so the
+               "Stale OnDeck" / "Other" wording below would misread as a problem. #}
+            <span class="badge badge-released"
+                  title="Handed back to the Unraid mover. Still on cache and no longer protected, so the mover will relocate it on its own schedule.">
+                <i data-lucide="send" style="width: 10px; height: 10px; vertical-align: middle;"></i>
+                Released
+            </span>
+            {% else %}
             {% if file.is_ondeck %}
             <span class="badge badge-info">OnDeck</span>
             {% endif %}
@@ -43,6 +52,7 @@
                 {% else %}
                 <span class="badge badge-warning">Other</span>
                 {% endif %}
+            {% endif %}
             {% endif %}
         </td>
         <td>

--- a/web/templates/cache/partials/priorities_content.html
+++ b/web/templates/cache/partials/priorities_content.html
@@ -177,6 +177,10 @@
                         {{ af_badge(assoc_count, (file.subtitle_count or 0) ~ ' subtitle' ~ ('s' if (file.subtitle_count or 0) != 1 else '') ~ ', ' ~ (file.sidecar_count or 0) ~ ' asset' ~ ('s' if (file.sidecar_count or 0) != 1 else '')) }}
                     </td>
                     <td class="source-badges">
+                        {% if file.is_released %}
+                        <span class="badge badge-released"
+                              title="Handed back to the Unraid mover, still on cache until it relocates.">Released</span>
+                        {% else %}
                         {% if file.is_ondeck %}
                         <span class="badge badge-info">OnDeck</span>
                         {% endif %}
@@ -191,6 +195,7 @@
                             {% else %}
                             <span class="badge badge-warning">Other</span>
                             {% endif %}
+                        {% endif %}
                         {% endif %}
                     </td>
                     <td class="text-muted">{{ file.cache_age_hours|round(1) }}h</td>

--- a/web/templates/cache/partials/storage_stats.html
+++ b/web/templates/cache/partials/storage_stats.html
@@ -274,8 +274,27 @@
                 </div>
                 <div class="breakdown-percent">{{ data.breakdown.watchlist.percent }}% of PlexCache data</div>
             </a>
+            {% if data.breakdown.released.count > 0 %}
+            <a href="/cache?source=released" class="breakdown-card breakdown-released"
+               title="Handed back to the Unraid mover. Still on cache and no longer protected, so the mover will relocate these on its own schedule. PlexCache keeps tracking them and will move them itself if the cache runs out of room first.">
+                <div class="breakdown-header">
+                    <i data-lucide="send"></i>
+                    <span>Released</span>
+                </div>
+                <div class="breakdown-stats">
+                    <div class="breakdown-value">{{ data.breakdown.released.count }}</div>
+                    <div class="breakdown-label">items</div>
+                </div>
+                <div class="breakdown-size">{{ data.breakdown.released.size_display }}</div>
+                <div class="breakdown-bar">
+                    <div class="breakdown-fill released" style="width: {{ data.breakdown.released.percent }}%"></div>
+                </div>
+                <div class="breakdown-percent">{{ data.breakdown.released.percent }}% of PlexCache data</div>
+            </a>
+            {% endif %}
             {% if data.breakdown.other.count > 0 %}
-            <a href="/cache?source=other" class="breakdown-card breakdown-other">
+            <a href="/cache?source=other" class="breakdown-card breakdown-other"
+               title="Cached files with no current OnDeck or watchlist demand recorded against them.">
                 <div class="breakdown-header">
                     <i data-lucide="help-circle"></i>
                     <span>Other</span>
@@ -331,6 +350,10 @@
                             </td>
                             {% endif %}
                             <td class="source-badges">
+                                {% if file.is_released %}
+                                <span class="badge badge-released badge-sm"
+                                      title="Handed back to the Unraid mover, still on cache until it relocates.">Released</span>
+                                {% else %}
                                 {% if file.is_ondeck %}
                                 <span class="badge badge-info badge-sm">OnDeck</span>
                                 {% endif %}
@@ -339,6 +362,7 @@
                                 {% endif %}
                                 {% if not file.is_ondeck and not file.is_watchlist %}
                                 <span class="badge badge-warning badge-sm">Other</span>
+                                {% endif %}
                                 {% endif %}
                             </td>
                             <td class="user-badges">
@@ -397,6 +421,10 @@
                             </td>
                             {% endif %}
                             <td class="source-badges">
+                                {% if file.is_released %}
+                                <span class="badge badge-released badge-sm"
+                                      title="Handed back to the Unraid mover, still on cache until it relocates.">Released</span>
+                                {% else %}
                                 {% if file.is_ondeck %}
                                 <span class="badge badge-info badge-sm">OnDeck</span>
                                 {% endif %}
@@ -405,6 +433,7 @@
                                 {% endif %}
                                 {% if not file.is_ondeck and not file.is_watchlist %}
                                 <span class="badge badge-warning badge-sm">Other</span>
+                                {% endif %}
                                 {% endif %}
                             </td>
                             <td class="user-badges">
@@ -473,6 +502,10 @@
                             </td>
                             {% endif %}
                             <td class="source-badges">
+                                {% if file.is_released %}
+                                <span class="badge badge-released badge-sm"
+                                      title="Handed back to the Unraid mover, still on cache until it relocates.">Released</span>
+                                {% else %}
                                 {% if file.is_ondeck %}
                                 <span class="badge badge-info badge-sm">OnDeck</span>
                                 {% endif %}
@@ -481,6 +514,7 @@
                                 {% endif %}
                                 {% if not file.is_ondeck and not file.is_watchlist %}
                                 <span class="badge badge-warning badge-sm">Other</span>
+                                {% endif %}
                                 {% endif %}
                             </td>
                             <td class="user-badges">

--- a/web/templates/cache/partials/storage_stats.html
+++ b/web/templates/cache/partials/storage_stats.html
@@ -257,7 +257,7 @@
                 <div class="breakdown-bar">
                     <div class="breakdown-fill ondeck" style="width: {{ data.breakdown.ondeck.percent }}%"></div>
                 </div>
-                <div class="breakdown-percent">{{ data.breakdown.ondeck.percent }}% of cache</div>
+                <div class="breakdown-percent">{{ data.breakdown.ondeck.percent }}% of PlexCache data</div>
             </a>
             <a href="/cache?source=watchlist" class="breakdown-card breakdown-watchlist">
                 <div class="breakdown-header">
@@ -272,7 +272,7 @@
                 <div class="breakdown-bar">
                     <div class="breakdown-fill watchlist" style="width: {{ data.breakdown.watchlist.percent }}%"></div>
                 </div>
-                <div class="breakdown-percent">{{ data.breakdown.watchlist.percent }}% of cache</div>
+                <div class="breakdown-percent">{{ data.breakdown.watchlist.percent }}% of PlexCache data</div>
             </a>
             {% if data.breakdown.other.count > 0 %}
             <a href="/cache?source=other" class="breakdown-card breakdown-other">
@@ -288,7 +288,7 @@
                 <div class="breakdown-bar">
                     <div class="breakdown-fill other" style="width: {{ data.breakdown.other.percent }}%"></div>
                 </div>
-                <div class="breakdown-percent">{{ data.breakdown.other.percent }}% of cache</div>
+                <div class="breakdown-percent">{{ data.breakdown.other.percent }}% of PlexCache data</div>
             </a>
             {% endif %}
         </div>


### PR DESCRIPTION
Refs #174.

When a watched file is no longer needed, PlexCache copies it to the array and deletes the cache copy. For a file PlexCache never lifted off the array in the first place, that is a first-time array write and a disk spinup on PlexCache's schedule rather than the user's. Unraid's mover reclaims that file on its own once it is out of the exclude list.

Anything that landed on cache from a downloader has no `.plexcached` backup, because there was no array original to rename. That absence is the signal: it means no move is required. When a backup does exist, PlexCache renamed the original and has to rename it back, otherwise the backup is orphaned and the mover later drops a second copy beside it.

So the rule is: backup present, relocate exactly as before. No backup, drop the exclude entry and leave the file where it is.

**Relocation still happens** wherever release would be unsafe or ineffective: not on Unraid, no array behind the share (ZFS pool-only), a differently-named `.plexcached` left by a Sonarr/Radarr upgrade, or a cache file with more than one hard link. The hard-link check runs unconditionally rather than behind `check_hardlinks_on_restore`, since that setting governs a different decision and defaults off.

**Fallback.** Release assumes the mover eventually relocates the file, which only holds on a `cache:yes` share. `/usr/local/sbin/mover` branches on exactly two values: `yes` moves primary to secondary, `prefer` moves secondary to primary, and `only` and `no` are not processed at all. PlexCache cannot read `shareUseCache` (neither `/boot` nor emhttp's share state is mounted), so instead of predicting the mover it observes the outcome: if `_apply_cache_limit()` reports it had to skip caching something for space while released files are still resident, PlexCache takes them back and relocates them. That is measured harm rather than a threshold, so it needs no constant and behaves the same on a 250GB SSD as on a 20TB pool, and it inherits whatever `cache_limit` / `min_free_space` / `plexcache_quota` is configured.

**Inventory change, needed first.** `_get_plexcache_tracked_size()` read the mover exclude file alone, and it is the only feed for both the quota check and the eviction candidate pool. Since release drops the exclude entry, a released file would have fallen out of PlexCache's own reach. It now leads with the timestamp tracker and unions the exclude file in, matching what `CacheService.get_cached_files_list()` already does on the web side. Union rather than replace, so installs whose two stores have drifted keep everything. Deduping through a set also stops repeated exclude lines from double-counting bytes.

**Audit and UI.** Released files are excluded from the unprotected list and from the stale-timestamp calculation, so a file the mover has taken does not read as tracking debris. `tools/audit_cache.py --add-to-exclude` skips them for the same reason. They get their own card in Cache Breakdown by Source, a badge in the file tables, and a `?source=released` filter, rather than accumulating silently in "Other".

**No new settings.** This is the default behavior.

### Testing

1. **Existing behavior unchanged.** Watch something PlexCache cached from the array. It should still log `[RESTORE] Returning to array (N episodes, instant via .plexcached)` and relocate as before.
2. **The new path.** Let a download land on cache, get it on deck, run PlexCache (it should add an exclude entry with no copy), then watch it so it drops off deck. Next run should log `[RELEASE] Handing N files back to the Unraid mover (no data moved)`.
3. **Confirm nothing was written.** The file stays on the cache pool at full size, and the array path has no `.mkv` and no `.plexcached`.
4. **Tracking survives.** The Storage page should show the file under Released, not Other, and it should still count toward the PlexCache total.
5. **Dry run.** `--dry-run` logs what it would release and writes nothing.

Verified on a live Unraid box: six watched episodes, 17.64 GB, all released, and the array directory for that show was never created.

---

Two notes on scope. I included the small "% of cache" to "% of PlexCache data" relabel in the breakdown panel, because the new Released card sits in that same panel and leaving it out would have meant inconsistent labels on adjacent cards. I left out an unrelated fix for a spurious "files not found on disk" warning, which is independent and will come separately.
