### PR TITLE
Three run-level fixes: plex.tv 5xx, spurious restore warning, full-drive pressure

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -2607,6 +2607,12 @@ class PlexCacheApp:
                 logging.warning(f"PlexCache quota reached ({plexcache_tracked / (1024**3):.2f}GB tracked, quota is {quota_readable})")
             else:
                 logging.warning(f"Cache drive already at or over limit ({drive_usage_gb:.2f}GB used, limit is {limit_readable})")
+            # No room for anything, so the packing loop below never runs and
+            # never reaches its own flag-setting branch. This is the strongest
+            # evidence of space pressure there is — every candidate was
+            # dropped, not just the ones that did not fit — so the reclaim in
+            # _reclaim_released_if_constrained() has to see it too.
+            self._cache_space_constrained = True
             return []
         files_to_cache = []
         skipped_count = 0

--- a/core/app.py
+++ b/core/app.py
@@ -3263,7 +3263,12 @@ class PlexCacheApp:
         if destination == 'cache':
             media_files_filtered = self._apply_cache_limit(media_files_filtered, cache_dir)
 
-        total_size, total_size_unit = self.file_utils.get_total_size_of_files(media_files_filtered)
+        # Array-destination paths are expected to be absent: the originals were
+        # renamed to .plexcached when the files were cached, so sizing them here
+        # misses every one. The fallback just below recovers the real total.
+        total_size, total_size_unit = self.file_utils.get_total_size_of_files(
+            media_files_filtered, warn_missing=(destination != 'array')
+        )
 
         # Fallback for array moves: on non-FUSE setups (e.g., ZFS with direct pool paths),
         # array paths don't exist because originals were renamed to .plexcached.

--- a/core/app.py
+++ b/core/app.py
@@ -2885,7 +2885,7 @@ class PlexCacheApp:
             total_drive_usage = plexcache_tracked  # Fallback if can't get disk usage
 
         if total_drive_usage < threshold_bytes and needed_space_bytes == 0:
-            logging.debug(f"Cache usage ({total_drive_usage/1e9:.2f}GB) below threshold ({threshold_bytes/1e9:.2f}GB), skipping eviction")
+            logging.debug(f"Cache usage ({total_drive_usage/(1024**3):.2f}GB) below threshold ({threshold_bytes/(1024**3):.2f}GB), skipping eviction")
             return (0, 0)
 
         # Calculate how much space to free based on total drive usage
@@ -2894,10 +2894,10 @@ class PlexCacheApp:
             return (0, 0)
 
         if needed_space_bytes > 0:
-            logging.info(f"[EVICTION] Smart eviction: drive over limit, need to free {space_to_free/1e9:.2f}GB")
+            logging.info(f"[EVICTION] Smart eviction: drive over limit, need to free {space_to_free/(1024**3):.2f}GB")
         else:
-            logging.info(f"[EVICTION] Smart eviction: drive usage ({total_drive_usage/1e9:.2f}GB) over threshold ({threshold_bytes/1e9:.2f}GB), need to free {space_to_free/1e9:.2f}GB")
-            logging.debug(f"PlexCache-tracked: {plexcache_tracked/1e9:.2f}GB, Other files: {(total_drive_usage-plexcache_tracked)/1e9:.2f}GB")
+            logging.info(f"[EVICTION] Smart eviction: drive usage ({total_drive_usage/(1024**3):.2f}GB) over threshold ({threshold_bytes/(1024**3):.2f}GB), need to free {space_to_free/(1024**3):.2f}GB")
+            logging.debug(f"PlexCache-tracked: {plexcache_tracked/(1024**3):.2f}GB, Other files: {(total_drive_usage-plexcache_tracked)/(1024**3):.2f}GB")
 
         # Get eviction candidates based on mode
         if eviction_mode == "smart":
@@ -2936,7 +2936,7 @@ class PlexCacheApp:
         # Check if candidates can free enough space
         candidate_bytes = sum(os.path.getsize(f) for f in candidates if os.path.exists(f))
         if candidate_bytes < space_to_free:
-            logging.warning(f"Can only evict {candidate_bytes/1e9:.2f}GB of {space_to_free/1e9:.2f}GB needed - non-PlexCache files may be filling the drive")
+            logging.warning(f"Can only evict {candidate_bytes/(1024**3):.2f}GB of {space_to_free/(1024**3):.2f}GB needed - non-PlexCache files may be filling the drive")
 
         # Log what we're evicting
         for cache_path in candidates:
@@ -3111,7 +3111,7 @@ class PlexCacheApp:
             except OSError as e:
                 logging.warning(f"Failed to evict {cache_path}: {e}")
 
-        logging.info(f"[EVICTION] Smart eviction complete: freed {bytes_freed/1e9:.2f}GB from {files_evicted} files")
+        logging.info(f"[EVICTION] Smart eviction complete: freed {bytes_freed/(1024**3):.2f}GB from {files_evicted} files")
         return (files_evicted, bytes_freed)
 
     def _backfill_empty_folder_cleanup(self) -> None:

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -22,7 +22,7 @@ from plexapi.server import PlexServer
 
 from plexapi.video import Episode, Movie
 from plexapi.myplex import MyPlexAccount
-from plexapi.exceptions import NotFound
+from plexapi.exceptions import BadRequest, NotFound
 import requests
 
 
@@ -184,13 +184,25 @@ def _derive_rss_fallback_url(url: str) -> Optional[str]:
 PLEXTV_MAX_RETRIES = 3
 PLEXTV_RETRY_BASE_WAIT = 2  # seconds (exponential: 2s, 4s)
 
+# plexapi collapses every non-2xx response that isn't 401/404 into BadRequest,
+# with the status code only present in the message text ("(503) service_unavailable;
+# https://..."). 5xx from plex.tv is a transient upstream hiccup and worth
+# retrying; 4xx means the request itself is wrong and never will be.
+_PLEXTV_RETRY_STATUS_RE = re.compile(r"^\((5\d\d)\)")
+
+
+def _is_transient_plextv_error(error: Exception) -> bool:
+    """True if `error` is a plex.tv 5xx that a retry could plausibly clear."""
+    return bool(_PLEXTV_RETRY_STATUS_RE.match(str(error)))
+
 
 def _retry_plextv_call(func, label: str, max_attempts: int = PLEXTV_MAX_RETRIES):
     """Call a plex.tv function, retrying on transient network errors.
 
-    Retries only `requests.Timeout` and `requests.ConnectionError` — other
-    exceptions (auth failures, parse errors, logic bugs) are raised immediately
-    so callers can distinguish retry-worthy failures from permanent ones.
+    Retries `requests.Timeout`, `requests.ConnectionError`, and 5xx responses
+    (which plexapi raises as `BadRequest`). Other exceptions — auth failures,
+    4xx, parse errors, logic bugs — are raised immediately so callers can
+    distinguish retry-worthy failures from permanent ones.
 
     Args:
         func: Zero-argument callable to invoke (wrap args via lambda).
@@ -208,13 +220,15 @@ def _retry_plextv_call(func, label: str, max_attempts: int = PLEXTV_MAX_RETRIES)
     for attempt in range(max_attempts):
         try:
             return func()
-        except (requests.Timeout, requests.ConnectionError) as e:
+        except (requests.Timeout, requests.ConnectionError, BadRequest) as e:
+            if isinstance(e, BadRequest) and not _is_transient_plextv_error(e):
+                raise
             last_error = e
             if attempt < max_attempts - 1:
                 wait_time = PLEXTV_RETRY_BASE_WAIT ** (attempt + 1)  # 2s, 4s
                 logging.warning(
                     f"plex.tv {label} attempt {attempt + 1}/{max_attempts} "
-                    f"timed out: {e}. Retrying in {wait_time}s..."
+                    f"failed: {e}. Retrying in {wait_time}s..."
                 )
                 time.sleep(wait_time)
     raise last_error
@@ -1488,45 +1502,73 @@ class PlexManager:
             )
             logging.debug(f"[USER:{current_username}] Found {len(watchlist)} watchlist items")
             for item in watchlist:
-                watchlisted_at = None
                 try:
-                    user_state = _retry_plextv_call(
-                        lambda: account.userState(item),
-                        label=f"userState for '{item.title}'",
+                    yield from self._process_watchlist_item(
+                        account, item, current_username, filtered_sections, watchlist_episodes
                     )
-                    watchlisted_at = getattr(user_state, 'watchlistedAt', None)
                 except Exception as e:
-                    logging.debug(f"Could not get userState for {item.title}: {e}")
-
-                # Extract GUID for accurate matching (prefer IMDB, then TVDB)
-                guid = None
-                item_guids = getattr(item, 'guids', [])
-                for g in item_guids:
-                    gid = getattr(g, 'id', str(g))
-                    if gid.startswith('imdb://') or gid.startswith('tvdb://'):
-                        guid = gid
-                        break
-
-                # Determine expected type from watchlist item
-                expected_type = getattr(item, 'type', None)
-
-                file = self.search_plex(item.title, guid=guid, expected_type=expected_type,
-                                       valid_sections=filtered_sections)
-                if file and (not filtered_sections or file.librarySectionID in filtered_sections):
-                    try:
-                        if file.TYPE == 'show':
-                            yield from self._process_watchlist_show(file, watchlist_episodes, current_username, watchlisted_at)
-                        elif file.TYPE == 'movie':
-                            yield from self._process_watchlist_movie(file, current_username, watchlisted_at)
-                        else:
-                            logging.debug(f"Ignoring item '{file.title}' of type '{file.TYPE}'")
-                    except Exception as e:
-                        logging.warning(f"Error processing '{file.title}': {e}")
-                elif file:
-                    logging.debug(f"Skipping watchlist item '{file.title}' — section {file.librarySectionID} not in valid_sections {filtered_sections}")
+                    # One unreadable item must not cost us the rest of the list.
+                    # plexapi resolves `guids` lazily against metadata.provider.plex.tv,
+                    # so a 5xx on a single item used to escape to the handler below and
+                    # drop every remaining item for this user.
+                    item_title = getattr(item, 'title', '<unknown>')
+                    logging.warning(
+                        f"[USER:{current_username}] Skipping watchlist item '{item_title}': {e}"
+                    )
+                    self.mark_watchlist_incomplete()
         except Exception as e:
             logging.error(f"[USER:{current_username}] Error fetching watchlist: {e}")
             self.mark_watchlist_incomplete()
+
+    def _process_watchlist_item(self, account, item, current_username: str,
+                                 filtered_sections: List[int],
+                                 watchlist_episodes: int) -> Generator[Tuple[str, str, Optional[datetime], Optional[Dict], Optional[str], str], None, None]:
+        """Resolve one plex.tv watchlist item to local media files.
+
+        Raises whatever plex.tv or the local server raises — the caller decides
+        whether a failure costs just this item or the whole watchlist.
+        """
+        watchlisted_at = None
+        try:
+            user_state = _retry_plextv_call(
+                lambda: account.userState(item),
+                label=f"userState for '{item.title}'",
+            )
+            watchlisted_at = getattr(user_state, 'watchlistedAt', None)
+        except Exception as e:
+            logging.debug(f"Could not get userState for {item.title}: {e}")
+
+        # Extract GUID for accurate matching (prefer IMDB, then TVDB). Reading
+        # `guids` on a watchlist item triggers a lazy plex.tv reload, so wrap it
+        # in the retry helper like every other plex.tv call.
+        guid = None
+        item_guids = _retry_plextv_call(
+            lambda: getattr(item, 'guids', []),
+            label=f"guids for '{item.title}'",
+        )
+        for g in item_guids:
+            gid = getattr(g, 'id', str(g))
+            if gid.startswith('imdb://') or gid.startswith('tvdb://'):
+                guid = gid
+                break
+
+        # Determine expected type from watchlist item
+        expected_type = getattr(item, 'type', None)
+
+        file = self.search_plex(item.title, guid=guid, expected_type=expected_type,
+                               valid_sections=filtered_sections)
+        if file and (not filtered_sections or file.librarySectionID in filtered_sections):
+            try:
+                if file.TYPE == 'show':
+                    yield from self._process_watchlist_show(file, watchlist_episodes, current_username, watchlisted_at)
+                elif file.TYPE == 'movie':
+                    yield from self._process_watchlist_movie(file, current_username, watchlisted_at)
+                else:
+                    logging.debug(f"Ignoring item '{file.title}' of type '{file.TYPE}'")
+            except Exception as e:
+                logging.warning(f"Error processing '{file.title}': {e}")
+        elif file:
+            logging.debug(f"Skipping watchlist item '{file.title}' — section {file.librarySectionID} not in valid_sections {filtered_sections}")
 
     def _process_rss_watchlist(self, rss_url: str, current_username: str,
                                 filtered_sections: List[int], watchlist_episodes: int,

--- a/core/system_utils.py
+++ b/core/system_utils.py
@@ -1005,8 +1005,20 @@ class FileUtils:
         stat = os.statvfs(directory)
         return stat.f_blocks * stat.f_frsize
 
-    def get_total_size_of_files(self, files: list) -> Tuple[float, str]:
-        """Calculate total size of files in human-readable format."""
+    def get_total_size_of_files(self, files: list, warn_missing: bool = True) -> Tuple[float, str]:
+        """Calculate total size of files in human-readable format.
+
+        Args:
+            files: Paths to size.
+            warn_missing: Whether an unreadable path is worth a WARNING. Set
+                False when the caller expects some paths to be absent. Sizing
+                an array-destination move is the case that matters: PlexCache
+                renamed those originals to .plexcached when it cached them, so
+                every path legitimately misses and the warning is noise on an
+                otherwise healthy restore. A genuinely missing file is still
+                reported by _move_to_array, which checks cache and .plexcached
+                before giving up.
+        """
         total_size_bytes = 0
         skipped_files = []
         for file in files:
@@ -1017,7 +1029,10 @@ class FileUtils:
 
         if skipped_files:
             file_word = "file" if len(skipped_files) == 1 else "files"
-            logging.warning(f"Skipping {len(skipped_files)} {file_word} not found on disk (may have been renamed - try refreshing Plex library)")
+            if warn_missing:
+                logging.warning(f"Skipping {len(skipped_files)} {file_word} not found on disk (may have been renamed - try refreshing Plex library)")
+            else:
+                logging.debug(f"Sizing skipped {len(skipped_files)} {file_word} not present at the requested path")
             for f in skipped_files:
                 logging.debug(f"  Not found: {f}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,34 @@ for _mod in [
 ]:
     sys.modules.setdefault(_mod, MagicMock())
 
+# Individual test modules mock the plexapi submodules they don't need, but
+# plexapi.exceptions must stay real: core code lists BadRequest / NotFound in
+# `except` clauses, and Python rejects a MagicMock there with "catching classes
+# that do not inherit from BaseException". Claiming the sys.modules slot here
+# (conftest is imported before any test module) makes their setdefault a no-op.
+try:  # pragma: no cover - exercised implicitly by every plexapi-touching test
+    import plexapi.exceptions  # noqa: F401
+except ImportError:  # plexapi absent - supply equivalent real classes
+    import types
+
+    _exc = types.ModuleType('plexapi.exceptions')
+
+    class PlexApiException(Exception):
+        """Base exception for all plexapi errors."""
+
+    class BadRequest(PlexApiException):
+        """An invalid request, or any non-2xx response other than 404."""
+
+    class NotFound(PlexApiException):
+        """Request media item or device is not found."""
+
+    class Unauthorized(BadRequest):
+        """Invalid username/password or token."""
+
+    for _cls in (PlexApiException, BadRequest, NotFound, Unauthorized):
+        setattr(_exc, _cls.__name__, _cls)
+    sys.modules['plexapi.exceptions'] = _exc
+
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/tests/test_plex_api_retry.py
+++ b/tests/test_plex_api_retry.py
@@ -1,7 +1,7 @@
 """Tests for _retry_plextv_call helper.
 
-Verifies that transient plex.tv network errors (timeouts, connection errors)
-are retried with backoff, while permanent errors raise immediately.
+Verifies that transient plex.tv failures (timeouts, connection errors, 5xx
+responses) are retried with backoff, while permanent errors raise immediately.
 """
 
 import os
@@ -23,8 +23,17 @@ for _mod in [
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import requests
+from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 
 from core.plex_api import _retry_plextv_call, PLEXTV_MAX_RETRIES
+
+
+def _plexapi_error(status: int, codename: str, cls=BadRequest):
+    """Build the exact message shape plexapi raises for a non-2xx response."""
+    return cls(
+        f"({status}) {codename}; https://metadata.provider.plex.tv/library/metadata/abc123 "
+        f"upstream connect error or disconnect/reset before headers"
+    )
 
 
 class TestRetryPlexTvCall:
@@ -88,3 +97,66 @@ class TestRetryPlexTvCall:
             _retry_plextv_call(func, label="watchlist for Brandon")
         assert any("watchlist for Brandon" in rec.message for rec in caplog.records)
         assert any("1/3" in rec.message for rec in caplog.records)
+
+
+class TestRetryOnHttpStatus:
+    """plexapi collapses non-2xx into BadRequest with the code in the message.
+
+    5xx from plex.tv is a transient upstream hiccup worth retrying; 4xx means
+    the request is wrong and never will be.
+    """
+
+    def test_retries_on_503_then_succeeds(self):
+        """The failure mode from the 2026-07-31 log: a 503 on a watchlist item."""
+        func = MagicMock(side_effect=[
+            _plexapi_error(503, "service_unavailable"), "ok"
+        ])
+        with patch('core.plex_api.time.sleep'):
+            result = _retry_plextv_call(func, label="guids for 'Weeds'")
+        assert result == "ok"
+        assert func.call_count == 2
+
+    @pytest.mark.parametrize("status,codename", [
+        (500, "internal_server_error"),
+        (502, "bad_gateway"),
+        (503, "service_unavailable"),
+        (504, "gateway_timeout"),
+    ])
+    def test_retries_every_5xx(self, status, codename):
+        func = MagicMock(side_effect=[_plexapi_error(status, codename), "ok"])
+        with patch('core.plex_api.time.sleep'):
+            assert _retry_plextv_call(func, label="test") == "ok"
+        assert func.call_count == 2
+
+    def test_gives_up_after_max_attempts_on_persistent_5xx(self):
+        func = MagicMock(side_effect=_plexapi_error(503, "service_unavailable"))
+        with patch('core.plex_api.time.sleep'), pytest.raises(BadRequest):
+            _retry_plextv_call(func, label="test")
+        assert func.call_count == PLEXTV_MAX_RETRIES
+
+    @pytest.mark.parametrize("status,codename,cls", [
+        (400, "bad_request", BadRequest),
+        (401, "unauthorized", Unauthorized),
+        (403, "forbidden", BadRequest),
+        (429, "too_many_requests", BadRequest),
+    ])
+    def test_4xx_raises_immediately(self, status, codename, cls):
+        """A bad token or a rejected request won't fix itself — don't burn backoff."""
+        func = MagicMock(side_effect=_plexapi_error(status, codename, cls))
+        with pytest.raises(BadRequest):
+            _retry_plextv_call(func, label="test")
+        assert func.call_count == 1
+
+    def test_not_found_raises_immediately(self):
+        """NotFound is a sibling of BadRequest in plexapi, not a subclass."""
+        func = MagicMock(side_effect=NotFound("(404) not_found; https://plex.tv/x"))
+        with pytest.raises(NotFound):
+            _retry_plextv_call(func, label="test")
+        assert func.call_count == 1
+
+    def test_bad_request_without_status_prefix_raises_immediately(self):
+        """Only messages that actually start with a 5xx code are retriable."""
+        func = MagicMock(side_effect=BadRequest("something went sideways"))
+        with pytest.raises(BadRequest):
+            _retry_plextv_call(func, label="test")
+        assert func.call_count == 1

--- a/tests/test_plexcache_quota.py
+++ b/tests/test_plexcache_quota.py
@@ -212,6 +212,69 @@ class TestPlexcacheQuotaEnforcement:
         assert len(result) == 1
 
 
+class TestCacheSpaceConstrainedFlag:
+    """_cache_space_constrained must be set whenever caching lost files to space.
+
+    _reclaim_released_if_constrained() gates entirely on this flag, so a path
+    that drops candidates without setting it silently disables the
+    release-to-mover reclaim. The full-drive path is the one that matters most:
+    it drops *every* candidate, which is stronger evidence of pressure than the
+    partial-skip path that does set the flag.
+    """
+
+    def _run(self, tmp_path, *, quota_bytes=0, cache_limit_bytes=0,
+             min_free_bytes=0, tracked=200*GB, drive_used=400*GB):
+        app, cache_dir, files, disk, _ = _build_app(
+            tmp_path, quota_bytes=quota_bytes, cache_limit_bytes=cache_limit_bytes,
+            min_free_bytes=min_free_bytes, drive_used=drive_used,
+        )
+        app._cache_space_constrained = False
+
+        with patch('core.app.get_disk_usage', return_value=disk), \
+             patch.object(app, '_get_plexcache_tracked_size', return_value=(tracked, [])), \
+             patch('os.path.getsize', return_value=10*GB):
+            result = app._apply_cache_limit(files, cache_dir)
+
+        return app, result
+
+    def test_quota_already_exhausted_sets_the_flag(self, tmp_path):
+        app, result = self._run(tmp_path, quota_bytes=150*GB, tracked=200*GB)
+
+        assert result == []
+        assert app._cache_space_constrained is True
+
+    def test_cache_limit_already_exceeded_sets_the_flag(self, tmp_path):
+        app, result = self._run(
+            tmp_path, cache_limit_bytes=300*GB, drive_used=400*GB)
+
+        assert result == []
+        assert app._cache_space_constrained is True
+
+    def test_min_free_space_floor_breached_sets_the_flag(self, tmp_path):
+        # 1000GB total, 900GB used -> 100GB free, floor is 200GB.
+        app, result = self._run(
+            tmp_path, min_free_bytes=200*GB, drive_used=900*GB)
+
+        assert result == []
+        assert app._cache_space_constrained is True
+
+    def test_partial_skip_still_sets_the_flag(self, tmp_path):
+        """Regression guard on the path that already worked."""
+        # 220GB quota - 200GB tracked = 20GB, so 2 of 5 files fit.
+        app, result = self._run(tmp_path, quota_bytes=220*GB, tracked=200*GB)
+
+        assert len(result) == 2
+        assert app._cache_space_constrained is True
+
+    def test_everything_fits_leaves_the_flag_alone(self, tmp_path):
+        """No harm measured, so the reclaim must not fire."""
+        # 300GB quota - 200GB tracked = 100GB, all 5 files (50GB) fit.
+        app, result = self._run(tmp_path, quota_bytes=300*GB, tracked=200*GB)
+
+        assert len(result) == 5
+        assert app._cache_space_constrained is False
+
+
 class TestNoGapShowOrdering:
     """Tests for #169: episodes of the same show stay contiguous when space is tight.
 

--- a/tests/test_resolve_pins_to_paths.py
+++ b/tests/test_resolve_pins_to_paths.py
@@ -13,6 +13,7 @@ Uses a minimal fake plexapi interface:
 import logging
 
 import pytest
+from plexapi.exceptions import NotFound
 
 from core.pinned_media import (
     PinnedMediaTracker,
@@ -25,9 +26,10 @@ from core.pinned_media import (
 # ---------------------------------------------------------------------------
 
 
-class FakeNotFound(Exception):
-    """Stand-in for plexapi.exceptions.NotFound."""
-    pass
+# The real exception, not a stand-in: conftest guarantees plexapi.exceptions
+# stays a real module, so resolve_pins_to_paths() resolves the same class it
+# catches and we exercise the genuine orphan path rather than its fallback.
+FakeNotFound = NotFound
 
 
 class FakePart:
@@ -84,19 +86,6 @@ class FakePlexServer:
         if key in self._items:
             return self._items[key]
         raise FakeNotFound(f"rating_key={key} not found")
-
-
-@pytest.fixture(autouse=True)
-def _patch_notfound(monkeypatch):
-    """Force resolve_pins_to_paths to treat FakeNotFound as the orphan signal.
-
-    The module does a lazy `from plexapi.exceptions import NotFound` inside
-    the function. We can't easily monkeypatch that, so the function already
-    falls back to `Exception` when plexapi is missing — meaning FakeNotFound
-    (a subclass of Exception) will be caught and trigger orphan removal.
-    """
-    # No-op — just documenting the behavior above.
-    yield
 
 
 @pytest.fixture

--- a/tests/test_total_size_warning.py
+++ b/tests/test_total_size_warning.py
@@ -1,0 +1,135 @@
+"""Tests for FileUtils.get_total_size_of_files() and its missing-path warning.
+
+Sizing an array-destination move hands this helper /mnt/user0/ paths whose
+originals were renamed to .plexcached when PlexCache cached them. Every path
+legitimately misses, so warning about them fires on every healthy restore and
+teaches users to ignore warnings.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+for _mod_name in [
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex', 'requests',
+]:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+from conftest import create_test_file  # noqa: E402
+
+
+def _file_utils():
+    from core.system_utils import FileUtils
+    return object.__new__(FileUtils)
+
+
+class TestTotalSizeOfFiles:
+
+    def test_sums_existing_files(self, tmp_path):
+        a = create_test_file(str(tmp_path / "a.mkv"), size_bytes=1024)
+        b = create_test_file(str(tmp_path / "b.mkv"), size_bytes=1024)
+
+        size, unit = _file_utils().get_total_size_of_files([a, b])
+
+        assert (size, unit) == (2.0, "KB")
+
+    def test_missing_files_are_excluded_from_the_total(self, tmp_path):
+        a = create_test_file(str(tmp_path / "a.mkv"), size_bytes=1024)
+        missing = str(tmp_path / "gone.mkv")
+
+        size, unit = _file_utils().get_total_size_of_files([a, missing])
+
+        assert (size, unit) == (1.0, "KB")
+
+
+class TestMissingPathWarning:
+
+    def test_warns_by_default(self, tmp_path, caplog):
+        missing = str(tmp_path / "gone.mkv")
+
+        with caplog.at_level("DEBUG"):
+            _file_utils().get_total_size_of_files([missing])
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "not found on disk" in warnings[0].message
+
+    def test_silent_when_absence_is_expected(self, tmp_path, caplog):
+        """The array-destination case: absence is normal, not a problem."""
+        missing = str(tmp_path / "gone.mkv")
+
+        with caplog.at_level("DEBUG"):
+            _file_utils().get_total_size_of_files([missing], warn_missing=False)
+
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+    def test_still_records_which_paths_missed_at_debug(self, tmp_path, caplog):
+        """Suppressing the warning must not lose the diagnostic detail."""
+        missing = str(tmp_path / "gone.mkv")
+
+        with caplog.at_level("DEBUG"):
+            _file_utils().get_total_size_of_files([missing], warn_missing=False)
+
+        debug_text = "\n".join(r.message for r in caplog.records if r.levelname == "DEBUG")
+        assert "gone.mkv" in debug_text
+
+    def test_no_warning_when_nothing_is_missing(self, tmp_path, caplog):
+        a = create_test_file(str(tmp_path / "a.mkv"), size_bytes=10)
+
+        with caplog.at_level("DEBUG"):
+            _file_utils().get_total_size_of_files([a])
+
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+
+class TestCallerPassesTheRightFlag:
+    """_check_free_space_and_move_files() sizes array moves without warning.
+
+    Drives the real method with a genuinely missing path, which is what an
+    array-destination move always looks like once the originals are .plexcached.
+    """
+
+    def _app(self, tmp_path, missing_path):
+        from core.app import PlexCacheApp
+        from core.system_utils import FileUtils
+
+        app = object.__new__(PlexCacheApp)
+        app.config_manager = MagicMock()
+        app.dry_run = True
+        app.all_active_media = []
+        app.media_to_cache = []
+        app.files_to_skip = []
+        app.restored_count = 0
+        app.restored_bytes = 0
+        app.moved_to_array_count = 0
+        app.moved_to_array_bytes = 0
+        app.file_utils = object.__new__(FileUtils)
+        app.file_filter = MagicMock()
+        app.file_filter.filter_files.return_value = [missing_path]
+        app.logging_manager = MagicMock()
+        app.file_mover = MagicMock()
+        return app
+
+    def test_array_destination_does_not_warn(self, tmp_path, caplog):
+        missing = str(tmp_path / "Movie.mkv")  # renamed to .plexcached on the array
+        app = self._app(tmp_path, missing)
+
+        with caplog.at_level("DEBUG"):
+            app._check_free_space_and_move_files([missing], 'array', '', str(tmp_path))
+
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+    def test_cache_destination_still_warns(self, tmp_path, caplog):
+        """A cache-bound file that isn't on the array is a real problem."""
+        missing = str(tmp_path / "Movie.mkv")
+        app = self._app(tmp_path, missing)
+        app._apply_cache_limit = lambda files, cache_dir: files
+
+        with caplog.at_level("DEBUG"):
+            app._check_free_space_and_move_files([missing], 'cache', '', str(tmp_path))
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("not found on disk" in r.message for r in warnings)

--- a/tests/test_watchlist_item_isolation.py
+++ b/tests/test_watchlist_item_isolation.py
@@ -1,0 +1,171 @@
+"""Tests that one bad watchlist item doesn't drop the rest of a user's watchlist.
+
+Observed 2026-07-31: plex.tv returned 503 while plexapi lazily resolved `guids`
+on a single watchlist item. The exception escaped the per-user try/except, so
+the remaining ~70 of that user's 93 items were never processed, and the run
+marked watchlist data incomplete — which blocks array restore for every user.
+
+Each item now resolves inside its own guard: a failure costs that item only.
+"""
+
+import os
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from plexapi.exceptions import BadRequest
+
+from core.plex_api import PlexManager
+
+
+SERVICE_UNAVAILABLE = BadRequest(
+    "(503) service_unavailable; https://metadata.provider.plex.tv/library/"
+    "metadata/5d9c086ee98e47001eb0fcba?includeBandwidths=1 upstream connect "
+    "error or disconnect/reset before headers. reset reason: connection termination"
+)
+
+
+def _bare_api():
+    """Construct a PlexManager without running __init__ (avoids network auth)."""
+    api = PlexManager.__new__(PlexManager)
+    api.plex_url = "http://localhost:32400"
+    api.plex_token = "ADMIN_TOKEN"
+    api.watchlist_enabled = True
+    api._user_tokens = {}
+    api._plex_tv_reachable = True
+    api._watchlist_data_complete = True
+    api._ondeck_data_complete = True
+    api._token_lock = threading.Lock()
+    api._rate_limited_api_call = MagicMock()
+    api.plex = MagicMock()
+    return api
+
+
+def _watchlist_item(title, guids_error=None):
+    """A plex.tv watchlist item whose `guids` may blow up on lazy reload."""
+    item = MagicMock()
+    item.title = title
+    item.type = 'movie'
+    if guids_error is not None:
+        type(item).guids = property(lambda self: (_ for _ in ()).throw(guids_error))
+    else:
+        item.guids = []
+    return item
+
+
+def _local_movie(title):
+    """A local Plex library match for a watchlist item."""
+    movie = MagicMock()
+    movie.title = title
+    movie.TYPE = 'movie'
+    movie.librarySectionID = 1
+    return movie
+
+
+class TestWatchlistItemIsolation:
+    """A single failing item must not abort the rest of the watchlist."""
+
+    def _run(self, api, items):
+        account = MagicMock()
+        account.watchlist.return_value = items
+        account.userState.return_value = MagicMock(watchlistedAt=None)
+
+        processed = []
+
+        def fake_process_movie(file, username, watchlisted_at):
+            processed.append(file.title)
+            yield (f"/data/Movies/{file.title}.mkv", username, watchlisted_at, None, None, "watchlist")
+
+        with patch.object(PlexManager, '_process_watchlist_movie', side_effect=fake_process_movie), \
+             patch.object(api, 'search_plex', side_effect=lambda title, **kw: _local_movie(title)), \
+             patch('core.plex_api.MyPlexAccount', return_value=account), \
+             patch('core.plex_api.requests.Session', MagicMock()), \
+             patch('core.plex_api.time.sleep'):
+            results = list(api._fetch_user_watchlist(
+                user=None, valid_sections=[1], watchlist_episodes=3,
+                skip_watchlist=[], rss_url=None, filtered_sections=[1],
+            ))
+        return processed, results
+
+    def test_failing_item_does_not_drop_later_items(self):
+        api = _bare_api()
+        items = [
+            _watchlist_item("Weeds"),
+            _watchlist_item("Motherland", guids_error=SERVICE_UNAVAILABLE),
+            _watchlist_item("Slow Horses"),
+            _watchlist_item("The Menu"),
+        ]
+
+        processed, results = self._run(api, items)
+
+        # The 503 costs exactly one item; the three healthy ones still resolve.
+        assert processed == ["Weeds", "Slow Horses", "The Menu"]
+        assert len(results) == 3
+
+    def test_failing_item_marks_watchlist_incomplete(self):
+        """Dropped items mean the data really is incomplete — restore stays gated."""
+        api = _bare_api()
+        items = [
+            _watchlist_item("Weeds"),
+            _watchlist_item("Motherland", guids_error=SERVICE_UNAVAILABLE),
+        ]
+
+        self._run(api, items)
+
+        assert api.is_watchlist_data_complete() is False
+
+    def test_clean_watchlist_stays_complete(self):
+        api = _bare_api()
+        items = [_watchlist_item("Weeds"), _watchlist_item("Slow Horses")]
+
+        processed, results = self._run(api, items)
+
+        assert processed == ["Weeds", "Slow Horses"]
+        assert api.is_watchlist_data_complete() is True
+
+    def test_skipped_item_is_logged_with_title_and_user(self, caplog):
+        import logging
+        api = _bare_api()
+        items = [_watchlist_item("Motherland", guids_error=SERVICE_UNAVAILABLE)]
+
+        with caplog.at_level(logging.WARNING):
+            self._run(api, items)
+
+        messages = [rec.message for rec in caplog.records]
+        assert any("Motherland" in m and "Skipping watchlist item" in m for m in messages)
+
+    def test_transient_503_on_guids_is_retried(self):
+        """A 503 that clears on retry costs nothing at all."""
+        api = _bare_api()
+        item = MagicMock()
+        item.title = "Motherland"
+        item.type = 'movie'
+        calls = {"n": 0}
+
+        def flaky_guids(self):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise SERVICE_UNAVAILABLE
+            return []
+
+        type(item).guids = property(flaky_guids)
+
+        processed, results = self._run(api, [item])
+
+        assert processed == ["Motherland"]
+        assert calls["n"] == 2
+        assert api.is_watchlist_data_complete() is True


### PR DESCRIPTION
Three unrelated fixes that come down to the same thing: what a run notices, and what it tells you about it.

## plex.tv 5xx no longer aborts the rest of a watchlist

A 503 on one watchlist item's lazy `guids` reload raised out of the loop, so the rest of that user's watchlist was skipped and array restore was blocked for the whole run. plexapi surfaces these as `BadRequest` with the status only in the message text, so `_retry_plextv_call` now recognises 5xx there and retries. Each item also gets its own guard, so one bad item costs one item.

Also brings the eviction logs onto the same unit as everything else. They divided by `1e9` while the `[QUOTA]` lines used `1024**3`, so the same drive reported two different sizes depending on which line you read.

## No more "files not found on disk" during a healthy restore

Sizing a move to the array hands `get_total_size_of_files()` the `/mnt/user0/` paths. Those originals were renamed to `.plexcached` when PlexCache cached them, so every one legitimately misses and the warning fires on every clean restore, moments before the files are restored successfully. `warn_missing` is now False for array destinations. Cache destinations still warn, since a miss there is real.

## A full cache drive counts as space pressure

`_apply_cache_limit()` returns early when the active constraint leaves no room at all, and that return sits before the packing loop that sets `_cache_space_constrained`. So the case with the most evidence of pressure, where every candidate is dropped rather than just the ones that did not fit, was the one case that never signalled it.

`_reclaim_released_if_constrained()` gates entirely on that flag, which means the reclaim added in #203 could not fire on a full drive. Now set on that path too, for all three bottlenecks (quota, cache limit, min free space).

## Testing

1. With a watchlist where one item returns 503 on reload, run PlexCache. The run should continue through the remaining items instead of stopping, and the log should show the retry plus a single skipped item.
2. Cache some files, mark them watched in Plex, and run again. The restore should complete without warning that files are missing from disk.
3. Fill the cache past `plexcache_quota` (or over `cache_limit`, or below `min_free_space`) and run with files waiting to be cached. The log should show the constraint warning, and any released files should be reclaimed rather than left in place.
4. Check `[EVICTION]` and `[QUOTA]` log lines report the same size for the same drive.

## Relationship to the other open PR

This can merge before or after #205 (Add Recently Added view), in either order. The two share four files
(`core/app.py`, `core/plex_api.py`, `core/system_utils.py`, `tests/test_resolve_pins_to_paths.py`) but
touch different regions. I tested both merge sequences against `main` and both auto-merge with no
conflicts and produce an identical tree, so there is no ordering requirement.

Together the two PRs bring `main` level with the fork's `dev` branch as it stands today. Further
fixes are in progress on the fork and will follow as separate PRs.
