### PR TITLE
Add Recently Added view

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The original PlexCache app only worked for local users for most features, due to
 - (New v3) - **Smart Error Handling** - Migration stops early on critical errors (disk full, permissions).
 - (New v3) - **Async Maintenance** - Background thread execution for maintenance actions (restore, sync, protect, delete, fix) with real-time progress.
 - (New v3) - **Parallel File Operations** - Concurrent file moves/copies with configurable worker count.
-- (New v3) - **Cache Health Audit** - Detect unprotected files, orphaned backups, stale entries with one-click fixes.
+- (New v3) - **Cache Health Audit** - Detect untracked files, orphaned backups, stale entries with one-click fixes.
 - (New v3) - **ZFS Support** - Automatic detection of ZFS pool-only shares with correct path resolution.
 - (New v3) - **Min Free Space** - Safety floor setting to prevent caching when cache drive space is low.
 - (New v3) - **Docker Support** - Official container with Unraid template, auto-setup, and path translation.
@@ -114,7 +114,7 @@ python3 plexcache.py --web --port 8080     # Custom port
 - **Dashboard** - Real-time cache stats, Plex connection status, recent activity feed
 - **Cached Files** - Sortable file browser with filters, eviction controls
 - **Storage** - Drive analytics, breakdowns by source, largest/oldest files
-- **Maintenance** - Cache health audit, unprotected file detection, one-click fixes
+- **Maintenance** - Cache health audit, untracked file detection, one-click fixes
 - **Settings** - Full configuration UI with Plex OAuth, library selection, user toggles, test connection
 - **Schedule** - Automatic runs with interval or cron expressions
 - **Logs** - Real-time log viewer with search, filters, and live streaming

--- a/core/activity.py
+++ b/core/activity.py
@@ -13,7 +13,6 @@ All run paths write to the same files:
 import json
 import logging
 import os
-import re
 import threading
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -22,6 +21,7 @@ from dataclasses import dataclass, field
 
 from core.system_utils import format_bytes
 from core.file_operations import save_json_atomically
+from core.media_grouping import group_ordered, show_name_from_filename, stable_group_id
 
 
 # ---------------------------------------------------------------------------
@@ -302,12 +302,6 @@ def record_file_activity(
 # Show-episode grouping (shared by completion banner + dashboard)
 # ---------------------------------------------------------------------------
 
-# Matches "<show> - S##E##" — the Sonarr/Plex TV naming convention.
-# Non-TV files (movies, specials without episode numbering) don't match
-# and pass through as singletons.
-_SHOW_EPISODE_PATTERN = re.compile(r'^(.+?) - S\d+E\d+', re.IGNORECASE)
-
-
 def group_episodes_by_show(files: List[dict]) -> List[dict]:
     """Collapse multi-episode TV runs into a single parent row per show.
 
@@ -315,28 +309,43 @@ def group_episodes_by_show(files: List[dict]) -> List[dict]:
     individual rows (grouping a single entry offers no compression).
     Preserves first-seen order so re-renders don't reshuffle.
 
+    Activity entries carry a filename but no Plex metadata, so show identity
+    comes from the filename. The bucketing itself is `core.media_grouping`'s
+    shared rule — the same one the Recently Added views use with Plex-derived
+    keys, so both surfaces group a burst of episodes identically.
+
     Used by both the completion banner (`OperationRunner`) and the
     Recent Activity grouping service (`web/services/activity_grouping.py`).
     """
-    groups: dict = {}
-    order: list = []
+    def key_fn(f: dict):
+        show_name = show_name_from_filename(f.get("filename", ""))
+        # Action is part of the key: a show that was partly cached and partly
+        # restored in one run must not collapse into a single ambiguous row.
+        return (f.get("action", ""), show_name) if show_name else None
 
-    for idx, f in enumerate(files):
-        match = _SHOW_EPISODE_PATTERN.match(f.get("filename", ""))
-        if match:
-            show_name = match.group(1).strip()
-            key = (f.get("action", ""), show_name)
-            if key not in groups:
-                groups[key] = {
-                    "action": f.get("action", ""),
-                    "show_name": show_name,
-                    "episodes": [],
-                    "total_bytes": 0,
-                }
-                order.append(key)
+    result: List[dict] = []
+    for key, members in group_ordered(files, key_fn):
+        if key is None or len(members) == 1:
+            result.extend(members)
+            continue
+
+        total_bytes = sum(f.get("size_bytes", 0) for f in members)
+        # Use the newest episode's time as the group's representative time
+        # (episodes arrive newest-first when called from the dashboard path).
+        head = members[0]
+        result.append({
+            "action": key[0],
+            "is_group": True,
+            "show_name": key[1],
+            # Identity for the rendered group. Derived from the same (action,
+            # show) key the grouping used, so a show that was partly cached and
+            # partly restored in one run gets two distinct ids — keying the DOM
+            # on the show name alone made those two groups collide.
+            "group_id": stable_group_id(key[0], key[1]),
+            "episode_count": len(members),
             # Preserve per-episode metadata the dashboard renders (time, users)
             # in addition to the fields the completion banner consumes.
-            groups[key]["episodes"].append({
+            "episodes": [{
                 "filename": f.get("filename", ""),
                 "size": f.get("size", ""),
                 "size_bytes": f.get("size_bytes", 0),
@@ -344,45 +353,12 @@ def group_episodes_by_show(files: List[dict]) -> List[dict]:
                 "timestamp": f.get("timestamp", ""),
                 "time_display": f.get("time_display", ""),
                 "users": f.get("users", []),
-            })
-            groups[key]["total_bytes"] += f.get("size_bytes", 0)
-        else:
-            key = ("__singleton__", idx)
-            groups[key] = f
-            order.append(key)
-
-    result: List[dict] = []
-    for key in order:
-        entry = groups[key]
-        if key[0] == "__singleton__":
-            result.append(entry)
-        elif len(entry["episodes"]) == 1:
-            ep = entry["episodes"][0]
-            result.append({
-                "action": entry["action"],
-                "filename": ep["filename"],
-                "size": ep.get("size", ""),
-                "size_bytes": ep.get("size_bytes", 0),
-                "associated_files": ep.get("associated_files", []),
-                "timestamp": ep.get("timestamp", ""),
-                "time_display": ep.get("time_display", ""),
-                "users": ep.get("users", []),
-            })
-        else:
-            # Use the newest episode's time as the group's representative time
-            # (episodes arrive newest-first when called from the dashboard path).
-            head_ep = entry["episodes"][0]
-            result.append({
-                "action": entry["action"],
-                "is_group": True,
-                "show_name": entry["show_name"],
-                "episode_count": len(entry["episodes"]),
-                "episodes": entry["episodes"],
-                "size_bytes": entry["total_bytes"],
-                "size": format_bytes(entry["total_bytes"]) if entry["total_bytes"] > 0 else "",
-                "time_display": head_ep.get("time_display", ""),
-                "users": head_ep.get("users", []),
-            })
+            } for f in members],
+            "size_bytes": total_bytes,
+            "size": format_bytes(total_bytes) if total_bytes > 0 else "",
+            "time_display": head.get("time_display", ""),
+            "users": head.get("users", []),
+        })
 
     return result
 

--- a/core/app.py
+++ b/core/app.py
@@ -27,7 +27,7 @@ except ImportError:
 from core import __version__
 from core.config import ConfigManager
 from core.logging_config import LoggingManager, reset_warning_error_flag
-from core.system_utils import SystemDetector, FileUtils, SingleInstanceLock, get_disk_usage, get_array_direct_path, detect_zfs, set_zfs_prefixes, format_bytes, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary, sweep_empty_folders
+from core.system_utils import SystemDetector, FileUtils, SingleInstanceLock, get_disk_usage, get_array_direct_path, detect_zfs, set_zfs_prefixes, format_bytes, create_dir_with_ownership, check_cache_share_alignment, cleanup_empty_parent_folders, resolve_cache_boundary, sweep_empty_folders
 from core.plex_api import PlexManager, OnDeckItem
 from core.file_operations import MultiPathModifier, SiblingFileFinder, FileFilter, FileMover, PlexcachedRestorer, CacheTimestampTracker, WatchlistTracker, OnDeckTracker, CachePriorityManager, PlexcachedMigration, get_media_identity, find_matching_plexcached, is_directory_level_file, is_video_file, save_json_atomically
 from core.pinned_media import PinnedMediaTracker, resolve_pins_to_paths
@@ -579,7 +579,34 @@ class PlexCacheApp:
         enabled_mappings = [m for m in all_mappings if m.enabled]
         logging.info(f"[CONFIG] Using multi-path mode with {len(all_mappings)} mappings ({len(enabled_mappings)} enabled)")
         self.file_path_modifier = MultiPathModifier(mappings=all_mappings)
+        self._warn_on_share_misalignment(enabled_mappings)
 
+        self._check_legacy_path_arrays()
+
+    def _warn_on_share_misalignment(self, mappings) -> None:
+        """Warn when a mapping caches into a different Unraid share than its media.
+
+        Unraid merges a share's pool and array tiers under one /mnt/user/ path, so
+        caching only works when both tiers belong to the same share. Pointing the
+        cache at a different share leaves Plex reading a .plexcached stub and
+        reporting the file missing (issues #189, #196). This is advisory only —
+        unusual but valid layouts exist, and the check stays quiet when it can't
+        resolve a share.
+        """
+        for mapping in mappings:
+            if not getattr(mapping, "cacheable", True):
+                continue
+            warning = check_cache_share_alignment(
+                getattr(mapping, "real_path", "") or "",
+                getattr(mapping, "cache_path", "") or "",
+                getattr(mapping, "host_cache_path", None),
+            )
+            if warning:
+                name = getattr(mapping, "name", None) or getattr(mapping, "real_path", "mapping")
+                logging.warning(f"[CONFIG] '{name}': {warning['message']}")
+
+    def _check_legacy_path_arrays(self) -> None:
+        """Log guidance when deprecated legacy path arrays are still configured."""
         if self.config_manager.has_legacy_path_arrays():
             legacy_info = self.config_manager.get_legacy_array_info()
             logging.info(f"[CONFIG] Legacy path arrays detected: {legacy_info}")

--- a/core/app.py
+++ b/core/app.py
@@ -1360,6 +1360,10 @@ class PlexCacheApp:
                 self.plex_manager.plex,
                 self.pinned_tracker,
                 preference=preference,
+                # The one caller that prunes. Read-only render paths pass the
+                # default (False) so loading a page can't delete a pin whose
+                # item is only transiently missing from Plex.
+                prune=True,
             )
         except Exception as e:
             logging.error(

--- a/core/config.py
+++ b/core/config.py
@@ -391,10 +391,18 @@ class ConfigManager:
         self.exit_if_active_session = False
         self._path_settings_migrated = False
         
-    def load_config(self) -> None:
-        """Load configuration from file and validate."""
+    def load_config(self, persist_updates: bool = True) -> None:
+        """Load configuration from file and validate.
+
+        Args:
+            persist_updates: When True (the CLI/run path), write back any
+                migrations and normalizations this load performed, and ensure
+                the data folder exists. Pass False from read-only callers such
+                as a web GET handler: a page render must not rewrite the user's
+                settings file or migrate tracking files as a side effect.
+        """
         logging.debug(f"Loading configuration from: {self.config_file}")
-        
+
         if not self.config_file.exists():
             logging.error(f"Settings file not found: {self.config_file}")
             raise FileNotFoundError(f"Settings file not found: {self.config_file}")
@@ -416,10 +424,11 @@ class ConfigManager:
         self._process_first_start()
         self._load_all_configs()
         self._validate_values()
-        self._save_updated_config()
 
-        # Ensure data folder exists and migrate tracking files if needed
-        self.ensure_data_folder()
+        if persist_updates:
+            self._save_updated_config()
+            # Ensure data folder exists and migrate tracking files if needed
+            self.ensure_data_folder()
 
         logging.debug("Configuration loaded and validated successfully")
     

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -3860,7 +3860,7 @@ class FileFilter:
                 # The file may not be in ondeck/watchlist API response but is actively being played
                 if files_to_skip and check_path in files_to_skip:
                     display_name = self._extract_display_name(cache_file)
-                    logging.debug(f"Active session, keeping protected: {display_name}")
+                    logging.debug(f"Active session, keeping in cache: {display_name}")
                     continue
 
                 # Skip files with active hard links

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -140,6 +140,36 @@ def name_matches_video_stem(name: str, stem: str) -> bool:
     return not name[len(stem)].isalnum()
 
 
+def is_sidecar_candidate(name: str) -> bool:
+    """Check whether a directory entry is eligible to be a media sidecar.
+
+    The app-wide admission rule, shared by every directory scan that looks for
+    subtitles, artwork or NFOs. Three exclusions, each for its own reason:
+
+    * a dotfile is OS or editor noise (``.DS_Store``, ``.nfo.swp``);
+    * a ``.plexcached`` name is the array backup of a cached file, not a
+      sidecar — and it slips a naive stem test, because
+      ``splitext("Movie.mkv.plexcached")[0]`` is ``"Movie.mkv"``, which starts
+      with ``"Movie."``;
+    * another video is its own media item. Plex local extras land beside the
+      feature as ``<stem>-trailer.mkv`` / ``<stem>-behindthescenes.mkv`` and
+      would otherwise be attached to it.
+
+    Says nothing about ownership. Pair with :func:`name_matches_video_stem`
+    when the caller needs "does this sidecar belong to *that* video".
+
+    Args:
+        name: A directory entry's basename. No stat call required, so this can
+            be applied before ``entry.is_file()``.
+
+    Returns:
+        True if the entry is eligible to be some video's sidecar.
+    """
+    return not (name.startswith('.')
+                or name.endswith(PLEXCACHED_EXTENSION)
+                or is_video_file(name))
+
+
 def is_season_like_folder(folder_name: str) -> bool:
     """Check if a folder name looks like a TV season directory.
 
@@ -3151,6 +3181,11 @@ class SiblingFileFinder:
                 if is_video_file(name):
                     video_stems.add(os.path.splitext(name)[0])
                 else:
+                    # Reaching here means is_sidecar_candidate(name) is True. The
+                    # branches stay explicit rather than calling it: this is a
+                    # partition, not a filter — every name the predicate rejects
+                    # still has to be classified (a .plexcached video contributes
+                    # a stem above), and a boolean cannot carry that.
                     sibling_paths.append(entry.path)
         except PermissionError as e:
             logging.error(f"Cannot access directory {directory_path}. Permission denied. {type(e).__name__}: {e}")
@@ -3179,10 +3214,8 @@ class SiblingFileFinder:
                 entry.path
                 for entry in os.scandir(directory_path)
                 if entry.is_file()
-                and not entry.name.startswith('.')
-                and not entry.name.endswith('.plexcached')
+                and is_sidecar_candidate(entry.name)
                 and entry.name != file_basename
-                and not is_video_file(entry.name)
             ]
         except PermissionError as e:
             logging.error(f"Cannot access directory {directory_path}. Permission denied. {type(e).__name__}: {e}")

--- a/core/media_grouping.py
+++ b/core/media_grouping.py
@@ -109,3 +109,32 @@ def format_season_range(seasons: List[int]) -> str:
     if len(known) == 1:
         return f"Season {known[0]}"
     return f"Seasons {known[0]}–{known[-1]}"
+
+
+def format_season_episode(season: Any, episode: Any) -> str:
+    """``"S01E03"`` for a numbered episode, ``""`` when either number is unknown.
+
+    Both numbers or neither: a half-known episode renders as nothing rather
+    than a fabricated ``S00E00``, which would be indistinguishable from a real
+    Specials episode 0. Callers fall back to the episode title.
+
+    The ``isinstance(..., int)`` guard is load-bearing, not defensive.
+    ``plexapi.utils.cast(int, value)`` returns ``float('nan')`` — not ``None``
+    — for anything it cannot parse, including the empty string. A ``None``
+    check therefore passes NaN straight into the format, where it raises
+    ``ValueError: cannot convert float NaN to integer``. ``bool`` is excluded
+    separately because ``isinstance(True, int)`` is True, and ``S01ETrue`` is
+    not a thing. This matches Jinja's own ``is integer`` test.
+
+    Args:
+        season: Season number, or any unparsed value from a Plex listing.
+        episode: Episode number, same.
+
+    Returns:
+        The ``SxxEyy`` code, or ``""`` if either number is unusable.
+    """
+    if isinstance(season, bool) or isinstance(episode, bool):
+        return ""
+    if isinstance(season, int) and isinstance(episode, int):
+        return f"S{season:02d}E{episode:02d}"
+    return ""

--- a/core/media_grouping.py
+++ b/core/media_grouping.py
@@ -1,0 +1,111 @@
+"""Shared media-grouping primitives.
+
+One definition, for the whole app, of "these items belong to the same show"
+and "how does an ordered sequence collapse into groups". Every surface that
+lists media — the Recent Activity feed, the completion banner, the Recently
+Added page and its dashboard widget — builds on this module, so a burst of
+episodes reads the same way wherever it appears.
+
+Two layers, deliberately separate:
+
+* ``parse_show_episode()`` / ``show_name_from_filename()`` — derive show
+  identity from a Sonarr/Plex-style *filename*. Used where the only thing on
+  hand is a path (the activity feed records filenames, not Plex metadata).
+* ``group_ordered()`` — the ordering/bucketing rule itself, independent of
+  where the key comes from. Callers that *do* have Plex metadata (Recently
+  Added) key on that instead of a filename and still group identically.
+
+No web framework imports — usable from ``core/`` (CLI path) and ``web/`` alike.
+"""
+
+import hashlib
+import re
+from typing import Any, Callable, Hashable, Iterable, List, Optional, Tuple
+
+# Matches "<show> - S##E##" — the Sonarr/Plex TV naming convention.
+# Non-TV files (movies, specials without episode numbering) don't match and
+# are left ungrouped by the callers below.
+SHOW_EPISODE_PATTERN = re.compile(r'^(.+?) - S(\d+)E(\d+)', re.IGNORECASE)
+
+
+def parse_show_episode(filename: str) -> Optional[Tuple[str, int, int]]:
+    """``(show, season, episode)`` parsed from a filename, or None if it isn't
+    a recognizably-numbered TV episode."""
+    match = SHOW_EPISODE_PATTERN.match(filename or "")
+    if not match:
+        return None
+    return match.group(1).strip(), int(match.group(2)), int(match.group(3))
+
+
+def show_name_from_filename(filename: str) -> Optional[str]:
+    """Show name from a Sonarr/Plex-style filename, or None if it isn't one."""
+    parsed = parse_show_episode(filename)
+    return parsed[0] if parsed else None
+
+
+def group_ordered(
+    items: Iterable[Any],
+    key_fn: Callable[[Any], Optional[Hashable]],
+) -> List[Tuple[Optional[Hashable], List[Any]]]:
+    """Bucket ``items`` by ``key_fn``, preserving first-seen order.
+
+    ``key_fn`` returns a hashable group key, or ``None`` for an item that never
+    groups (a movie, an unparseable filename). Each ungroupable item becomes
+    its own single-member bucket keyed ``None``, so callers can emit everything
+    in one pass and still render those in place.
+
+    A group anchors at the position of its *first* member, so re-rendering the
+    same list never reshuffles rows.
+
+    Returns a list of ``(key, members)`` pairs. Buckets holding a single member
+    are returned as-is — every current caller renders those as a plain row,
+    since grouping one item offers no compression.
+    """
+    buckets: dict = {}
+    order: List[Tuple[Optional[Hashable], Any]] = []
+
+    for idx, item in enumerate(items):
+        key = key_fn(item)
+        # Ungroupable items get a positional bucket key so two of them never
+        # collide, while the key reported back to the caller stays None.
+        bucket_key = key if key is not None else ("__single__", idx)
+        if bucket_key not in buckets:
+            buckets[bucket_key] = []
+            order.append((key, bucket_key))
+        buckets[bucket_key].append(item)
+
+    return [(key, buckets[bucket_key]) for key, bucket_key in order]
+
+
+def stable_group_id(*parts: Any) -> str:
+    """Deterministic DOM id for a group, derived from its grouping key.
+
+    Two properties the surfaces depend on:
+
+    * **Stable across re-renders.** Derived from the key, not from list
+      position, so a poll that re-renders the same list produces the same ids
+      and an expanded group stays expanded (the completion banner re-renders
+      every 2s and restores expand state by id).
+    * **Safe in an HTML attribute.** Carries no user content, so interpolating
+      it into ``data-*`` can't be broken by a title containing a quote — which
+      a raw show name can.
+
+    Uniqueness holds *within one grouping call*. A page that renders several
+    grouped lists must namespace it (Recent Activity prefixes the run id), or
+    the same show in two runs would collide.
+    """
+    raw = "\x1f".join("" if p is None else str(p) for p in parts)
+    return "g" + hashlib.sha1(raw.encode("utf-8")).hexdigest()[:10]
+
+
+def format_season_range(seasons: List[int]) -> str:
+    """Human label for the seasons covered by a group.
+
+    ``[1] -> "Season 1"``, ``[1, 2] -> "Seasons 1–2"``, ``[] -> ""``.
+    """
+    known = sorted({s for s in seasons if s is not None})
+    if not known:
+        return ""
+    if len(known) == 1:
+        return f"Season {known[0]}"
+    return f"Seasons {known[0]}–{known[-1]}"

--- a/core/pinned_cli.py
+++ b/core/pinned_cli.py
@@ -124,7 +124,12 @@ def handle_list_pins(config_manager: ConfigManager) -> None:
         if resolved:
             print(f"\n  Resolved to {len(resolved)} file(s) (preference: {preference})")
         if orphaned:
-            print(f"  {len(orphaned)} orphaned pin(s) were auto-removed (items no longer in Plex)")
+            # Listing is read-only: it reports unresolvable pins but does not
+            # remove them. The next full run prunes (prune=True there).
+            print(
+                f"  {len(orphaned)} pin(s) could not be resolved in Plex "
+                f"(removed on the next run if still missing)"
+            )
 
 
 def handle_pin(config_manager: ConfigManager, rating_key: str) -> None:

--- a/core/pinned_media.py
+++ b/core/pinned_media.py
@@ -229,18 +229,27 @@ def resolve_pins_to_paths(
     plex_server: Any,
     tracker: "PinnedMediaTracker",
     preference: str = "highest",
+    prune: bool = False,
 ) -> Tuple[List[Tuple[str, str, str]], List[str]]:
     """Resolve every pin in the tracker to its file paths.
 
-    Orphan cleanup: pins whose ``rating_key`` is no longer reachable in Plex
-    (item deleted, library removed) are removed from the tracker and returned
-    in the ``orphaned`` list for caller-side logging/reporting.
+    Orphan handling: pins whose ``rating_key`` is no longer reachable in Plex
+    (item deleted, library removed) are reported in the ``orphaned`` list, and
+    removed from the tracker only when ``prune`` is True.
 
     Args:
         plex_server: A connected plexapi ``PlexServer`` instance. Lazily
             references plexapi so unit tests can pass a mock.
         tracker: The ``PinnedMediaTracker`` instance.
         preference: Value from ``pinned_preferred_resolution``.
+        prune: Whether to delete unresolvable pins from the tracker. Defaults
+            to False so read-only callers never mutate user state: this
+            resolver runs on plain page renders (Cached Files, Recently Added,
+            the dashboard widget), and a rating_key can be transiently absent —
+            the window Sonarr/Radarr's "Empty Trash after every scan" opens
+            mid-upgrade — which would silently and permanently drop the pin.
+            Pass True only from the CLI/scheduled run, where the removal is
+            logged and reported.
 
     Returns:
         ``(resolved, orphaned)`` where:
@@ -248,7 +257,8 @@ def resolve_pins_to_paths(
         - ``resolved`` is a list of ``(plex_file_path, rating_key, pin_type)``
           tuples. Paths are still in Plex form — the caller is responsible for
           running them through the path modifier to get real paths.
-        - ``orphaned`` is a list of rating_key strings that were removed.
+        - ``orphaned`` is a list of rating_key strings that could not be
+          resolved (removed from the tracker only when ``prune`` is True).
     """
     # Lazy import so tests that don't need plexapi can still import this module.
     # Fall back to Exception when plexapi is missing OR when it's been mocked
@@ -298,11 +308,18 @@ def resolve_pins_to_paths(
                     )
                     time.sleep(_PIN_FETCH_RETRY_WAIT)
             except (NotFound, ValueError) as e:
-                logging.warning(
-                    f"Pinned item no longer in Plex: '{title}' "
-                    f"(rating_key={rk}) — removing pin. ({type(e).__name__}: {e})"
-                )
-                tracker.remove_pin(rk)
+                if prune:
+                    logging.warning(
+                        f"Pinned item no longer in Plex: '{title}' "
+                        f"(rating_key={rk}) — removing pin. ({type(e).__name__}: {e})"
+                    )
+                    tracker.remove_pin(rk)
+                else:
+                    logging.debug(
+                        f"Pinned item not resolvable right now: '{title}' "
+                        f"(rating_key={rk}) — leaving pin in place. "
+                        f"({type(e).__name__}: {e})"
+                    )
                 orphaned.append(rk)
                 item = None
                 last_transient_err = None

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -10,7 +10,7 @@ import re
 import threading
 import time
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timedelta
 from email.utils import parsedate_to_datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List, Optional, Generator, Tuple, Dict, Set
@@ -124,6 +124,37 @@ class OnDeckItem:
     episode_info: Optional[Dict[str, any]] = None
     is_current_ondeck: bool = False
     rating_key: Optional[str] = None
+
+
+@dataclass
+class RecentlyAddedItem:
+    """Represents a recently-added library item with metadata.
+
+    Unlike OnDeck/Watchlist items, recently-added media is server-wide
+    (library-level), so there is no per-user ``username`` field. One item is
+    emitted per media file (part).
+
+    Attributes:
+        file_path: Plex path to the media file.
+        rating_key: Plex rating key (for pin lookups and version grouping).
+        title: The item's own title — episode title for episodes, movie title
+            for movies. Use ``episode_info`` for show/season context.
+        media_type: "movie" or "episode".
+        added_at: When the item was added to the library (None if unavailable).
+        library_title: Display name of the source library section.
+        library_section_id: The library section id (matches ``valid_sections``).
+        size: File size in bytes for this part (0 if unavailable).
+        episode_info: For episodes, dict with 'show', 'season', 'episode' keys.
+    """
+    file_path: str
+    rating_key: Optional[str] = None
+    title: str = ""
+    media_type: str = "movie"
+    added_at: Optional[datetime] = None
+    library_title: str = ""
+    library_section_id: Optional[int] = None
+    size: int = 0
+    episode_info: Optional[Dict[str, any]] = None
 
 
 # API delay between plex.tv calls (seconds)
@@ -1597,6 +1628,100 @@ class PlexManager:
 
         if unknown_user_ids:
             logging.debug(f"[PLEX API] {len(unknown_user_ids)} unknown user ID(s) in RSS feed: {', '.join(sorted(unknown_user_ids))}. Run 'python3 plexcache_setup.py' and refresh users to resolve.")
+
+    def get_recently_added_media(self, valid_sections: List[int], days_to_monitor: int,
+                                 max_items: int = 100) -> List['RecentlyAddedItem']:
+        """Get recently-added media across enabled libraries (server-wide).
+
+        Recently-added is a library-level view, so this uses the main account
+        only — there is no per-user token machinery (unlike OnDeck/Watchlist).
+
+        Args:
+            valid_sections: Library section ids to include (matches enabled
+                path mappings). An empty list means all available sections.
+            days_to_monitor: Only include items added within this many days.
+            max_items: Cap on the number of items returned (newest first).
+
+        Returns:
+            List of RecentlyAddedItem, newest first, one entry per media file.
+        """
+        items: List[RecentlyAddedItem] = []
+        cutoff = datetime.now() - timedelta(days=days_to_monitor)
+
+        try:
+            sections = self.plex.library.sections()
+        except Exception as e:
+            _log_api_error("list library sections for recently added", e)
+            return items
+
+        section_ids = set(valid_sections or [])
+        for section in sections:
+            if section_ids and section.key not in section_ids:
+                continue
+            try:
+                # recentlyAdded() returns newest first; the days cutoff trims further.
+                recent = section.recentlyAdded(maxresults=max_items)
+            except Exception as e:
+                _log_api_error(
+                    f"fetch recently added for section '{getattr(section, 'title', '?')}'", e
+                )
+                continue
+
+            for video in recent:
+                media_type = getattr(video, 'type', None)
+                if media_type not in ('movie', 'episode'):
+                    # Skip season/show wrappers — we surface individual files.
+                    continue
+
+                added_at = getattr(video, 'addedAt', None)
+                if added_at is not None and added_at < cutoff:
+                    continue
+
+                episode_info = None
+                if media_type == 'episode':
+                    season = getattr(video, 'parentIndex', None)
+                    episode = getattr(video, 'index', None)
+                    if season is not None and episode is not None:
+                        episode_info = {
+                            'show': getattr(video, 'grandparentTitle', None),
+                            'season': season,
+                            'episode': episode,
+                        }
+
+                rating_key = str(getattr(video, 'ratingKey', '') or '')
+                title = getattr(video, 'title', '') or ''
+                library_title = getattr(section, 'title', '') or ''
+                library_section_id = getattr(section, 'key', None)
+
+                for media in getattr(video, 'media', []) or []:
+                    for part in getattr(media, 'parts', []) or []:
+                        if not getattr(part, 'file', None):
+                            continue
+                        items.append(RecentlyAddedItem(
+                            file_path=part.file,
+                            rating_key=rating_key,
+                            title=title,
+                            media_type=media_type,
+                            added_at=added_at,
+                            library_title=library_title,
+                            library_section_id=library_section_id,
+                            size=int(getattr(part, 'size', 0) or 0),
+                            episode_info=episode_info,
+                        ))
+
+        # Newest first, then cap. Items without added_at sort last.
+        items.sort(key=lambda i: i.added_at or datetime.min, reverse=True)
+        if len(items) > max_items:
+            logging.info(
+                f"Recently added: {len(items)} files found, capping display to {max_items}"
+            )
+            items = items[:max_items]
+
+        logging.debug(
+            f"Recently added: returning {len(items)} item(s) from "
+            f"{len(section_ids) or 'all'} section(s)"
+        )
+        return items
 
     def get_watchlist_media(self, valid_sections: List[int], watchlist_episodes: int,
                             users_toggle: bool, skip_watchlist: List[str], rss_url: Optional[str] = None,

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -1654,9 +1654,11 @@ class PlexManager:
             _log_api_error("list library sections for recently added", e)
             return items
 
-        section_ids = set(valid_sections or [])
+        # plexapi exposes section.key as a string ("1"), while valid_sections
+        # from config are ints — compare as strings so the filter actually matches.
+        section_ids = {str(s) for s in (valid_sections or [])}
         for section in sections:
-            if section_ids and section.key not in section_ids:
+            if section_ids and str(getattr(section, 'key', '')) not in section_ids:
                 continue
             try:
                 # recentlyAdded() returns newest first; the days cutoff trims further.

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -1788,14 +1788,17 @@ class PlexManager:
                 if media_type == 'episode':
                     # _partial_attr, not getattr: these are the two reads that
                     # legitimately hold None and so trigger the reload above.
-                    season = _partial_attr(video, 'parentIndex')
-                    episode = _partial_attr(video, 'index')
-                    if season is not None and episode is not None:
-                        episode_info = {
-                            'show': getattr(video, 'grandparentTitle', None),
-                            'season': season,
-                            'episode': episode,
-                        }
+                    # Emitted whenever the item is an episode, even with the
+                    # numbering missing — the show name is the more useful half
+                    # and gating the whole dict on the numbers threw it away,
+                    # leaving the row to render as a movie. Renderers format the
+                    # code with format_season_episode(), which yields "" rather
+                    # than a fabricated S00E00 when a number is unusable.
+                    episode_info = {
+                        'show': getattr(video, 'grandparentTitle', None),
+                        'season': _partial_attr(video, 'parentIndex'),
+                        'episode': _partial_attr(video, 'index'),
+                    }
 
                 rating_key = str(getattr(video, 'ratingKey', '') or '')
                 title = getattr(video, 'title', '') or ''

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -165,6 +165,26 @@ class RecentlyAddedItem:
     version_files: List[Dict[str, any]] = field(default_factory=list)
 
 
+@dataclass
+class RecentlyAddedResult:
+    """What a recently-added sweep found, and what it could not read.
+
+    A per-library fetch can fail on its own — a section that times out or 5xxes
+    while its neighbours answer. Returning only the items would make that
+    library indistinguishable from one that genuinely had nothing new, so the
+    page would state "Nothing added" about media it never managed to look at.
+
+    Attributes:
+        items: Recently-added items, newest first, one entry per Plex item.
+        unreadable_libraries: Titles of sections that were attempted and
+            failed. Empty on a clean sweep. A total failure — no section
+            readable at all — raises instead, since there is no partial
+            result to report.
+    """
+    items: List[RecentlyAddedItem] = field(default_factory=list)
+    unreadable_libraries: List[str] = field(default_factory=list)
+
+
 def _partial_attr(obj: Any, name: str, default: Any = None) -> Any:
     """Read an attribute off a plexapi *listing* object without failing the caller.
 
@@ -1677,7 +1697,7 @@ class PlexManager:
 
     def get_recently_added_media(self, valid_sections: List[int], days_to_monitor: int,
                                  max_items: int = 100,
-                                 version_preference: str = "highest") -> List['RecentlyAddedItem']:
+                                 version_preference: str = "highest") -> 'RecentlyAddedResult':
         """Get recently-added media across enabled libraries (server-wide).
 
         Recently-added is a library-level view, so this uses the main account
@@ -1693,17 +1713,30 @@ class PlexManager:
                 choice the pin and caching paths make.
 
         Returns:
-            List of RecentlyAddedItem, newest first, one entry per Plex item
-            (not per file). ``version_files`` carries every underlying file.
+            RecentlyAddedResult. ``items`` is newest first, one entry per Plex
+            item (not per file) — ``version_files`` carries every underlying
+            file. ``unreadable_libraries`` names any section that was attempted
+            and failed, so the caller can say so instead of reporting an empty
+            library as empty.
+
+        Raises:
+            Exception: If the library list itself cannot be read. Nothing was
+                enumerated in that case, so there is no partial result and the
+                caller must render the failure rather than an empty view.
         """
         items: List[RecentlyAddedItem] = []
+        unreadable: List[str] = []
+        read_sections: List[str] = []
         cutoff = datetime.now() - timedelta(days=days_to_monitor)
 
         try:
             sections = self.plex.library.sections()
         except Exception as e:
+            # Nothing was enumerated, so there is no partial result to report.
+            # Returning [] here would render as "Nothing added", stating a fact
+            # about libraries that were never contacted.
             _log_api_error("list library sections for recently added", e)
-            return items
+            raise
 
         # plexapi exposes section.key as a string ("1"), while valid_sections
         # from config are ints — compare as strings so the filter actually matches.
@@ -1721,11 +1754,16 @@ class PlexManager:
                 else:
                     recent = section.recentlyAdded(maxresults=max_items)
             except Exception as e:
-                _log_api_error(
-                    f"fetch recently added for section '{getattr(section, 'title', '?')}'", e
+                section_title = str(
+                    getattr(section, 'title', '') or f"section {getattr(section, 'key', '?')}"
                 )
+                _log_api_error(f"fetch recently added for section '{section_title}'", e)
+                # Name it rather than dropping it: an unreadable library that
+                # vanishes silently looks exactly like an empty one.
+                unreadable.append(section_title)
                 continue
 
+            read_sections.append(str(getattr(section, 'title', '?')))
             section_kept = 0
             for video in recent:
                 # Read-only view over listing fields: opt out of plexapi's lazy
@@ -1830,11 +1868,17 @@ class PlexManager:
             )
             items = items[:max_items]
 
-        logging.info(
+        # Count sections actually answered, not the ones config asked for —
+        # the old form reported "from 2 section(s)" even when both had failed.
+        answered = len(read_sections)
+        summary = (
             f"Recently added: returning {len(items)} item(s) from "
-            f"{len(section_ids) or 'all'} section(s) within {days_to_monitor}d"
+            f"{answered} section(s) within {days_to_monitor}d"
         )
-        return items
+        if unreadable:
+            summary += f"; {len(unreadable)} unreadable ({', '.join(unreadable)})"
+        logging.info(summary)
+        return RecentlyAddedResult(items=items, unreadable_libraries=unreadable)
 
     def get_watchlist_media(self, valid_sections: List[int], watchlist_episodes: int,
                             users_toggle: bool, skip_watchlist: List[str], rss_url: Optional[str] = None,

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -155,10 +155,37 @@ class RecentlyAddedItem:
     library_section_id: Optional[int] = None
     size: int = 0
     episode_info: Optional[Dict[str, any]] = None
+    # For episodes, the *show's* rating key. Stable identity for grouping —
+    # two distinct shows can share a title ("The Office" US and UK), and
+    # grouping on the display title merges them into one nonsense group.
+    show_rating_key: str = ""
     # Every file behind this item, across all versions:
     # [{file_path, size, is_preferred, label}]. ``file_path``/``size`` above
     # describe the PREFERRED version only — the one PlexCache caches and pins.
     version_files: List[Dict[str, any]] = field(default_factory=list)
+
+
+def _partial_attr(obj: Any, name: str, default: Any = None) -> Any:
+    """Read an attribute off a plexapi *listing* object without failing the caller.
+
+    Section listings hand back partial objects, and plexapi reloads on any
+    ``None``/``[]`` value — so reading an unnumbered special's ``index`` or an
+    unanalyzed item's ``media`` fires a live metadata GET that can 5xx or time
+    out. ``getattr``'s 3-arg default only swallows ``AttributeError``, not
+    transport errors, so one bad item would otherwise abort the whole fetch and
+    discard every library already collected.
+    """
+    try:
+        return getattr(obj, name, default)
+    except Exception as e:
+        # Read the label out of __dict__ so this can't re-enter __getattribute__
+        # and raise a second time; plexapi's own error path does the same.
+        label = obj.__dict__.get('title') or obj.__dict__.get('ratingKey') or '?'
+        logging.warning(
+            f"Recently added: could not read '{name}' for '{label}': "
+            f"{type(e).__name__}: {e}"
+        )
+        return default
 
 
 def _media_version_label(media: Any) -> str:
@@ -397,11 +424,13 @@ class PlexManager:
 
     def __init__(self, plex_url: str, plex_token: str, retry_limit: int = 3, delay: int = 5,
                  token_cache_file: Optional[str] = None, rss_cache_file: Optional[str] = None,
-                 plex_db_path: str = "", watchlist_enabled: bool = True):
+                 plex_db_path: str = "", watchlist_enabled: bool = True,
+                 timeout: Optional[int] = None):
         self.plex_url = plex_url
         self.plex_token = plex_token
         self.retry_limit = retry_limit
         self.delay = delay
+        self.timeout = timeout
         self.plex = None
         self._token_cache = UserTokenCache(cache_file=token_cache_file, cache_expiry_hours=24)
         self._rss_cache_file = rss_cache_file  # Path to RSS cache file
@@ -425,7 +454,7 @@ class PlexManager:
         logging.debug(f"Connecting to Plex server: {self.plex_url}")
 
         try:
-            self.plex = PlexServer(self.plex_url, self.plex_token)
+            self.plex = PlexServer(self.plex_url, self.plex_token, timeout=self.timeout)
             logging.debug(f"Plex server version: {self.plex.version}")
         except Exception as e:
             # Extract the root cause from nested exception chains
@@ -1699,6 +1728,15 @@ class PlexManager:
 
             section_kept = 0
             for video in recent:
+                # Read-only view over listing fields: opt out of plexapi's lazy
+                # reload so a null `index` (unnumbered special) or empty `media`
+                # (unanalyzed item) costs no per-item metadata GET, and so it
+                # can't 5xx mid-fetch. Best-effort — older plexapi lacks the attr.
+                try:
+                    video._autoReload = False
+                except Exception:
+                    pass
+
                 media_type = getattr(video, 'type', None)
                 if media_type not in ('movie', 'episode'):
                     # Skip season/show wrappers — we surface individual files.
@@ -1710,8 +1748,10 @@ class PlexManager:
 
                 episode_info = None
                 if media_type == 'episode':
-                    season = getattr(video, 'parentIndex', None)
-                    episode = getattr(video, 'index', None)
+                    # _partial_attr, not getattr: these are the two reads that
+                    # legitimately hold None and so trigger the reload above.
+                    season = _partial_attr(video, 'parentIndex')
+                    episode = _partial_attr(video, 'index')
                     if season is not None and episode is not None:
                         episode_info = {
                             'show': getattr(video, 'grandparentTitle', None),
@@ -1732,7 +1772,7 @@ class PlexManager:
                 # where the second reads "Pin" but unpins. Multi-PART items
                 # (cd1/cd2) are parts of ONE Media and are all cached together,
                 # so they stay folded into this item's file list.
-                medias = list(getattr(video, 'media', None) or [])
+                medias = list(_partial_attr(video, 'media') or [])
                 if not medias:
                     continue
                 try:
@@ -1771,6 +1811,8 @@ class PlexManager:
                     # the item's footprint is their sum.
                     size=sum(f['size'] for f in preferred_files),
                     episode_info=episode_info,
+                    # plexapi casts this to int; grouping keys on it as a string.
+                    show_rating_key=str(_partial_attr(video, 'grandparentRatingKey') or ''),
                     version_files=version_files,
                 ))
                 section_kept += 1

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -13,8 +13,8 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
 from email.utils import parsedate_to_datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Optional, Generator, Tuple, Dict, Set
-from dataclasses import dataclass
+from typing import Any, List, Optional, Generator, Tuple, Dict, Set
+from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
 from plexapi.server import PlexServer
@@ -155,6 +155,23 @@ class RecentlyAddedItem:
     library_section_id: Optional[int] = None
     size: int = 0
     episode_info: Optional[Dict[str, any]] = None
+    # Every file behind this item, across all versions:
+    # [{file_path, size, is_preferred, label}]. ``file_path``/``size`` above
+    # describe the PREFERRED version only — the one PlexCache caches and pins.
+    version_files: List[Dict[str, any]] = field(default_factory=list)
+
+
+def _media_version_label(media: Any) -> str:
+    """Short human label for a Plex Media version, e.g. "4k" or "1080p".
+
+    Used to distinguish rows in the multi-version expand detail. Falls back to
+    an empty string when Plex reports no resolution.
+    """
+    res = getattr(media, 'videoResolution', None)
+    if not res:
+        return ""
+    res = str(res).strip().lower()
+    return res if res.endswith('k') else f"{res}p"
 
 
 # API delay between plex.tv calls (seconds)
@@ -1630,7 +1647,8 @@ class PlexManager:
             logging.debug(f"[PLEX API] {len(unknown_user_ids)} unknown user ID(s) in RSS feed: {', '.join(sorted(unknown_user_ids))}. Run 'python3 plexcache_setup.py' and refresh users to resolve.")
 
     def get_recently_added_media(self, valid_sections: List[int], days_to_monitor: int,
-                                 max_items: int = 100) -> List['RecentlyAddedItem']:
+                                 max_items: int = 100,
+                                 version_preference: str = "highest") -> List['RecentlyAddedItem']:
         """Get recently-added media across enabled libraries (server-wide).
 
         Recently-added is a library-level view, so this uses the main account
@@ -1641,9 +1659,13 @@ class PlexManager:
                 path mappings). An empty list means all available sections.
             days_to_monitor: Only include items added within this many days.
             max_items: Cap on the number of items returned (newest first).
+            version_preference: ``pinned_preferred_resolution`` value used to
+                pick which version represents a multi-version item — the same
+                choice the pin and caching paths make.
 
         Returns:
-            List of RecentlyAddedItem, newest first, one entry per media file.
+            List of RecentlyAddedItem, newest first, one entry per Plex item
+            (not per file). ``version_files`` carries every underlying file.
         """
         items: List[RecentlyAddedItem] = []
         cutoff = datetime.now() - timedelta(days=days_to_monitor)
@@ -1702,22 +1724,56 @@ class PlexManager:
                 library_title = getattr(section, 'title', '') or ''
                 library_section_id = getattr(section, 'key', None)
 
-                for media in getattr(video, 'media', []) or []:
-                    for part in getattr(media, 'parts', []) or []:
-                        if not getattr(part, 'file', None):
+                # One item per rating_key, describing the version PlexCache would
+                # actually manage. Multi-VERSION items (4K + 1080p) are distinct
+                # Media objects and only the preferred one is ever cached or
+                # pinned (core/pinned_media.select_media_version) — emitting a
+                # row per version would put two pin controls on one rating_key,
+                # where the second reads "Pin" but unpins. Multi-PART items
+                # (cd1/cd2) are parts of ONE Media and are all cached together,
+                # so they stay folded into this item's file list.
+                medias = list(getattr(video, 'media', None) or [])
+                if not medias:
+                    continue
+                try:
+                    from core.pinned_media import select_media_version
+                    preferred = select_media_version(video, version_preference)
+                except (ValueError, AttributeError, ImportError):
+                    preferred = medias[0]
+
+                version_files: List[Dict[str, Any]] = []
+                for media in medias:
+                    is_preferred = media is preferred
+                    for part in getattr(media, 'parts', None) or []:
+                        part_file = getattr(part, 'file', None)
+                        if not part_file:
                             continue
-                        items.append(RecentlyAddedItem(
-                            file_path=part.file,
-                            rating_key=rating_key,
-                            title=title,
-                            media_type=media_type,
-                            added_at=added_at,
-                            library_title=library_title,
-                            library_section_id=library_section_id,
-                            size=int(getattr(part, 'size', 0) or 0),
-                            episode_info=episode_info,
-                        ))
-                        section_kept += 1
+                        version_files.append({
+                            'file_path': part_file,
+                            'size': int(getattr(part, 'size', 0) or 0),
+                            'is_preferred': is_preferred,
+                            'label': _media_version_label(media),
+                        })
+
+                preferred_files = [f for f in version_files if f['is_preferred']]
+                if not preferred_files:
+                    continue
+
+                items.append(RecentlyAddedItem(
+                    file_path=preferred_files[0]['file_path'],
+                    rating_key=rating_key,
+                    title=title,
+                    media_type=media_type,
+                    added_at=added_at,
+                    library_title=library_title,
+                    library_section_id=library_section_id,
+                    # Every part of the preferred version is cached together, so
+                    # the item's footprint is their sum.
+                    size=sum(f['size'] for f in preferred_files),
+                    episode_info=episode_info,
+                    version_files=version_files,
+                ))
+                section_kept += 1
 
             logging.debug(
                 f"Recently added [{getattr(section, 'title', '?')}] "

--- a/core/plex_api.py
+++ b/core/plex_api.py
@@ -1660,15 +1660,22 @@ class PlexManager:
         for section in sections:
             if section_ids and str(getattr(section, 'key', '')) not in section_ids:
                 continue
+            section_type = getattr(section, 'type', None)
             try:
                 # recentlyAdded() returns newest first; the days cutoff trims further.
-                recent = section.recentlyAdded(maxresults=max_items)
+                # For SHOW libraries recentlyAdded() yields show-level items, so use
+                # recentlyAddedEpisodes() to get the actual recently-added episodes.
+                if section_type == 'show' and hasattr(section, 'recentlyAddedEpisodes'):
+                    recent = section.recentlyAddedEpisodes(maxresults=max_items)
+                else:
+                    recent = section.recentlyAdded(maxresults=max_items)
             except Exception as e:
                 _log_api_error(
                     f"fetch recently added for section '{getattr(section, 'title', '?')}'", e
                 )
                 continue
 
+            section_kept = 0
             for video in recent:
                 media_type = getattr(video, 'type', None)
                 if media_type not in ('movie', 'episode'):
@@ -1710,6 +1717,12 @@ class PlexManager:
                             size=int(getattr(part, 'size', 0) or 0),
                             episode_info=episode_info,
                         ))
+                        section_kept += 1
+
+            logging.debug(
+                f"Recently added [{getattr(section, 'title', '?')}] "
+                f"(type={section_type}): {section_kept} file(s) within {days_to_monitor}d"
+            )
 
         # Newest first, then cap. Items without added_at sort last.
         items.sort(key=lambda i: i.added_at or datetime.min, reverse=True)
@@ -1719,9 +1732,9 @@ class PlexManager:
             )
             items = items[:max_items]
 
-        logging.debug(
+        logging.info(
             f"Recently added: returning {len(items)} item(s) from "
-            f"{len(section_ids) or 'all'} section(s)"
+            f"{len(section_ids) or 'all'} section(s) within {days_to_monitor}d"
         )
         return items
 

--- a/core/system_utils.py
+++ b/core/system_utils.py
@@ -389,7 +389,8 @@ def format_cache_age(updated_at) -> Optional[str]:
         updated_at: datetime when the cache was last updated, or None.
 
     Returns:
-        String like 'just now', '5 min ago', '2 hr ago', or None if no timestamp.
+        String like 'just now', '5 min ago', '2 hr ago', '3 days ago', or None
+        if no timestamp.
     """
     if not updated_at:
         return None
@@ -400,8 +401,12 @@ def format_cache_age(updated_at) -> Optional[str]:
         return "just now"
     elif age_seconds < 3600:
         return f"{int(age_seconds / 60)} min ago"
-    else:
+    elif age_seconds < 86400:
         return f"{int(age_seconds / 3600)} hr ago"
+    # Without a day tier the hour tier was terminal, so Recently Added's 30-day
+    # window rendered "696 hr ago". int() truncation matches the tiers above.
+    days = int(age_seconds / 86400)
+    return f"{days} day ago" if days == 1 else f"{days} days ago"
 
 
 def format_time_of_day(time_str: str, time_format: str) -> str:

--- a/core/system_utils.py
+++ b/core/system_utils.py
@@ -55,6 +55,116 @@ def resolve_user0_to_disk(user0_path: str) -> Optional[str]:
     return None
 
 
+# ============================================================================
+# Share Alignment Validation
+# ============================================================================
+
+# Unraid mount points that aggregate shares rather than being a share root
+# themselves. Everything else under /mnt/ is treated as a pool name.
+_SHARE_AGGREGATE_MOUNTS = ("user", "user0")
+
+
+def extract_unraid_share(path: str) -> Optional[str]:
+    """Return the Unraid share name a path belongs to, or None if undeterminable.
+
+    Every Unraid path is `/mnt/<mount>/<share>/...` where `<mount>` is `user`,
+    `user0`, `diskN`, or a pool name. The share name is the segment after it.
+
+        /mnt/user/Movies/Action/       -> "Movies"
+        /mnt/user0/data/media/movies/  -> "data"
+        /mnt/disk3/data/media/         -> "data"
+        /mnt/cache_downloads/Movies/   -> "Movies"
+
+    Returns None for paths that aren't under /mnt/ or have no segment past the
+    mount point, so callers can skip validation rather than guess.
+    """
+    if not path:
+        return None
+    normalized = posixpath.normpath(path.strip())
+    if not normalized.startswith("/mnt/"):
+        return None
+    parts = [p for p in normalized[len("/mnt/"):].split("/") if p]
+    if len(parts) < 2:
+        return None  # bare mount point, no share segment
+    return parts[1]
+
+
+def check_cache_share_alignment(
+    real_path: str,
+    cache_path: str,
+    host_cache_path: Optional[str] = None,
+) -> Optional[dict]:
+    """Check that a mapping's cache destination is the same Unraid share as its media.
+
+    Unraid presents a share's pool tier and array tier merged under
+    /mnt/user/<share>/. Caching only works when both tiers belong to the *same*
+    share: a file moves between them and the /mnt/user/ path Plex reads never
+    changes. Point the cache at a different share and the cached copy lands
+    somewhere Plex isn't looking, leaving only the .plexcached stub behind
+    (issues #189, #196).
+
+    The host-side cache path is preferred when set, because under Docker
+    `cache_path` is a container path whose prefix may be remapped.
+
+    Args:
+        real_path: Where the media lives (container path).
+        cache_path: Where cached copies go (container path).
+        host_cache_path: Host-side equivalent of cache_path, when Docker remaps it.
+
+    Returns:
+        None when the paths agree or can't be compared. Otherwise a dict with
+        `kind` ("share_mismatch" or "cache_not_absolute"), the share names
+        involved, and a human-readable `message`.
+    """
+    if not real_path or not cache_path:
+        return None
+
+    effective_cache = (host_cache_path or "").strip() or cache_path
+
+    # Anchor on the media path. If it isn't an Unraid-style share path, this
+    # install doesn't follow the layout these checks reason about — stay quiet
+    # rather than guess. This is advisory and must not cry wolf.
+    real_share = extract_unraid_share(real_path)
+    if not real_share:
+        return None
+
+    # The media is on an Unraid share, so its cache tier has to live under /mnt/
+    # too. A path like "/movies/" is a container-relative fragment: it resolves
+    # to no share, and it also breaks the mover exclude file, which needs real
+    # host paths.
+    if not posixpath.normpath(effective_cache.strip()).startswith("/mnt/"):
+        label = "Host Cache Path" if (host_cache_path or "").strip() else "Cache Path"
+        return {
+            "kind": "cache_not_under_mnt",
+            "real_share": real_share,
+            "cache_share": None,
+            "message": (
+                f"{label} '{effective_cache}' is not under /mnt/. Media is on the "
+                f"'{real_share}' share, so the cache path should be that share's pool "
+                f"tier, for example '/mnt/<pool>/{real_share}/...'."
+            ),
+        }
+
+    cache_share = extract_unraid_share(effective_cache)
+    if not cache_share:
+        return None  # bare mount point, nothing to compare
+
+    if real_share == cache_share:
+        return None
+
+    return {
+        "kind": "share_mismatch",
+        "real_share": real_share,
+        "cache_share": cache_share,
+        "message": (
+            f"Media is in the '{real_share}' share but the cache path points into "
+            f"'{cache_share}'. Cached files would land in a different share than Plex "
+            f"reads from, so they would appear missing. The cache path should be the "
+            f"pool tier of '{real_share}'."
+        ),
+    }
+
+
 # ZFS-backed path prefixes that should NOT be converted to /mnt/user0/.
 # For ZFS pool-only shares (shareUseCache=only), files never appear at /mnt/user0/
 # because that path only shows standard array disks. Using /mnt/user/ is safe for

--- a/tests/test_activity_action_badges.py
+++ b/tests/test_activity_action_badges.py
@@ -132,16 +132,92 @@ class TestFilterPills:
             for action in value.split("|"):
                 assert action in ALL_ACTIONS, f"pill filters on unknown action {action!r}"
 
-    def test_actions_without_a_pill_fall_through_to_other(self, dashboard_src):
-        """Anything not named by a pill must be reachable under "Other"."""
+    def test_every_action_is_reachable_by_some_filter(self, dashboard_src):
+        """Each action matches either its own pill or "Other" — never neither.
+
+        Rows matched neither when KNOWN_ACTIONS named an action that had no
+        pill: the pill couldn't match it and "Other" excluded it, so it was
+        visible only under "All". Deriving the list from the pills makes the two
+        sets identical by construction, which is what this asserts.
+        """
         bar = dashboard_src[dashboard_src.index('id="activity-filter-bar"'):]
         bar = bar[:bar.index("</div>")]
         covered = set()
         for value in re.findall(r'data-filter="([^"]+)"', bar):
             if value not in ("all", "other"):
                 covered.update(value.split("|"))
-        uncovered = [a for a in ALL_ACTIONS if a not in covered]
-        # These have no pill of their own, so "Other" is their only filter —
-        # which the derived knownActions() now guarantees.
-        assert "Released" in uncovered
-        assert "Protected" in uncovered
+
+        # "Other" is the complement of the pill set, and the pill set is what
+        # knownActions() derives — so reachability holds iff no action is
+        # claimed by the known-list without also having a pill. That is exactly
+        # what a hardcoded list broke, so assert the two can't diverge: every
+        # covered action must appear as a pill's own data-filter value.
+        pill_values = set()
+        for value in re.findall(r'data-filter="([^"]+)"', bar):
+            if value not in ("all", "other"):
+                pill_values.update(value.split("|"))
+        assert covered == pill_values
+
+        # Released earns a pill of its own — it is a deliberate state, not a
+        # leftover, so burying it under "Other" hid the feature working.
+        assert "Released" in covered
+
+
+SOURCE_BADGE = REPO / "web" / "templates" / "macros" / "source_badge.html"
+FILE_TABLE = REPO / "web" / "templates" / "cache" / "partials" / "file_table.html"
+RA_LIST = REPO / "web" / "templates" / "recently_added" / "partials" / "list.html"
+
+
+class TestSharedSourceBadges:
+    """OnDeck/Watchlist/lapsed badges are shared, not hand-copied.
+
+    Hand-copied copy is how "Protected" came to mean three different things.
+    Both the Cached Files table and Recently Added answer the same question —
+    what put this file on cache, and does that still hold — so one macro serves
+    both.
+    """
+
+    @pytest.fixture(scope="class")
+    def macro_src(self):
+        return SOURCE_BADGE.read_text(encoding="utf-8")
+
+    def test_both_pages_import_the_shared_macro(self):
+        for path in (FILE_TABLE, RA_LIST):
+            src = path.read_text(encoding="utf-8")
+            assert "macros/source_badge.html" in src, f"{path.name} hand-rolls its badges"
+
+    def test_neither_page_hardcodes_the_per_file_badge_markup(self):
+        # Scoped to the per-row source cell. The Cached Files totals legend
+        # legitimately prints the words with its counts, which is a different
+        # thing from a row's source badge.
+        src = FILE_TABLE.read_text(encoding="utf-8")
+        cell = src[src.index('class="source-badges"'):]
+        cell = cell[:cell.index("</td>")]
+        assert ">OnDeck<" not in cell, "file_table row still inlines an OnDeck badge"
+        assert ">Watchlist<" not in cell, "file_table row still inlines a Watchlist badge"
+        assert "ondeck_badge()" in cell and "watchlist_badge()" in cell
+
+        ra = RA_LIST.read_text(encoding="utf-8")
+        badge_macro = ra[ra.index("{% macro ra_status_badge"):ra.index("{% macro ra_row")]
+        assert ">OnDeck<" not in badge_macro
+        assert "ondeck_badge()" in badge_macro and "watchlist_badge()" in badge_macro
+
+    def test_ondeck_and_watchlist_have_tooltips(self, macro_src):
+        for key in ("ondeck", "watchlist", "stale_ondeck", "stale_watchlist", "other"):
+            assert f"'{key}':" in macro_src, f"no tooltip for {key}"
+
+    def test_transient_sources_disclaim_eviction_protection(self, macro_src):
+        # OnDeck/Watchlist add +15 to the priority score; only a pin exempts.
+        # The badge must not read as a protection guarantee.
+        tips = macro_src[macro_src.index("SOURCE_TOOLTIPS = {"):]
+        tips = tips[:tips.index("} %}")]
+        for key in ("ondeck", "watchlist"):
+            line = [l for l in tips.splitlines() if f"'{key}':" in l][0]
+            assert "Not eviction protection" in line, f"{key} implies protection it lacks"
+
+    def test_lapsed_badges_say_what_happens_next(self, macro_src):
+        tips = macro_src[macro_src.index("SOURCE_TOOLTIPS = {"):]
+        tips = tips[:tips.index("} %}")]
+        for key in ("stale_ondeck", "stale_watchlist", "other"):
+            line = [l for l in tips.splitlines() if f"'{key}':" in l][0]
+            assert "moves it back to the array" in line

--- a/tests/test_activity_action_badges.py
+++ b/tests/test_activity_action_badges.py
@@ -210,14 +210,16 @@ class TestSharedSourceBadges:
         for key in ("ondeck", "watchlist", "stale_ondeck", "stale_watchlist", "other"):
             assert f"'{key}':" in macro_src, f"no tooltip for {key}"
 
-    def test_transient_sources_disclaim_eviction_protection(self, macro_src):
+    def test_transient_sources_make_no_protection_claim(self, macro_src):
         # OnDeck/Watchlist add +15 to the priority score; only a pin exempts.
-        # The badge must not read as a protection guarantee.
+        # The badge needn't spell that out, but it must not claim otherwise —
+        # "keeps it on cache for now" is a statement of the current reason, not
+        # a guarantee. The disclaimer lives on the outcome badge instead.
         tips = macro_src[macro_src.index("SOURCE_TOOLTIPS = {"):]
         tips = tips[:tips.index("} %}")]
         for key in ("ondeck", "watchlist"):
             line = [l for l in tips.splitlines() if f"'{key}':" in l][0]
-            assert "Not eviction protection" in line, f"{key} implies protection it lacks"
+            assert "protect" not in line.lower(), f"{key} makes a protection claim"
 
     def test_lapsed_badges_say_what_happens_next(self, macro_src):
         tips = macro_src[macro_src.index("SOURCE_TOOLTIPS = {"):]

--- a/tests/test_activity_action_badges.py
+++ b/tests/test_activity_action_badges.py
@@ -1,0 +1,147 @@
+"""Recent Activity action badges and filter pills.
+
+Two defects these lock down:
+
+* `Moved` and `Released` had no arm in `action_badge`, so both fell through to
+  the muted default and were styled like an unrecognised action. `Moved` is the
+  main restore-by-copy path and `Released` is a deliberate, user-visible state.
+* The "Moved" pill sent ``data-filter="Moved to Array"`` — the label maintenance
+  writes — so it matched no entry from an actual run, and those rows landed
+  under "Other" instead. The hardcoded ``KNOWN_ACTIONS`` also named `Protected`,
+  which has no pill, so those rows matched neither their own filter nor "Other"
+  and were reachable only under "All".
+
+Source-text tests: this is template + inline JS with no Python seam, and the
+contract that matters is "every action a writer emits is handled".
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+ACTIVITY = REPO / "web" / "templates" / "components" / "recent_activity.html"
+DASHBOARD = REPO / "web" / "templates" / "dashboard.html"
+
+# Every action string written to the activity feed, with its writer.
+#   FileMover._move_to_cache / _move_to_array  -> Cached / Restored / Moved
+#   PlexCacheApp._release_files                -> Released
+#   MaintenanceRunner.ACTION_ACTIVITY_LABELS   -> the rest
+#   web/routers/pinned.py                      -> Cached
+ALL_ACTIONS = [
+    "Cached", "Restored", "Moved", "Released",
+    "Protected", "Moved to Array", "Fixed", "Restored Backup", "Deleted Backup",
+]
+
+
+@pytest.fixture(scope="module")
+def activity_src():
+    return ACTIVITY.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def dashboard_src():
+    return DASHBOARD.read_text(encoding="utf-8")
+
+
+class TestWriterInventory:
+    def test_action_labels_match_the_maintenance_runner(self):
+        """If a maintenance action label is added, this list must grow with it."""
+        src = (REPO / "web" / "services" / "maintenance_runner.py").read_text(encoding="utf-8")
+        block = src[src.index("ACTION_ACTIVITY_LABELS = {"):]
+        block = block[:block.index("}")]
+        for label in re.findall(r':\s*"([^"]+)"', block):
+            assert label in ALL_ACTIONS, f"maintenance emits {label!r}, not in ALL_ACTIONS"
+
+    def test_release_action_is_still_spelled_the_same(self):
+        src = (REPO / "core" / "app.py").read_text(encoding="utf-8")
+        assert '_record_file_activity("Released"' in src
+
+
+class TestBadgeCoverage:
+    def test_every_action_has_a_tooltip(self, activity_src):
+        tips = activity_src[activity_src.index("ACTION_TOOLTIPS = {"):]
+        tips = tips[:tips.index("} %}")]
+        for action in ALL_ACTIONS:
+            assert f"'{action}':" in tips, f"no tooltip for {action}"
+
+    def test_moved_and_released_are_not_left_to_the_default_arm(self, activity_src):
+        macro = activity_src[activity_src.index("{% macro action_badge"):
+                             activity_src.index("{% macro source_icon")]
+        assert "'Moved'" in macro
+        assert "action == 'Released'" in macro
+
+    def test_released_uses_its_own_badge_not_muted(self, activity_src):
+        macro = activity_src[activity_src.index("{% macro action_badge"):
+                             activity_src.index("{% macro source_icon")]
+        released_arm = macro[macro.index("action == 'Released'"):]
+        released_arm = released_arm[:released_arm.index("{%- elif")]
+        assert "badge-released" in released_arm
+
+    def test_tooltips_are_non_empty(self, activity_src):
+        tips = activity_src[activity_src.index("ACTION_TOOLTIPS = {"):]
+        tips = tips[:tips.index("} %}")]
+        for action, text in re.findall(r"'([^']+)':\s*'([^']*)'", tips):
+            assert len(text) > 20, f"{action} tooltip is too short to be useful"
+
+
+class TestProtectedRelabel:
+    """"Protected" is the mover sense, and the same action's own button says
+    "Keep on Cache" (tests/test_pin_vocabulary.py guards that wording). Re-label
+    at render only — the action string is persisted in recent_activity.json."""
+
+    def test_protected_is_relabelled_for_display(self, activity_src):
+        assert "'Protected': 'Kept on Cache'" in activity_src
+
+    def test_relabel_happens_in_the_template_not_the_writer(self):
+        # Renaming at the writer would need a migration and would rewrite what
+        # already happened; old entries must keep rendering consistently.
+        src = (REPO / "web" / "services" / "maintenance_runner.py").read_text(encoding="utf-8")
+        assert '"protect-with-backup": "Protected"' in src
+
+    def test_protected_tooltip_disclaims_being_a_pin(self, activity_src):
+        tips = activity_src[activity_src.index("ACTION_TOOLTIPS = {"):]
+        assert "not a pin" in tips[:tips.index("} %}")].lower()
+
+
+class TestFilterPills:
+    def test_moved_pill_matches_both_restore_labels(self, dashboard_src):
+        assert 'data-filter="Moved|Moved to Array"' in dashboard_src
+
+    def test_filter_matching_splits_on_pipe(self, dashboard_src):
+        assert "filter.split('|').indexOf(action) !== -1" in dashboard_src
+
+    def test_known_actions_is_derived_from_the_pills(self, dashboard_src):
+        # A hardcoded list is what let the two drift.
+        assert "KNOWN_ACTIONS:" not in dashboard_src
+        assert "knownActions: function()" in dashboard_src
+
+    def test_filter_bar_is_scoped_by_id(self, dashboard_src):
+        # Recently Added reuses .activity-filter-bar; an unscoped query would
+        # pick up its location pills.
+        assert 'id="activity-filter-bar"' in dashboard_src
+        assert "#activity-filter-bar .activity-filter-pill" in dashboard_src
+
+    def test_every_pill_action_is_a_real_action(self, dashboard_src):
+        bar = dashboard_src[dashboard_src.index('id="activity-filter-bar"'):]
+        bar = bar[:bar.index("</div>")]
+        for value in re.findall(r'data-filter="([^"]+)"', bar):
+            if value in ("all", "other"):
+                continue
+            for action in value.split("|"):
+                assert action in ALL_ACTIONS, f"pill filters on unknown action {action!r}"
+
+    def test_actions_without_a_pill_fall_through_to_other(self, dashboard_src):
+        """Anything not named by a pill must be reachable under "Other"."""
+        bar = dashboard_src[dashboard_src.index('id="activity-filter-bar"'):]
+        bar = bar[:bar.index("</div>")]
+        covered = set()
+        for value in re.findall(r'data-filter="([^"]+)"', bar):
+            if value not in ("all", "other"):
+                covered.update(value.split("|"))
+        uncovered = [a for a in ALL_ACTIONS if a not in covered]
+        # These have no pill of their own, so "Other" is their only filter —
+        # which the derived knownActions() now guarantees.
+        assert "Released" in uncovered
+        assert "Protected" in uncovered

--- a/tests/test_activity_action_badges.py
+++ b/tests/test_activity_action_badges.py
@@ -100,9 +100,13 @@ class TestProtectedRelabel:
         src = (REPO / "web" / "services" / "maintenance_runner.py").read_text(encoding="utf-8")
         assert '"protect-with-backup": "Protected"' in src
 
-    def test_protected_tooltip_disclaims_being_a_pin(self, activity_src):
+    def test_protected_tooltip_states_the_mover_effect(self, activity_src):
+        # The pin-vs-keep distinction is guarded where the user acts on it —
+        # the button and confirm modal (tests/test_pin_vocabulary.py). This
+        # badge is a history record, so it only needs to say what was done.
         tips = activity_src[activity_src.index("ACTION_TOOLTIPS = {"):]
-        assert "not a pin" in tips[:tips.index("} %}")].lower()
+        line = [l for l in tips[:tips.index("} %}")].splitlines() if "'Protected':" in l][0]
+        assert "mover leaves it alone" in line
 
 
 class TestFilterPills:

--- a/tests/test_activity_grouping.py
+++ b/tests/test_activity_grouping.py
@@ -167,6 +167,63 @@ class TestShowGrouping:
         # Single episode passes through as a singleton, not a group of 1
         assert runs[0]["entries"][0].get("is_group") is None
 
+    def test_same_show_different_actions_stay_separate(self):
+        # One run can cache some episodes of a show and restore others; merging
+        # them would produce a row whose action is a lie.
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=3), "Cached", "Entourage - S02E01.mkv", run_id="r1", run_source="web"),
+            _entry(now + timedelta(seconds=2), "Cached", "Entourage - S02E02.mkv", run_id="r1", run_source="web"),
+            _entry(now + timedelta(seconds=1), "Moved", "Entourage - S01E01.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Moved", "Entourage - S01E02.mkv", run_id="r1", run_source="web"),
+        ]
+        entries = group_activity_into_runs(activities)[0]["entries"]
+        assert len(entries) == 2
+        assert [e["action"] for e in entries] == ["Cached", "Moved"]
+        assert all(e["episode_count"] == 2 for e in entries)
+        # Distinct DOM ids, or expanding one would expand the other — the banner
+        # and Recent Activity both key their toggle on this.
+        assert entries[0]["group_id"] != entries[1]["group_id"]
+
+    def test_group_id_is_stable_across_renders(self):
+        # The banner re-renders every 2s and restores expand state by id, so the
+        # same run must produce the same ids each time.
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=1), "Cached", "Entourage - S01E01.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "Entourage - S01E02.mkv", run_id="r1", run_source="web"),
+        ]
+        first = group_activity_into_runs(activities)[0]["entries"][0]["group_id"]
+        second = group_activity_into_runs(activities)[0]["entries"][0]["group_id"]
+        assert first == second
+
+    def test_group_id_survives_a_new_file_arriving(self):
+        # Position-derived ids would shift when a newer file lands on top,
+        # silently collapsing an expanded group on the next poll.
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        base = [
+            _entry(now + timedelta(seconds=1), "Cached", "Entourage - S01E01.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "Entourage - S01E02.mkv", run_id="r1", run_source="web"),
+        ]
+        before = group_activity_into_runs(base)[0]["entries"][0]["group_id"]
+        newer = [_entry(now + timedelta(seconds=5), "Cached", "Dune (2021).mkv", run_id="r1", run_source="web")] + base
+        entries = group_activity_into_runs(newer)[0]["entries"]
+        after = next(e["group_id"] for e in entries if e.get("is_group"))
+        assert before == after
+
+    def test_seasons_merge_into_one_show_group(self):
+        # Matches the Recently Added views: a season rollover is still one show.
+        now = datetime(2026, 4, 25, 10, 0, 0)
+        activities = [
+            _entry(now + timedelta(seconds=2), "Cached", "Sugar (2024) - S02E03.mkv", run_id="r1", run_source="web"),
+            _entry(now + timedelta(seconds=1), "Cached", "Sugar (2024) - S01E05.mkv", run_id="r1", run_source="web"),
+            _entry(now, "Cached", "Sugar (2024) - S01E07.mkv", run_id="r1", run_source="web"),
+        ]
+        entries = group_activity_into_runs(activities)[0]["entries"]
+        assert len(entries) == 1
+        assert entries[0]["show_name"] == "Sugar (2024)"
+        assert entries[0]["episode_count"] == 3
+
 
 class TestAggregates:
     def test_byte_totals_per_action(self):

--- a/tests/test_config_read_only_load.py
+++ b/tests/test_config_read_only_load.py
@@ -1,0 +1,97 @@
+"""`ConfigManager.load_config(persist_updates=False)` must not touch the disk.
+
+The Recently Added service loads config on a GET, and the dashboard widget fires
+one on every dashboard visit. The default load path ends in `_save_updated_config()`
+— a truncating rewrite of plexcache_settings.json — which races any concurrent
+reader of that file (the hazard `web/services/settings_service.py` documents and
+routes around via `save_json_atomically()`).
+"""
+
+import json
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+sys.modules.setdefault('plexapi', MagicMock())
+sys.modules.setdefault('plexapi.server', MagicMock())
+
+from core.config import ConfigManager
+
+
+def _minimal_settings(tmp_path):
+    """A settings file complete enough for load_config() to validate."""
+    cache_dir = tmp_path / "cache"
+    real_dir = tmp_path / "media"
+    for d in (cache_dir, real_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    return {
+        "PLEX_URL": "http://localhost:32400",
+        "PLEX_TOKEN": "tok",
+        "number_episodes": 5,
+        "valid_sections": [1],
+        "days_to_monitor": 99,
+        "users_toggle": False,
+        "watchlist_toggle": False,
+        "watchlist_episodes": 3,
+        "watched_move": True,
+        "max_concurrent_moves_array": 2,
+        "max_concurrent_moves_cache": 5,
+        "cache_dir": str(cache_dir),
+        "real_source": str(real_dir),
+        "plex_source": "/data/",
+        "path_mappings": [{
+            "name": "Movies",
+            "plex_path": "/data/movies",
+            "real_path": str(real_dir),
+            "cache_path": str(cache_dir),
+            "enabled": True,
+        }],
+    }
+
+
+@pytest.fixture
+def settings_file(tmp_path):
+    path = tmp_path / "plexcache_settings.json"
+    path.write_text(json.dumps(_minimal_settings(tmp_path), indent=2), encoding="utf-8")
+    return path
+
+
+class TestReadOnlyLoad:
+    def test_read_only_load_does_not_rewrite_the_file(self, settings_file):
+        before_bytes = settings_file.read_bytes()
+        before_mtime = settings_file.stat().st_mtime_ns
+
+        cfg = ConfigManager(str(settings_file))
+        cfg.load_config(persist_updates=False)
+
+        assert settings_file.read_bytes() == before_bytes
+        assert settings_file.stat().st_mtime_ns == before_mtime
+
+    def test_read_only_load_still_populates_config(self, settings_file):
+        cfg = ConfigManager(str(settings_file))
+        cfg.load_config(persist_updates=False)
+
+        assert cfg.plex.plex_url == "http://localhost:32400"
+        assert cfg.plex.plex_token == "tok"
+        assert cfg.plex.valid_sections == [1]
+        assert len(cfg.paths.path_mappings) == 1
+
+    def test_read_only_load_still_normalizes_path_mappings(self, settings_file):
+        # The trailing-slash normalization is what MultiPathModifier relies on,
+        # so skipping the write must not skip this. Asserted on plex_path, which
+        # is POSIX on every platform (real_path here is an OS-native tmp path,
+        # which _add_trailing_slashes deliberately leaves alone on Windows).
+        cfg = ConfigManager(str(settings_file))
+        cfg.load_config(persist_updates=False)
+
+        assert cfg.paths.path_mappings[0].plex_path == "/data/movies/"
+
+    def test_default_load_still_persists(self, settings_file):
+        # The CLI path must keep writing back migrations/normalizations.
+        cfg = ConfigManager(str(settings_file))
+        cfg.load_config()
+        assert settings_file.exists()
+        reloaded = json.loads(settings_file.read_text(encoding="utf-8"))
+        assert reloaded["PLEX_TOKEN"] == "tok"

--- a/tests/test_extension_free_caching.py
+++ b/tests/test_extension_free_caching.py
@@ -24,6 +24,7 @@ from core.file_operations import (
     is_video_file,
     is_directory_level_file,
     name_matches_video_stem,
+    is_sidecar_candidate,
     is_season_like_folder,
     _get_file_category,
     find_matching_plexcached,
@@ -352,6 +353,54 @@ class TestNameMatchesVideoStem:
 
     def test_non_matching_prefix(self):
         assert not name_matches_video_stem("The Revenant 2015.srt", "Deadwood - The Movie (2019)")
+
+
+class TestIsSidecarCandidate:
+    """The app-wide admission rule shared by every sidecar-hunting scan."""
+
+    @pytest.mark.parametrize("name", [
+        "Movie (2012).en.srt", "Movie (2012).nfo", "Movie (2012)-poster.jpg",
+        "Movie (2012).idx", "Movie (2012).sub", "Movie (2012).sup",
+        "Movie (2012).en.ass", "Movie (2012).bif", "English.srt", "poster.jpg",
+    ])
+    def test_admits_every_sidecar_shape(self, name):
+        assert is_sidecar_candidate(name)
+
+    @pytest.mark.parametrize("name", [
+        "Movie (2012)-trailer.mkv", "Movie (2012)-behindthescenes.mkv",
+        "Movie (2012).mkv", "Other Movie.mp4",
+    ])
+    def test_rejects_videos_including_plex_local_extras(self, name):
+        # Plex stores local extras beside the feature; each is its own media
+        # item, never a sidecar of the film it sits next to.
+        assert not is_sidecar_candidate(name)
+
+    def test_rejects_plexcached_backups(self):
+        # The reason this clause exists: splitext() leaves the real extension
+        # behind, so a naive stem test accepts these.
+        assert os.path.splitext("Movie (2012).mkv.plexcached")[0] == "Movie (2012).mkv"
+        assert not is_sidecar_candidate("Movie (2012).mkv.plexcached")
+        assert not is_sidecar_candidate("Movie (2012).en.srt.plexcached")
+
+    def test_rejects_dotfiles(self):
+        assert not is_sidecar_candidate(".DS_Store")
+
+    def test_agrees_with_the_scanner_it_was_extracted_from(self, temp_dir):
+        """The predicate must reproduce _find_sibling_files' filter exactly."""
+        names = [
+            "Movie.mkv", "Movie-trailer.mkv", "Movie.en.srt", "Movie.nfo",
+            "Movie-poster.jpg", "Movie.mkv.plexcached", ".DS_Store", "poster.jpg",
+        ]
+        for n in names:
+            with open(os.path.join(temp_dir, n), "w") as f:
+                f.write("x")
+        finder = SiblingFileFinder()
+        scanned = {
+            os.path.basename(p)
+            for p in finder._find_sibling_files(temp_dir, os.path.join(temp_dir, "Movie.mkv"))
+        }
+        expected = {n for n in names if is_sidecar_candidate(n) and n != "Movie.mkv"}
+        assert scanned == expected
 
 
 # ============================================================

--- a/tests/test_maintenance_service.py
+++ b/tests/test_maintenance_service.py
@@ -776,12 +776,12 @@ class TestAuditResultsHealth:
 
     def test_untracked_files_do_not_affect_health(self):
         """Untracked files are informational and should not trigger critical status"""
-        from web.services.maintenance_service import AuditResults, UnprotectedFile
+        from web.services.maintenance_service import AuditResults, UntrackedFile
         results = AuditResults(
             cache_file_count=10, exclude_entry_count=5, timestamp_entry_count=10
         )
-        results.unprotected_files.append(
-            UnprotectedFile(
+        results.untracked_files.append(
+            UntrackedFile(
                 cache_path="/path/file.mkv", filename="file.mkv",
                 size=1000, size_display="1 KB",
                 has_plexcached_backup=False, backup_path=None,
@@ -852,14 +852,14 @@ class TestRunFullAuditFanOut:
         svc = _make_service(tmp_path, settings)
         return svc, cache_root, array_root
 
-    def test_audit_finds_unprotected_duplicate_and_orphaned(self, tmp_path):
+    def test_audit_finds_untracked_duplicate_and_orphaned(self, tmp_path):
         svc, cache_root, array_root = self._make_e2e_service(tmp_path)
 
         # Cache files
-        unprotected = cache_root / "Unprotected.mkv"
+        untracked = cache_root / "Unprotected.mkv"
         duplicated = cache_root / "Duplicated.mkv"
         protected = cache_root / "Protected.mkv"
-        for p in (unprotected, duplicated, protected):
+        for p in (untracked, duplicated, protected):
             p.write_bytes(b"x" * 1024)
 
         # Array side:
@@ -875,20 +875,20 @@ class TestRunFullAuditFanOut:
 
         results = svc.run_full_audit()
 
-        unprotected_paths = {f.cache_path for f in results.unprotected_files}
-        assert str(unprotected) in unprotected_paths
-        assert str(duplicated) in unprotected_paths
-        assert str(protected) not in unprotected_paths
+        untracked_paths = {f.cache_path for f in results.untracked_files}
+        assert str(untracked) in untracked_paths
+        assert str(duplicated) in untracked_paths
+        assert str(protected) not in untracked_paths
 
         # Duplicated.mkv should be flagged as duplicate AND marked fix_with_backup
-        dup_entry = next(f for f in results.unprotected_files
+        dup_entry = next(f for f in results.untracked_files
                          if f.cache_path == str(duplicated))
         assert dup_entry.has_array_duplicate is True
         assert dup_entry.recommended_action == "fix_with_backup"
 
         # Unprotected.mkv has no backup/duplicate → sync_to_array
-        un_entry = next(f for f in results.unprotected_files
-                        if f.cache_path == str(unprotected))
+        un_entry = next(f for f in results.untracked_files
+                        if f.cache_path == str(untracked))
         assert un_entry.has_array_duplicate is False
         assert un_entry.has_plexcached_backup is False
         assert un_entry.recommended_action == "sync_to_array"
@@ -927,8 +927,8 @@ class TestRunFullAuditFanOut:
                    side_effect=tracking_exists):
             results = svc.run_full_audit()
 
-        # All 50 should be flagged as unprotected
-        assert len(results.unprotected_files) == 50
+        # All 50 should be flagged as untracked
+        assert len(results.untracked_files) == 50
 
         # Any os.path.exists call against an individual cache FILE path would
         # indicate the old per-file probe pattern. Probing the cache directory

--- a/tests/test_media_grouping.py
+++ b/tests/test_media_grouping.py
@@ -1,0 +1,146 @@
+"""Tests for the shared grouping primitives in ``core/media_grouping.py``.
+
+These cover the rule itself. The two callers that build on it — the activity
+feed (``core.activity.group_episodes_by_show``) and the Recently Added views
+(``RecentlyAddedService.group_rows_for_display``) — are covered in their own
+modules; what matters here is that both inherit the same ordering and
+singleton semantics.
+"""
+
+from core.media_grouping import (
+    format_season_range,
+    group_ordered,
+    parse_show_episode,
+    show_name_from_filename,
+    stable_group_id,
+)
+
+
+class TestParseShowEpisode:
+    def test_parses_show_season_episode(self):
+        assert parse_show_episode("Sugar (2024) - S02E03 - Ruthless.mkv") == (
+            "Sugar (2024)", 2, 3
+        )
+
+    def test_case_insensitive(self):
+        assert parse_show_episode("The Bear - s01e04.mkv")[0] == "The Bear"
+
+    def test_multi_digit_season_and_episode(self):
+        assert parse_show_episode("Show - S10E120.mkv") == ("Show", 10, 120)
+
+    def test_movie_is_not_an_episode(self):
+        assert parse_show_episode("Dune (2021) 2160p.mkv") is None
+
+    def test_empty_and_none_safe(self):
+        assert parse_show_episode("") is None
+        assert parse_show_episode(None) is None
+
+    def test_show_name_helper(self):
+        assert show_name_from_filename("Sugar (2024) - S01E01.mkv") == "Sugar (2024)"
+        assert show_name_from_filename("Dune.mkv") is None
+
+
+class TestGroupOrdered:
+    def test_groups_by_key_preserving_first_seen_order(self):
+        items = [
+            {"n": "a", "k": "X"},
+            {"n": "b", "k": "Y"},
+            {"n": "c", "k": "X"},
+        ]
+        result = group_ordered(items, lambda i: i["k"])
+        assert [key for key, _ in result] == ["X", "Y"]
+        assert [i["n"] for i in result[0][1]] == ["a", "c"]
+        assert [i["n"] for i in result[1][1]] == ["b"]
+
+    def test_none_key_items_never_merge(self):
+        items = [{"n": "a"}, {"n": "b"}, {"n": "c"}]
+        result = group_ordered(items, lambda i: None)
+        assert len(result) == 3
+        assert all(key is None and len(members) == 1 for key, members in result)
+        assert [m[0]["n"] for _, m in result] == ["a", "b", "c"]
+
+    def test_group_anchors_at_first_member_position(self):
+        # A group must render where its FIRST member appeared, not where its
+        # last one did — otherwise re-renders reshuffle the list.
+        items = [
+            {"n": "movie1", "k": None},
+            {"n": "ep1", "k": "Show"},
+            {"n": "movie2", "k": None},
+            {"n": "ep2", "k": "Show"},
+        ]
+        result = group_ordered(items, lambda i: i["k"])
+        assert [key for key, _ in result] == [None, "Show", None]
+        assert [i["n"] for i in result[1][1]] == ["ep1", "ep2"]
+
+    def test_singletons_are_returned_as_one_member_buckets(self):
+        items = [{"k": "Show"}]
+        result = group_ordered(items, lambda i: i["k"])
+        assert len(result) == 1
+        key, members = result[0]
+        assert key == "Show"
+        assert len(members) == 1
+
+    def test_empty_input(self):
+        assert group_ordered([], lambda i: None) == []
+
+    def test_tuple_keys_supported(self):
+        items = [
+            {"n": "a", "k": ("Cached", "Show")},
+            {"n": "b", "k": ("Restored", "Show")},
+            {"n": "c", "k": ("Cached", "Show")},
+        ]
+        result = group_ordered(items, lambda i: i["k"])
+        assert len(result) == 2
+        assert [i["n"] for i in result[0][1]] == ["a", "c"]
+
+
+class TestStableGroupId:
+    def test_same_key_same_id(self):
+        # Stability is the whole point: the banner re-renders every 2s and
+        # restores expand state by id.
+        assert stable_group_id("Cached", "Entourage") == stable_group_id("Cached", "Entourage")
+
+    def test_action_is_part_of_the_identity(self):
+        # One run can cache some episodes of a show and restore others. Those
+        # are two rows and must toggle independently.
+        assert stable_group_id("Cached", "Entourage") != stable_group_id("Moved", "Entourage")
+
+    def test_different_shows_differ(self):
+        assert stable_group_id("Cached", "Entourage") != stable_group_id("Cached", "Sugar (2024)")
+
+    def test_id_is_attribute_safe(self):
+        # A title carrying a quote must not leak into the data-* attribute.
+        gid = stable_group_id("Cached", 'Some "Quoted" Show \'s')
+        assert gid.isalnum()
+        assert '"' not in gid and "'" not in gid and "<" not in gid
+
+    def test_parts_are_delimited_not_concatenated(self):
+        # ("ab", "c") and ("a", "bc") are different groups, not the same one.
+        assert stable_group_id("ab", "c") != stable_group_id("a", "bc")
+
+    def test_none_parts_are_handled(self):
+        # A missing part is treated as empty rather than raising. No caller
+        # distinguishes None from "" in the same key position, so folding them
+        # together is safe.
+        assert stable_group_id("Cached", None) == stable_group_id("Cached", "")
+        assert stable_group_id(None).startswith("g")
+
+    def test_non_string_parts_are_accepted(self):
+        # Recently Added keys include a season number in some call sites.
+        assert stable_group_id("ra", "TV", 2) == stable_group_id("ra", "TV", 2)
+        assert stable_group_id("ra", "TV", 2) != stable_group_id("ra", "TV", 3)
+
+
+class TestFormatSeasonRange:
+    def test_single_season(self):
+        assert format_season_range([2]) == "Season 2"
+
+    def test_span(self):
+        assert format_season_range([1, 2]) == "Seasons 1–2"
+
+    def test_unsorted_and_duplicated_input(self):
+        assert format_season_range([3, 1, 3, 2]) == "Seasons 1–3"
+
+    def test_no_seasons(self):
+        assert format_season_range([]) == ""
+        assert format_season_range([None]) == ""

--- a/tests/test_media_grouping.py
+++ b/tests/test_media_grouping.py
@@ -9,6 +9,7 @@ singleton semantics.
 
 from core.media_grouping import (
     format_season_range,
+    format_season_episode,
     group_ordered,
     parse_show_episode,
     show_name_from_filename,
@@ -144,3 +145,49 @@ class TestFormatSeasonRange:
     def test_no_seasons(self):
         assert format_season_range([]) == ""
         assert format_season_range([None]) == ""
+
+
+class TestFormatSeasonEpisode:
+    def test_numbered_episode(self):
+        assert format_season_episode(1, 3) == "S01E03"
+
+    def test_zero_padding_and_wide_numbers(self):
+        assert format_season_episode(0, 0) == "S00E00"
+        assert format_season_episode(12, 105) == "S12E105"
+
+    def test_specials_episode_zero_is_real_and_renders(self):
+        """Season 0 is Plex's Specials. A truthiness check would drop it, which
+        is why the guard tests the type rather than the value."""
+        assert format_season_episode(0, 7) == "S00E07"
+
+    def test_missing_numbers_render_as_nothing_not_as_s00e00(self):
+        # A fabricated S00E00 is indistinguishable from a genuine Specials 0.
+        assert format_season_episode(None, None) == ""
+        assert format_season_episode(1, None) == ""
+        assert format_season_episode(None, 3) == ""
+
+    def test_nan_is_rejected(self):
+        """plexapi.utils.cast(int, x) yields float('nan') — not None — for
+        anything unparseable, including "". An `is not None` guard would let it
+        through and the format would then raise ValueError."""
+        nan = float("nan")
+        assert format_season_episode(nan, nan) == ""
+        assert format_season_episode(1, nan) == ""
+        assert format_season_episode(nan, 3) == ""
+
+    def test_booleans_are_rejected(self):
+        # isinstance(True, int) is True, and "S01ETrue" is not a thing.
+        assert format_season_episode(True, True) == ""
+        assert format_season_episode(1, True) == ""
+
+    def test_strings_are_rejected(self):
+        assert format_season_episode("1", "3") == ""
+
+    def test_matches_jinja_is_integer(self):
+        """The template and the Python callers must agree on what counts as a
+        usable number, or the two surfaces drift."""
+        from jinja2 import Environment
+        is_integer = Environment().compile_expression("x is integer")
+        for value in [3, 0, -1, None, float("nan"), True, False, "1", 1.5]:
+            assert bool(format_season_episode(value, 1)) == bool(
+                is_integer(x=value)), f"disagreement on {value!r}"

--- a/tests/test_operation_runner.py
+++ b/tests/test_operation_runner.py
@@ -329,6 +329,45 @@ class TestGetStatusDictCompleted:
         status = runner.get_status_dict()
         assert status["error_count"] == 3
 
+    def test_completion_banner_groups_episodes(self, runner):
+        runner._current_run_files = [
+            {"action": "Cached", "filename": f"Entourage - S01E0{i}.mkv", "size_bytes": 100,
+             "size": "100 B"} for i in range(1, 4)
+        ]
+        entries = runner.get_status_dict()["recent_files"]
+        assert len(entries) == 1
+        assert entries[0]["is_group"] is True
+        assert entries[0]["episode_count"] == 3
+
+    def test_completion_banner_same_show_two_actions_get_distinct_ids(self, runner):
+        # The banner keys its expand state on group_id. If both rows shared an
+        # id, expanding one would reveal the other's episodes under it.
+        runner._current_run_files = [
+            {"action": "Cached", "filename": "Entourage - S02E01.mkv", "size_bytes": 1, "size": "1 B"},
+            {"action": "Cached", "filename": "Entourage - S02E02.mkv", "size_bytes": 1, "size": "1 B"},
+            {"action": "Moved", "filename": "Entourage - S01E01.mkv", "size_bytes": 1, "size": "1 B"},
+            {"action": "Moved", "filename": "Entourage - S01E02.mkv", "size_bytes": 1, "size": "1 B"},
+        ]
+        entries = runner.get_status_dict()["recent_files"]
+        assert len(entries) == 2
+        ids = [e["group_id"] for e in entries]
+        assert len(set(ids)) == 2
+        assert all(ids)
+
+    def test_completion_banner_caps_at_fifteen_groups(self, runner):
+        # The cap counts rows, not files — 40 episodes of one show is one row.
+        runner._current_run_files = [
+            {"action": "Cached", "filename": f"Entourage - S01E{i:02d}.mkv", "size_bytes": 1, "size": "1 B"}
+            for i in range(1, 41)
+        ] + [
+            {"action": "Cached", "filename": f"Movie {i}.mkv", "size_bytes": 1, "size": "1 B"}
+            for i in range(20)
+        ]
+        entries = runner.get_status_dict()["recent_files"]
+        assert len(entries) == 15
+        assert entries[0]["is_group"] is True
+        assert entries[0]["episode_count"] == 40
+
 
 # ============================================================================
 # get_status_dict() — byte-level progress

--- a/tests/test_outcome_vocabulary.py
+++ b/tests/test_outcome_vocabulary.py
@@ -1,0 +1,231 @@
+"""Outcome vocabulary for Recently Added.
+
+The defect this replaces: the group-header badge chain lived in Jinja and ended
+in `{% else %}` → "Protected", so a group of three episodes sitting on the array
+with nothing pinned rendered a reassuring green "Protected". Groups render
+collapsed by default, so that false badge was the default view on the one page
+whose job is answering "is this held or not".
+
+Three classes of test here:
+  1. the classifier maps facts → exactly one outcome;
+  2. the group reduction leads with its weakest member;
+  3. source-text exhaustiveness — every enum member is handled explicitly in the
+     template, and the template names no outcome the enum can't emit. These are
+     what keep the neutral `{% else %}` guard unreachable in practice.
+"""
+
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+sys.modules.setdefault('apscheduler', MagicMock())
+sys.modules.setdefault('apscheduler.schedulers', MagicMock())
+sys.modules.setdefault('apscheduler.schedulers.background', MagicMock())
+sys.modules.setdefault('apscheduler.triggers', MagicMock())
+sys.modules.setdefault('apscheduler.triggers.cron', MagicMock())
+sys.modules.setdefault('apscheduler.triggers.interval', MagicMock())
+sys.modules.setdefault('plexapi', MagicMock())
+sys.modules.setdefault('plexapi.server', MagicMock())
+
+from web.outcome_vocabulary import OUTCOMES, outcome_tooltip
+from web.services.recently_added_service import RecentlyAddedRow, RecentlyAddedService
+
+REPO = Path(__file__).resolve().parent.parent
+LIST_TEMPLATE = REPO / "web" / "templates" / "recently_added" / "partials" / "list.html"
+
+_classify = RecentlyAddedService._classify_outcome
+
+
+def _facts(**over):
+    base = dict(
+        pin_index_available=True, is_pinned=False, location="cache",
+        is_mover_protected=True, watched_move=True,
+        is_ondeck=False, is_watchlist=False,
+    )
+    base.update(over)
+    return base
+
+
+class TestClassifier:
+    def test_pinned_and_on_cache(self):
+        assert _classify(**_facts(is_pinned=True)) == "held"
+
+    def test_pinned_but_not_yet_on_cache(self):
+        # The state Option B could not represent without stating something false.
+        assert _classify(**_facts(is_pinned=True, location="array")) == "arriving"
+
+    def test_ondeck_on_cache(self):
+        assert _classify(**_facts(is_ondeck=True)) == "returns_when_done"
+
+    def test_watchlist_on_cache(self):
+        assert _classify(**_facts(is_watchlist=True)) == "returns_when_done"
+
+    def test_on_cache_no_longer_held(self):
+        assert _classify(**_facts()) == "moves_back"
+
+    def test_on_cache_but_not_in_exclude_list_is_the_movers_call(self):
+        # Covers both a deliberately released file and a never-tracked fresh
+        # download — the most common state on this page.
+        assert _classify(**_facts(is_mover_protected=False)) == "mover_decides"
+
+    def test_watched_move_off_holds_everything_on_cache(self):
+        # A and B are both wrong on every cached row when this setting is off.
+        assert _classify(**_facts(watched_move=False)) == "held_by_setting"
+        assert _classify(**_facts(watched_move=False, is_ondeck=True)) == "held_by_setting"
+
+    def test_on_array(self):
+        assert _classify(**_facts(location="array")) == "stays_on_array"
+
+    def test_unmapped_path(self):
+        assert _classify(**_facts(location="unknown")) == "unmapped"
+
+    def test_pin_state_unknown_outranks_everything(self):
+        # A row whose pin state is unverified cannot honestly claim any lower
+        # outcome — including "unmapped".
+        assert _classify(**_facts(pin_index_available=False)) == "pin_unknown"
+        assert _classify(**_facts(pin_index_available=False, location="unknown")) == "pin_unknown"
+        assert _classify(**_facts(pin_index_available=False, is_pinned=True)) == "pin_unknown"
+
+    def test_every_emitted_value_is_a_known_outcome(self):
+        import itertools
+        for combo in itertools.product([True, False], repeat=6):
+            avail, pinned, mover, wm, od, wl = combo
+            for loc in ("cache", "array", "unknown"):
+                got = _classify(pin_index_available=avail, is_pinned=pinned, location=loc,
+                                is_mover_protected=mover, watched_move=wm,
+                                is_ondeck=od, is_watchlist=wl)
+                assert got in OUTCOMES, got
+
+
+def _row(outcome, ep=1):
+    return RecentlyAddedRow(
+        rating_key=str(ep), title=f"E{ep}", media_type="episode", library_title="TV",
+        file_path=f"/data/{ep}.mkv", size=100, size_display="100 B",
+        added_at=datetime.now(), added_display="1 hr ago",
+        location="cache", state="on_cache_not_pinned", outcome=outcome,
+        episode_info={"show": "Show", "season": 1, "episode": ep},
+    )
+
+
+class TestGroupReduction:
+    def test_all_on_array_does_not_claim_protection(self):
+        # The exact shape that used to render a green "Protected".
+        g = RecentlyAddedService.group_rows_for_display(
+            [_row("stays_on_array", i) for i in (1, 2, 3)]
+        )[0]
+        assert g["outcome_lead"] == "stays_on_array"
+        assert "Protected" not in g["outcome_label"]
+        assert g["outcome_label"] == "Not on cache"
+
+    def test_all_unmapped_does_not_claim_protection(self):
+        g = RecentlyAddedService.group_rows_for_display(
+            [_row("unmapped", i) for i in (1, 2, 3)]
+        )[0]
+        assert g["outcome_lead"] == "unmapped"
+        assert "Protected" not in g["outcome_label"]
+
+    def test_weakest_member_leads(self):
+        # 2 held + 1 leaving must not read like a healthy group.
+        g = RecentlyAddedService.group_rows_for_display(
+            [_row("held", 1), _row("held", 2), _row("moves_back", 3)]
+        )[0]
+        assert g["outcome_lead"] == "moves_back"
+        assert g["outcome_label"] == "1 of 3 Moves to array"
+        assert g["outcome_mixed"] is True
+
+    def test_unanimous_group_has_a_bare_label(self):
+        g = RecentlyAddedService.group_rows_for_display([_row("held", i) for i in (1, 2)])[0]
+        assert g["outcome_label"] == "Stays on cache"
+        assert g["outcome_mixed"] is False
+
+    def test_stays_on_array_yields_to_a_real_outcome(self):
+        # A file that never arrived on cache cannot leave it, so it sits outside
+        # the ranking and only leads when unanimous.
+        g = RecentlyAddedService.group_rows_for_display(
+            [_row("stays_on_array", 1), _row("stays_on_array", 2), _row("moves_back", 3)]
+        )[0]
+        assert g["outcome_lead"] == "moves_back"
+
+    def test_pin_unknown_leads_over_everything(self):
+        g = RecentlyAddedService.group_rows_for_display(
+            [_row("held", 1), _row("pin_unknown", 2)]
+        )[0]
+        assert g["outcome_lead"] == "pin_unknown"
+
+    def test_counts_partition_the_group(self):
+        rows = [_row("held", 1), _row("moves_back", 2), _row("moves_back", 3)]
+        g = RecentlyAddedService.group_rows_for_display(rows)[0]
+        assert sum(g["outcome_counts"].values()) == g["episode_count"] == 3
+
+    def test_tooltip_lists_every_present_outcome(self):
+        g = RecentlyAddedService.group_rows_for_display(
+            [_row("held", 1), _row("moves_back", 2)]
+        )[0]
+        assert "1 Stays on cache" in g["outcome_tooltip"]
+        assert "1 Moves to array" in g["outcome_tooltip"]
+
+
+class TestTemplateExhaustiveness:
+    """Source-text checks — the enum and the template must not drift apart."""
+
+    @pytest.fixture(scope="class")
+    def source(self):
+        return LIST_TEMPLATE.read_text(encoding="utf-8")
+
+    def test_every_outcome_is_handled_explicitly_in_the_row_badge(self, source):
+        row_macro = source[source.index("{% macro ra_status_badge"):source.index("{% macro ra_row")]
+        for key in OUTCOMES:
+            assert f"row.outcome == '{key}'" in row_macro, f"row badge does not handle {key}"
+
+    def test_every_outcome_is_handled_explicitly_in_the_group_header(self, source):
+        for key in OUTCOMES:
+            assert f"item.outcome_lead == '{key}'" in source, f"group header does not handle {key}"
+
+    def test_template_names_no_outcome_the_enum_cannot_emit(self, source):
+        named = set(re.findall(r"(?:row\.outcome|item\.outcome_lead) == '([a-z_]+)'", source))
+        assert named <= set(OUTCOMES), f"template names unknown outcomes: {named - set(OUTCOMES)}"
+
+    def test_no_bare_protected_badge_survives(self, source):
+        # "Protected" may appear only inside a tooltip sentence, never as badge text.
+        assert ">Protected<" not in source
+        assert "> Protected<" not in source
+
+
+class TestReservedProtectedSentence:
+    """The owner's constraint: "Protected" means protected from EVICTION only."""
+
+    SENTENCE = "Pinned — protected from eviction."
+
+    def test_only_pin_backed_outcomes_use_the_word(self):
+        for key, outcome in OUTCOMES.items():
+            if "protected from eviction" in outcome.tooltip:
+                assert key in ("held", "arriving"), (
+                    f"{key} claims eviction protection but is not pin-backed"
+                )
+
+    def test_both_pin_backed_outcomes_carry_it_verbatim(self):
+        for key in ("held", "arriving"):
+            assert OUTCOMES[key].tooltip.startswith(self.SENTENCE)
+
+    def test_transient_states_never_claim_protection(self):
+        # OnDeck/Watchlist only add +15 to the priority score; they exempt nothing.
+        for key in ("returns_when_done", "moves_back", "mover_decides",
+                    "stays_on_array", "unmapped", "pin_unknown", "held_by_setting"):
+            assert "protected" not in OUTCOMES[key].tooltip.lower()
+
+    def test_every_outcome_has_a_tooltip(self):
+        for key, outcome in OUTCOMES.items():
+            assert outcome.tooltip.strip(), f"{key} has no tooltip"
+            assert outcome_tooltip(key) == outcome.tooltip
+
+    def test_unknown_key_yields_empty_tooltip(self):
+        assert outcome_tooltip("nonexistent") == ""
+
+    def test_tiers_are_unique_among_ranked_outcomes(self):
+        ranked = [o.tier for o in OUTCOMES.values() if o.tier < 99]
+        assert len(ranked) == len(set(ranked))

--- a/tests/test_outcome_vocabulary.py
+++ b/tests/test_outcome_vocabulary.py
@@ -204,13 +204,42 @@ class TestReservedProtectedSentence:
     def test_only_pin_backed_outcomes_use_the_word(self):
         for key, outcome in OUTCOMES.items():
             if "protected from eviction" in outcome.tooltip:
-                assert key in ("held", "arriving"), (
+                assert key in ("held", "held_mover_gap"), (
                     f"{key} claims eviction protection but is not pin-backed"
                 )
 
-    def test_both_pin_backed_outcomes_carry_it_verbatim(self):
-        for key in ("held", "arriving"):
+    def test_on_cache_pinned_states_carry_it_verbatim(self):
+        for key in ("held", "held_mover_gap"):
             assert OUTCOMES[key].tooltip.startswith(self.SENTENCE)
+
+    def test_arriving_makes_no_eviction_claim(self):
+        # Nothing is on cache to evict, so the sentence would be vacuous.
+        assert "protected from eviction" not in OUTCOMES["arriving"].tooltip
+
+    def test_pinned_tooltips_also_name_the_move_back_guarantee(self):
+        # A pin short-circuits the watched move-back too
+        # (core/file_operations.py:3814), so "eviction" alone undersells it.
+        for key in ("held", "held_mover_gap"):
+            assert "move it back" in OUTCOMES[key].tooltip
+
+    def test_only_held_claims_mover_protection(self):
+        # Pinning writes no exclude line, so mover protection is not a pin's to
+        # promise until a run has added one.
+        assert "mover is told to skip it" in OUTCOMES["held"].tooltip
+        assert "could still relocate it" in OUTCOMES["held_mover_gap"].tooltip
+
+    def test_no_two_outcomes_share_a_label_unless_they_share_a_badge(self):
+        # At group level only the label survives — the badge colour and icon
+        # that distinguished two same-labelled states are gone.
+        seen = {}
+        for key, o in OUTCOMES.items():
+            if o.label in seen:
+                other = seen[o.label]
+                assert o.badge == OUTCOMES[other].badge, (
+                    f"{key} and {other} render the same label {o.label!r} with "
+                    f"different badges — indistinguishable in a group header"
+                )
+            seen.setdefault(o.label, key)
 
     def test_transient_states_never_claim_protection(self):
         # OnDeck/Watchlist only add +15 to the priority score; they exempt nothing.

--- a/tests/test_pin_button_macro.py
+++ b/tests/test_pin_button_macro.py
@@ -61,13 +61,15 @@ class TestPinButtonMacroShape:
         assert 'name="title" value="Show - S01E05"' in html
         assert 'data-lucide="pin"' in html
         assert 'btn-primary' in html
-        assert 'Pin this item' in html  # button title, unambiguous
+        # Tooltip makes the "always cached" semantics explicit (distinguishes
+        # Pin from Maintenance's one-time "Keep on Cache" action).
+        assert 'Pin — always keep this item on cache (never evicted)' in html
 
     def test_pinned_state_renders_unpin_button(self):
         html = _render_macro(is_pinned=True)
         assert 'data-lucide="pin-off"' in html
         assert 'btn-secondary' in html
-        assert 'Unpin this item' in html
+        assert 'Unpin — allow this item to be evicted or moved back to the array' in html
         assert 'data-is-pinned="true"' in html
 
     def test_macro_matches_toggle_response_attributes(self):
@@ -85,6 +87,18 @@ class TestPinButtonMacroShape:
         ):
             assert attr in macro_html, f"macro missing {attr}"
             assert attr in response_html, f"toggle response missing {attr}"
+
+    def test_macro_and_toggle_response_share_tooltip_wording(self):
+        """The button tooltip must match between the macro and its HTMX
+        swap-response in the SAME state — otherwise the "always cached"
+        wording reverts to the old copy after the first toggle."""
+        pin_tip = 'Pin — always keep this item on cache (never evicted)'
+        unpin_tip = 'Unpin — allow this item to be evicted or moved back to the array'
+
+        assert pin_tip in _render_macro(is_pinned=False)
+        assert pin_tip in _render_toggle_response(is_pinned=False)
+        assert unpin_tip in _render_macro(is_pinned=True)
+        assert unpin_tip in _render_toggle_response(is_pinned=True)
 
 
 class TestFileTableRowMarkup:

--- a/tests/test_pin_button_macro.py
+++ b/tests/test_pin_button_macro.py
@@ -162,3 +162,46 @@ class TestFileTableRowMarkup:
         html = self._render_file_table([f])
         assert 'badge-pinned' in html
         assert '>\n                Pinned\n' in html
+
+
+class TestToggleResponseUsesTheSharedMacro:
+    """The toggle response used to hand-copy the pin button's markup.
+
+    The copy accepted no label/confirm, so after unpinning a show from a
+    Recently Added episode row the swapped-in control came back as a bare,
+    confirm-less "Pin" still bound to pin_type=show — one stray click re-pinned
+    the entire series.
+    """
+
+    TEMPLATE = "settings/partials/pinned_toggle_response.html"
+
+    def _render(self, **ctx):
+        from web.config import templates
+        base = {"error": None, "rating_key": "1", "pin_type": "movie",
+                "title": "Dune", "is_pinned": False}
+        base.update(ctx)
+        return templates.get_template(self.TEMPLATE).render(**base)
+
+    def test_it_imports_the_macro_rather_than_duplicating_markup(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "web" / "templates" /
+               "settings" / "partials" / "pinned_toggle_response.html").read_text(encoding="utf-8")
+        assert 'import pin_button' in src
+        assert '<button type="submit"' not in src, "markup is hand-copied again"
+
+    def test_movie_toggle_is_unchanged(self):
+        out = self._render(pin_type="movie", is_pinned=False)
+        assert "/api/pinned/toggle" in out
+        assert ">Pin<" in out.replace("\n", "").replace(" ", "") or "Pin" in out
+        assert "hx-confirm" not in out
+
+    def test_unpinning_a_show_keeps_its_scope_label_and_confirm(self):
+        out = self._render(pin_type="show", title="The Office", is_pinned=True)
+        assert "Unpin show" in out
+        assert "hx-confirm" in out
+        assert "releases every episode it covers" in out
+
+    def test_pinning_a_show_needs_no_confirm(self):
+        # Adding protection is not destructive; only releasing it is.
+        out = self._render(pin_type="show", title="The Office", is_pinned=False)
+        assert "hx-confirm" not in out

--- a/tests/test_pin_vocabulary.py
+++ b/tests/test_pin_vocabulary.py
@@ -1,0 +1,50 @@
+"""Vocabulary-clarity guards for the Pin vs "Keep on Cache" distinction.
+
+PlexCache has two related-but-different protect-on-cache concepts:
+
+* **Pin** (``core/pinned_media.py``, keyed by rating_key) — deliberate
+  curation: the item is *always* kept on cache, re-applied every run, and
+  never evicted. Surfaced in Settings → Cache and the Cached Files badge.
+* **Keep on Cache** (``MaintenanceService.protect_with_backup``, keyed by
+  path) — a *one-time* triage action on the Maintenance → Untracked Files
+  card, paired with "Move to Array". It backs the file up + excludes it once,
+  but does NOT create a pin.
+
+These tests assert the UI copy keeps that distinction legible so the two
+mechanisms don't silently blur into "same name, different behavior". The
+Untracked Files partial is large and depends on a fully-populated ``results``
+object, so this guards the template source text directly rather than rendering.
+"""
+
+from pathlib import Path
+
+TEMPLATE_ROOT = Path(__file__).resolve().parents[1] / "web" / "templates"
+AUDIT_RESULTS = TEMPLATE_ROOT / "maintenance" / "partials" / "audit_results.html"
+
+
+def _audit_source() -> str:
+    return AUDIT_RESULTS.read_text(encoding="utf-8")
+
+
+class TestKeepOnCacheClarity:
+    def test_keep_on_cache_button_tooltip_says_one_time_not_pin(self):
+        src = _audit_source()
+        assert "This is a one-time action, not a pin" in src
+        # Points users at the real pin surface for permanent caching.
+        assert "pin it in Settings → Cache" in src
+
+    def test_confirm_modal_distinguishes_keep_from_pin(self):
+        src = _audit_source()
+        assert "one-time keep" in src
+        assert "won't be re-cached automatically on future runs" in src
+
+    def test_confirm_modal_step_clarifies_not_a_pin(self):
+        src = _audit_source()
+        assert "one-time — not a pin" in src
+
+    def test_keep_on_cache_name_is_retained(self):
+        """The 'Keep on Cache' verb stays distinct from 'Pin' on purpose —
+        it's the one-time triage action, paired with 'Move to Array'."""
+        src = _audit_source()
+        assert "Keep on Cache" in src
+        assert "Move to Array" in src

--- a/tests/test_pin_vocabulary.py
+++ b/tests/test_pin_vocabulary.py
@@ -29,9 +29,13 @@ def _audit_source() -> str:
 class TestKeepOnCacheClarity:
     def test_keep_on_cache_button_tooltip_says_one_time_not_pin(self):
         src = _audit_source()
-        assert "This is a one-time action, not a pin" in src
-        # Points users at the real pin surface for permanent caching.
+        assert "Not a pin: won't re-cache automatically" in src
+        # The confirm modal still points users at the real pin surface.
         assert "pin it in Settings → Cache" in src
+
+    def test_move_to_array_button_has_tooltip(self):
+        src = _audit_source()
+        assert "Move these files off the cache drive to the array" in src
 
     def test_confirm_modal_distinguishes_keep_from_pin(self):
         src = _audit_source()

--- a/tests/test_plex_api_recently_added.py
+++ b/tests/test_plex_api_recently_added.py
@@ -93,7 +93,7 @@ class TestGetRecentlyAddedMedia:
         api = _api([_section(1, "Movies", [
             _movie(101, "Dune", added_days_ago=1, parts=[_part("/data/movies/Dune.mkv", 28_000)]),
         ])])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
 
         assert len(items) == 1
         item = items[0]
@@ -112,7 +112,7 @@ class TestGetRecentlyAddedMedia:
             _movie(1, "Fresh", added_days_ago=2),
             _movie(2, "Stale", added_days_ago=40),
         ])])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
 
         titles = {i.title for i in items}
         assert titles == {"Fresh"}
@@ -121,7 +121,7 @@ class TestGetRecentlyAddedMedia:
         api = _api([_section(3, "TV Shows", [
             _episode(50, "Future Days", "The Last of Us", 2, 1, added_days_ago=1),
         ])])
-        items = api.get_recently_added_media(valid_sections=[3], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[3], days_to_monitor=7).items
 
         assert len(items) == 1
         item = items[0]
@@ -133,7 +133,7 @@ class TestGetRecentlyAddedMedia:
             _section(1, "Movies", [_movie(1, "A", added_days_ago=1)]),
             _section(2, "4K Movies", [_movie(2, "B", added_days_ago=1)]),
         ])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
 
         assert {i.title for i in items} == {"A"}
 
@@ -142,7 +142,7 @@ class TestGetRecentlyAddedMedia:
             _section(1, "Movies", [_movie(1, "A", added_days_ago=1)]),
             _section(2, "4K Movies", [_movie(2, "B", added_days_ago=1)]),
         ])
-        items = api.get_recently_added_media(valid_sections=[], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[], days_to_monitor=7).items
 
         assert {i.title for i in items} == {"A", "B"}
 
@@ -152,7 +152,7 @@ class TestGetRecentlyAddedMedia:
             _movie(2, "Middle", added_days_ago=2),
             _movie(3, "Newest", added_days_ago=1),
         ])])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7, max_items=2)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7, max_items=2).items
 
         assert [i.title for i in items] == ["Newest", "Middle"]
 
@@ -161,7 +161,7 @@ class TestGetRecentlyAddedMedia:
             _section(1, "Movies", [_movie(1, "Older", added_days_ago=5)]),
             _section(2, "TV Shows", [_episode(2, "Ep", "Show", 1, 1, added_days_ago=1)]),
         ])
-        items = api.get_recently_added_media(valid_sections=[1, 2], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1, 2], days_to_monitor=7).items
 
         assert [i.title for i in items] == ["Ep", "Older"]
 
@@ -171,7 +171,7 @@ class TestGetRecentlyAddedMedia:
             addedAt=datetime.now(), media=[],
         )
         api = _api([_section(3, "TV Shows", [season_wrapper])])
-        items = api.get_recently_added_media(valid_sections=[3], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[3], days_to_monitor=7).items
 
         assert items == []
 
@@ -184,7 +184,7 @@ class TestGetRecentlyAddedMedia:
                 _part("/data/movies/Multi-cd2.mkv", 600),
             ]),
         ])])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
 
         assert len(items) == 1
         assert items[0].file_path == "/data/movies/Multi-cd1.mkv"
@@ -207,7 +207,7 @@ class TestGetRecentlyAddedMedia:
             ],
         )
         api = _api([_section(1, "Movies", [movie])])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
 
         assert len(items) == 1
         assert items[0].file_path == "/data/movies/Dune-4K.mkv"
@@ -230,7 +230,7 @@ class TestGetRecentlyAddedMedia:
         api = _api([_section(1, "Movies", [movie])])
         items = api.get_recently_added_media(
             valid_sections=[1], days_to_monitor=7, version_preference="lowest"
-        )
+        ).items
         assert items[0].file_path == "/data/movies/Dune-1080p.mkv"
 
     def test_item_with_no_media_is_skipped(self):
@@ -239,18 +239,56 @@ class TestGetRecentlyAddedMedia:
             addedAt=datetime.now(), media=[],
         )
         api = _api([_section(1, "Movies", [blank])])
-        assert api.get_recently_added_media(valid_sections=[1], days_to_monitor=7) == []
+        assert api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items == []
 
-    def test_returns_empty_when_sections_unavailable(self):
+    def test_raises_when_sections_unavailable(self):
+        """No section was ever enumerated, so there is no partial result to
+        return. Swallowing this gave the caller available=True with no rows,
+        which renders as "Nothing added" — a confident statement about
+        libraries that were never contacted."""
         api = PlexManager.__new__(PlexManager)
 
         def _raise():
             raise RuntimeError("not connected")
 
         api.plex = SimpleNamespace(library=SimpleNamespace(sections=_raise))
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        with pytest.raises(RuntimeError, match="not connected"):
+            api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
 
-        assert items == []
+
+class TestPartialLibraryFailure:
+    """One library failing must not look like one library being empty."""
+
+    def _flaky_section(self, key, title):
+        def _raise(**kwargs):
+            raise RuntimeError("(504) gateway timeout")
+        return SimpleNamespace(key=str(key), title=title, type='movie',
+                               recentlyAdded=_raise)
+
+    def test_failed_section_is_named_not_dropped(self):
+        movie = _movie(1, "Dune", added_days_ago=1)
+        api = _api([
+            _section(1, "Movies", [movie]),
+            self._flaky_section(2, "Documentaries"),
+        ])
+        result = api.get_recently_added_media(valid_sections=[1, 2], days_to_monitor=7)
+
+        assert [i.title for i in result.items] == ["Dune"]
+        assert result.unreadable_libraries == ["Documentaries"]
+
+    def test_clean_sweep_reports_nothing_unreadable(self):
+        movie = _movie(1, "Dune", added_days_ago=1)
+        api = _api([_section(1, "Movies", [movie])])
+        result = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        assert result.unreadable_libraries == []
+
+    def test_untitled_section_falls_back_to_its_key(self):
+        section = self._flaky_section(7, "")
+        api = _api([section])
+        result = api.get_recently_added_media(valid_sections=[7], days_to_monitor=7)
+
+        assert result.unreadable_libraries == ["section 7"]
 
     def test_show_section_uses_recently_added_episodes(self):
         # recentlyAdded() on a show library returns show wrappers (skipped);
@@ -259,7 +297,7 @@ class TestGetRecentlyAddedMedia:
         section = _show_section(2, "TV Shows", episodes=eps,
                                 shows=[_show_wrapper(9, "The Last of Us")])
         api = _api([section])
-        items = api.get_recently_added_media(valid_sections=[2], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[2], days_to_monitor=7).items
 
         assert len(items) == 1
         assert items[0].media_type == "episode"
@@ -273,7 +311,7 @@ class TestGetRecentlyAddedMedia:
             recentlyAdded=lambda maxresults=None, _e=eps: list(_e),
         )
         api = _api([section])
-        items = api.get_recently_added_media(valid_sections=[2], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[2], days_to_monitor=7).items
 
         assert len(items) == 1
         assert items[0].media_type == "episode"
@@ -282,7 +320,7 @@ class TestGetRecentlyAddedMedia:
         api = _api([_section(1, "Movies", [
             _movie(1, "NoFile", added_days_ago=1, parts=[_part(None), _part("/data/movies/Ok.mkv")]),
         ])])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
 
         assert [i.file_path for i in items] == ["/data/movies/Ok.mkv"]
 
@@ -328,7 +366,7 @@ class TestPartialObjectResilience:
         ])
 
         with caplog.at_level(logging.WARNING):
-            items = api.get_recently_added_media(valid_sections=[1, 2], days_to_monitor=7)
+            items = api.get_recently_added_media(valid_sections=[1, 2], days_to_monitor=7).items
 
         # All four survive — including the raising item, degraded rather than dropped.
         assert len(items) == 4
@@ -347,7 +385,7 @@ class TestPartialObjectResilience:
         ])])
 
         with caplog.at_level(logging.WARNING):
-            items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+            items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
 
         # No media means no file to show, so this one is correctly skipped —
         # but it takes only itself down. Compared as a set: both survivors share
@@ -368,11 +406,11 @@ class TestShowIdentity:
         ep = _episode(1, "Ep", "Show", 1, 1, added_days_ago=1)
         ep.grandparentRatingKey = 500          # plexapi casts this to int
         api = _api([_section(1, "TV Shows", [ep])])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
         assert items[0].show_rating_key == "500"
 
     def test_missing_show_rating_key_degrades_to_empty(self):
         ep = _episode(1, "Ep", "Show", 1, 1, added_days_ago=1)
         api = _api([_section(1, "TV Shows", [ep])])
-        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7).items
         assert items[0].show_rating_key == ""

--- a/tests/test_plex_api_recently_added.py
+++ b/tests/test_plex_api_recently_added.py
@@ -372,9 +372,14 @@ class TestPartialObjectResilience:
         assert len(items) == 4
         degraded = [i for i in items if i.title == "Special"]
         assert len(degraded) == 1
-        # A healthy server with a genuinely unnumbered special produces exactly
-        # this, so the degraded path is byte-identical to the healthy one.
-        assert degraded[0].episode_info is None
+        # Degraded in the numbering only. The show name is the more useful half
+        # and is still there, so the row renders as an episode of its show
+        # rather than falling through to the movie layout. A healthy server with
+        # a genuinely unnumbered special produces exactly this shape too.
+        assert degraded[0].media_type == "episode"
+        assert degraded[0].episode_info == {
+            "show": "Show", "season": 1, "episode": None,
+        }
         assert any("could not read 'index'" in r.message for r in caplog.records)
 
     def test_unreadable_media_is_skipped_but_the_rest_survive(self, caplog):

--- a/tests/test_plex_api_recently_added.py
+++ b/tests/test_plex_api_recently_added.py
@@ -174,7 +174,9 @@ class TestGetRecentlyAddedMedia:
 
         assert items == []
 
-    def test_emits_one_item_per_file_part(self):
+    def test_multi_part_version_is_one_item_covering_both_files(self):
+        # cd1/cd2 are parts of ONE version: both are cached together, so they
+        # belong to a single item whose size is their sum.
         api = _api([_section(1, "Movies", [
             _movie(1, "Multi", added_days_ago=1, parts=[
                 _part("/data/movies/Multi-cd1.mkv", 500),
@@ -183,9 +185,60 @@ class TestGetRecentlyAddedMedia:
         ])])
         items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
 
-        assert {i.file_path for i in items} == {
+        assert len(items) == 1
+        assert items[0].file_path == "/data/movies/Multi-cd1.mkv"
+        assert items[0].size == 1100
+        assert [f["file_path"] for f in items[0].version_files] == [
             "/data/movies/Multi-cd1.mkv", "/data/movies/Multi-cd2.mkv",
-        }
+        ]
+        assert all(f["is_preferred"] for f in items[0].version_files)
+
+    def test_multi_version_item_emits_one_row_for_the_preferred_version(self):
+        # 4K + 1080p of one movie share a ratingKey. PlexCache only ever caches
+        # and pins the preferred version, so a second row would put two pin
+        # controls on one ratingKey — the second reading "Pin" but unpinning.
+        movie = SimpleNamespace(
+            type='movie', ratingKey=7, title="Dune",
+            addedAt=datetime.now() - timedelta(days=1),
+            media=[
+                SimpleNamespace(videoResolution='1080', parts=[_part("/data/movies/Dune-1080p.mkv", 8)]),
+                SimpleNamespace(videoResolution='4k', parts=[_part("/data/movies/Dune-4K.mkv", 40)]),
+            ],
+        )
+        api = _api([_section(1, "Movies", [movie])])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        assert len(items) == 1
+        assert items[0].file_path == "/data/movies/Dune-4K.mkv"
+        assert items[0].size == 40
+        # The 1080p file is still disclosed, flagged as not the managed version.
+        assert len(items[0].version_files) == 2
+        others = [f for f in items[0].version_files if not f["is_preferred"]]
+        assert [f["file_path"] for f in others] == ["/data/movies/Dune-1080p.mkv"]
+        assert others[0]["label"] == "1080p"
+
+    def test_version_preference_selects_the_row(self):
+        movie = SimpleNamespace(
+            type='movie', ratingKey=7, title="Dune",
+            addedAt=datetime.now() - timedelta(days=1),
+            media=[
+                SimpleNamespace(videoResolution='1080', parts=[_part("/data/movies/Dune-1080p.mkv", 8)]),
+                SimpleNamespace(videoResolution='4k', parts=[_part("/data/movies/Dune-4K.mkv", 40)]),
+            ],
+        )
+        api = _api([_section(1, "Movies", [movie])])
+        items = api.get_recently_added_media(
+            valid_sections=[1], days_to_monitor=7, version_preference="lowest"
+        )
+        assert items[0].file_path == "/data/movies/Dune-1080p.mkv"
+
+    def test_item_with_no_media_is_skipped(self):
+        blank = SimpleNamespace(
+            type='movie', ratingKey=8, title="Blank",
+            addedAt=datetime.now(), media=[],
+        )
+        api = _api([_section(1, "Movies", [blank])])
+        assert api.get_recently_added_media(valid_sections=[1], days_to_monitor=7) == []
 
     def test_returns_empty_when_sections_unavailable(self):
         api = PlexManager.__new__(PlexManager)

--- a/tests/test_plex_api_recently_added.py
+++ b/tests/test_plex_api_recently_added.py
@@ -1,0 +1,191 @@
+"""Tests for PlexManager.get_recently_added_media().
+
+Recently-added is a server-wide, library-level fetch (no per-user token
+machinery). It iterates enabled library sections, calls section.recentlyAdded(),
+filters by an added-within-N-days cutoff, emits one RecentlyAddedItem per media
+file, and returns the newest first capped at max_items.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions', 'requests',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.plex_api import PlexManager, RecentlyAddedItem
+
+
+# --- fixtures / builders -------------------------------------------------
+
+def _part(file, size=1000):
+    return SimpleNamespace(file=file, size=size)
+
+
+def _media(*parts):
+    return SimpleNamespace(parts=list(parts))
+
+
+def _movie(rating_key, title, added_days_ago, parts=None, added_at=None):
+    when = added_at if added_at is not None else datetime.now() - timedelta(days=added_days_ago)
+    return SimpleNamespace(
+        type='movie', ratingKey=rating_key, title=title, addedAt=when,
+        media=[_media(*(parts or [_part(f"/data/movies/{title}.mkv")]))],
+    )
+
+
+def _episode(rating_key, title, show, season, episode, added_days_ago, parts=None):
+    return SimpleNamespace(
+        type='episode', ratingKey=rating_key, title=title,
+        grandparentTitle=show, parentIndex=season, index=episode,
+        addedAt=datetime.now() - timedelta(days=added_days_ago),
+        media=[_media(*(parts or [_part(f"/data/tv/{show}/{title}.mkv")]))],
+    )
+
+
+def _section(key, title, items):
+    return SimpleNamespace(
+        key=key, title=title,
+        recentlyAdded=lambda maxresults=None, _items=items: list(_items),
+    )
+
+
+def _api(sections):
+    api = PlexManager.__new__(PlexManager)
+    api.plex = SimpleNamespace(library=SimpleNamespace(sections=lambda: sections))
+    return api
+
+
+# --- tests ---------------------------------------------------------------
+
+class TestGetRecentlyAddedMedia:
+    def test_returns_movie_with_metadata(self):
+        api = _api([_section(1, "Movies", [
+            _movie(101, "Dune", added_days_ago=1, parts=[_part("/data/movies/Dune.mkv", 28_000)]),
+        ])])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        assert len(items) == 1
+        item = items[0]
+        assert isinstance(item, RecentlyAddedItem)
+        assert item.file_path == "/data/movies/Dune.mkv"
+        assert item.rating_key == "101"  # stringified
+        assert item.title == "Dune"
+        assert item.media_type == "movie"
+        assert item.library_title == "Movies"
+        assert item.library_section_id == 1
+        assert item.size == 28_000
+        assert item.episode_info is None
+
+    def test_filters_out_items_older_than_window(self):
+        api = _api([_section(1, "Movies", [
+            _movie(1, "Fresh", added_days_ago=2),
+            _movie(2, "Stale", added_days_ago=40),
+        ])])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        titles = {i.title for i in items}
+        assert titles == {"Fresh"}
+
+    def test_episode_carries_show_season_episode(self):
+        api = _api([_section(3, "TV Shows", [
+            _episode(50, "Future Days", "The Last of Us", 2, 1, added_days_ago=1),
+        ])])
+        items = api.get_recently_added_media(valid_sections=[3], days_to_monitor=7)
+
+        assert len(items) == 1
+        item = items[0]
+        assert item.media_type == "episode"
+        assert item.episode_info == {"show": "The Last of Us", "season": 2, "episode": 1}
+
+    def test_respects_valid_sections(self):
+        api = _api([
+            _section(1, "Movies", [_movie(1, "A", added_days_ago=1)]),
+            _section(2, "4K Movies", [_movie(2, "B", added_days_ago=1)]),
+        ])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        assert {i.title for i in items} == {"A"}
+
+    def test_empty_valid_sections_includes_all(self):
+        api = _api([
+            _section(1, "Movies", [_movie(1, "A", added_days_ago=1)]),
+            _section(2, "4K Movies", [_movie(2, "B", added_days_ago=1)]),
+        ])
+        items = api.get_recently_added_media(valid_sections=[], days_to_monitor=7)
+
+        assert {i.title for i in items} == {"A", "B"}
+
+    def test_caps_at_max_items_keeping_newest(self):
+        api = _api([_section(1, "Movies", [
+            _movie(1, "Oldest", added_days_ago=3),
+            _movie(2, "Middle", added_days_ago=2),
+            _movie(3, "Newest", added_days_ago=1),
+        ])])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7, max_items=2)
+
+        assert [i.title for i in items] == ["Newest", "Middle"]
+
+    def test_sorted_newest_first_across_sections(self):
+        api = _api([
+            _section(1, "Movies", [_movie(1, "Older", added_days_ago=5)]),
+            _section(2, "TV Shows", [_episode(2, "Ep", "Show", 1, 1, added_days_ago=1)]),
+        ])
+        items = api.get_recently_added_media(valid_sections=[1, 2], days_to_monitor=7)
+
+        assert [i.title for i in items] == ["Ep", "Older"]
+
+    def test_skips_non_movie_episode_types(self):
+        season_wrapper = SimpleNamespace(
+            type='season', ratingKey=9, title="Season 2",
+            addedAt=datetime.now(), media=[],
+        )
+        api = _api([_section(3, "TV Shows", [season_wrapper])])
+        items = api.get_recently_added_media(valid_sections=[3], days_to_monitor=7)
+
+        assert items == []
+
+    def test_emits_one_item_per_file_part(self):
+        api = _api([_section(1, "Movies", [
+            _movie(1, "Multi", added_days_ago=1, parts=[
+                _part("/data/movies/Multi-cd1.mkv", 500),
+                _part("/data/movies/Multi-cd2.mkv", 600),
+            ]),
+        ])])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        assert {i.file_path for i in items} == {
+            "/data/movies/Multi-cd1.mkv", "/data/movies/Multi-cd2.mkv",
+        }
+
+    def test_returns_empty_when_sections_unavailable(self):
+        api = PlexManager.__new__(PlexManager)
+
+        def _raise():
+            raise RuntimeError("not connected")
+
+        api.plex = SimpleNamespace(library=SimpleNamespace(sections=_raise))
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        assert items == []
+
+    def test_skips_parts_without_file_path(self):
+        api = _api([_section(1, "Movies", [
+            _movie(1, "NoFile", added_days_ago=1, parts=[_part(None), _part("/data/movies/Ok.mkv")]),
+        ])])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        assert [i.file_path for i in items] == ["/data/movies/Ok.mkv"]

--- a/tests/test_plex_api_recently_added.py
+++ b/tests/test_plex_api_recently_added.py
@@ -63,6 +63,22 @@ def _section(key, title, items):
     )
 
 
+def _show_wrapper(rating_key, title):
+    """A show-level item (what recentlyAdded() returns for a show library)."""
+    return SimpleNamespace(type='show', ratingKey=rating_key, title=title,
+                           addedAt=datetime.now(), media=[])
+
+
+def _show_section(key, title, episodes, shows=None):
+    """A show library: recentlyAdded() yields show wrappers, while
+    recentlyAddedEpisodes() yields the actual recently-added episodes."""
+    return SimpleNamespace(
+        key=key, title=title, type='show',
+        recentlyAdded=lambda maxresults=None, _s=(shows or []): list(_s),
+        recentlyAddedEpisodes=lambda maxresults=None, _e=episodes: list(_e),
+    )
+
+
 def _api(sections):
     api = PlexManager.__new__(PlexManager)
     api.plex = SimpleNamespace(library=SimpleNamespace(sections=lambda: sections))
@@ -181,6 +197,32 @@ class TestGetRecentlyAddedMedia:
         items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
 
         assert items == []
+
+    def test_show_section_uses_recently_added_episodes(self):
+        # recentlyAdded() on a show library returns show wrappers (skipped);
+        # the episodes must come from recentlyAddedEpisodes().
+        eps = [_episode(50, "Future Days", "The Last of Us", 2, 1, added_days_ago=1)]
+        section = _show_section(2, "TV Shows", episodes=eps,
+                                shows=[_show_wrapper(9, "The Last of Us")])
+        api = _api([section])
+        items = api.get_recently_added_media(valid_sections=[2], days_to_monitor=7)
+
+        assert len(items) == 1
+        assert items[0].media_type == "episode"
+        assert items[0].episode_info == {"show": "The Last of Us", "season": 2, "episode": 1}
+
+    def test_show_section_without_episode_helper_falls_back(self):
+        # type == 'show' but no recentlyAddedEpisodes() → fall back to recentlyAdded().
+        eps = [_episode(51, "Pilot", "Severance", 1, 1, added_days_ago=1)]
+        section = SimpleNamespace(
+            key=2, title="TV", type="show",
+            recentlyAdded=lambda maxresults=None, _e=eps: list(_e),
+        )
+        api = _api([section])
+        items = api.get_recently_added_media(valid_sections=[2], days_to_monitor=7)
+
+        assert len(items) == 1
+        assert items[0].media_type == "episode"
 
     def test_skips_parts_without_file_path(self):
         api = _api([_section(1, "Movies", [

--- a/tests/test_plex_api_recently_added.py
+++ b/tests/test_plex_api_recently_added.py
@@ -6,6 +6,7 @@ filters by an added-within-N-days cutoff, emits one RecentlyAddedItem per media
 file, and returns the newest first capped at max_items.
 """
 
+import logging
 import os
 import sys
 from datetime import datetime, timedelta
@@ -284,3 +285,94 @@ class TestGetRecentlyAddedMedia:
         items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
 
         assert [i.file_path for i in items] == ["/data/movies/Ok.mkv"]
+
+
+class TestPartialObjectResilience:
+    """One bad item must not discard every library already collected.
+
+    Section listings return plexapi *partial* objects, which reload on any
+    None/[] value — so reading an unnumbered special's `index` fires a live
+    metadata GET. When that 5xx'd, the exception escaped
+    get_recently_added_media() and the service rendered a full-page error.
+    """
+
+    class _RaisesOn:
+        """An episode whose named attribute raises, as a failing reload would."""
+
+        def __init__(self, name, rating_key=99, title="Special"):
+            self._name = name
+            self.type = 'episode'
+            self.ratingKey = rating_key
+            self.title = title
+            self.grandparentTitle = "Show"
+            self.grandparentRatingKey = 500
+            self.addedAt = datetime.now()
+            self.parentIndex = 1
+            self.index = 1
+            self.media = [_media(_part("/data/tv/Show/Special.mkv"))]
+
+        def __getattribute__(self, item):
+            if item != "_name" and item == object.__getattribute__(self, "_name"):
+                raise RuntimeError("(503) reload failed")
+            return object.__getattribute__(self, item)
+
+    def test_bad_item_does_not_discard_the_section(self, caplog):
+        bad = self._RaisesOn('index')
+        api = _api([
+            _section(1, "TV Shows", [
+                _episode(1, "Good1", "Show", 1, 1, added_days_ago=1),
+                bad,
+                _episode(2, "Good2", "Show", 1, 2, added_days_ago=1),
+            ]),
+            _section(2, "Movies", [_movie(3, "Dune", added_days_ago=1)]),
+        ])
+
+        with caplog.at_level(logging.WARNING):
+            items = api.get_recently_added_media(valid_sections=[1, 2], days_to_monitor=7)
+
+        # All four survive — including the raising item, degraded rather than dropped.
+        assert len(items) == 4
+        degraded = [i for i in items if i.title == "Special"]
+        assert len(degraded) == 1
+        # A healthy server with a genuinely unnumbered special produces exactly
+        # this, so the degraded path is byte-identical to the healthy one.
+        assert degraded[0].episode_info is None
+        assert any("could not read 'index'" in r.message for r in caplog.records)
+
+    def test_unreadable_media_is_skipped_but_the_rest_survive(self, caplog):
+        api = _api([_section(1, "TV Shows", [
+            _episode(1, "Good1", "Show", 1, 1, added_days_ago=1),
+            self._RaisesOn('media', rating_key=98, title="Unanalyzed"),
+            _episode(2, "Good2", "Show", 1, 2, added_days_ago=1),
+        ])])
+
+        with caplog.at_level(logging.WARNING):
+            items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+
+        # No media means no file to show, so this one is correctly skipped —
+        # but it takes only itself down. Compared as a set: both survivors share
+        # an addedAt, so their relative order is sort noise, not behaviour.
+        assert {i.title for i in items} == {"Good1", "Good2"}
+        assert any("could not read 'media'" in r.message for r in caplog.records)
+
+    def test_lazy_reload_is_disabled_on_listing_objects(self):
+        """Guards the _autoReload opt-out from silently regressing."""
+        ep = _episode(1, "Ep", "Show", 1, 1, added_days_ago=1)
+        api = _api([_section(1, "TV Shows", [ep])])
+        api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        assert ep._autoReload is False
+
+
+class TestShowIdentity:
+    def test_show_rating_key_is_captured_as_a_string(self):
+        ep = _episode(1, "Ep", "Show", 1, 1, added_days_ago=1)
+        ep.grandparentRatingKey = 500          # plexapi casts this to int
+        api = _api([_section(1, "TV Shows", [ep])])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        assert items[0].show_rating_key == "500"
+
+    def test_missing_show_rating_key_degrades_to_empty(self):
+        ep = _episode(1, "Ep", "Show", 1, 1, added_days_ago=1)
+        api = _api([_section(1, "TV Shows", [ep])])
+        items = api.get_recently_added_media(valid_sections=[1], days_to_monitor=7)
+        assert items[0].show_rating_key == ""

--- a/tests/test_plex_manager_timeout.py
+++ b/tests/test_plex_manager_timeout.py
@@ -1,0 +1,88 @@
+"""`PlexManager` takes an explicit connection timeout.
+
+`PlexServer` was constructed with no timeout, so it inherited plexapi's 30s
+default implicitly. plexapi keeps the constructor value on the session
+(`PlexServer._timeout`, consumed by `query()`), so it governs every subsequent
+request, not just the handshake — which is why the web caller pins 30 rather
+than the shorter values used by connect-and-validate handshakes elsewhere.
+
+Mock-only: a real black-hole-socket timing test costs ~2 minutes of wall clock
+to assert the same contract.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers', 'apscheduler.schedulers.background',
+    'apscheduler.triggers', 'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions', 'requests',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.plex_api import PlexManager
+
+
+class _FakeServer:
+    version = "1.2.3"
+    seen = {}
+
+    def __init__(self, url, token, timeout=None):
+        _FakeServer.seen = {"url": url, "token": token, "timeout": timeout}
+
+
+class TestConnectTimeout:
+    def test_defaults_to_none_so_plexapi_picks_its_own(self, monkeypatch):
+        # The CLI path must stay byte-identical: plexapi does `timeout or TIMEOUT`,
+        # so None yields exactly today's behaviour. Hardcoding 30 in the core
+        # default would instead pin the value if plexapi ever changes TIMEOUT.
+        monkeypatch.setattr("core.plex_api.PlexServer", _FakeServer)
+        PlexManager("http://host:32400", "TOKEN").connect()
+        assert _FakeServer.seen["timeout"] is None
+
+    def test_forwards_an_explicit_timeout(self, monkeypatch):
+        monkeypatch.setattr("core.plex_api.PlexServer", _FakeServer)
+        PlexManager("http://host:32400", "TOKEN", timeout=30).connect()
+        assert _FakeServer.seen["timeout"] == 30
+
+    def test_timeout_is_stored_on_the_manager(self):
+        assert PlexManager("http://h:32400", "T").timeout is None
+        assert PlexManager("http://h:32400", "T", timeout=15).timeout == 15
+
+
+class TestRecentlyAddedUsesTheLongTimeout:
+    """Guards against someone 'tidying' this down to match the 10s handshakes."""
+
+    def test_service_constructs_the_manager_with_30s(self, monkeypatch):
+        import web.services.recently_added_service as ras
+
+        captured = {}
+
+        class _CapturingManager:
+            def __init__(self, url, token, **kwargs):
+                captured.update(kwargs)
+                captured["url"] = url
+
+            def connect(self):
+                return None
+
+        monkeypatch.setattr("core.plex_api.PlexManager", _CapturingManager)
+
+        cfg = MagicMock()
+        cfg.plex.plex_url = "http://host:32400"
+        cfg.plex.plex_token = "TOKEN"
+        cfg.plex.plex_db_path = ""
+
+        ras.RecentlyAddedService()._connect_plex(cfg)
+
+        assert captured["timeout"] == 30, (
+            "Recently Added pulls up to recently_added_max_items per library; "
+            "plexapi applies this timeout to those sweeps, not just the connect."
+        )

--- a/tests/test_protection_vocabulary.py
+++ b/tests/test_protection_vocabulary.py
@@ -1,0 +1,124 @@
+"""Sitewide guard: "protected" means exempt from eviction, and nothing else.
+
+An audit found the word carrying four unrelated meanings across the app —
+eviction exemption (a pin), exclude-list membership (the Unraid mover),
+transient OnDeck/Watchlist residency, and the audit's own "not in the exclude
+list" model. Only the first is a real guarantee: OnDeck adds +15 to the priority
+score, while a pin short-circuits eviction outright.
+
+These tests keep the word from spreading back. They are source-text checks
+because the offenders are template copy and identifier names, which have no
+Python seam.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+TEMPLATES = REPO / "web" / "templates"
+
+# Where the eviction sense is legitimate: a pin genuinely exempts these.
+ALLOWED_PROTECTED_PHRASES = (
+    "protected from eviction",   # the reserved sentence
+    "eviction protection",       # the disclaimer on transient badges
+)
+
+
+def _user_facing_strings(path: Path):
+    """Rendered text and tooltips from a template, ignoring comments/attrs."""
+    src = path.read_text(encoding="utf-8")
+    src = re.sub(r"\{#.*?#\}", "", src, flags=re.S)          # jinja comments
+    src = re.sub(r"<!--.*?-->", "", src, flags=re.S)          # html comments
+    # Jinja expressions render to a value, not to their own source. Leaving them
+    # in flags `{{ protected_sentence }}` — the shared constant this sweep exists
+    # to introduce — as if it were stray copy.
+    src = re.sub(r"\{\{.*?\}\}", "", src, flags=re.S)
+    out = []
+    out += re.findall(r'title="([^"]*)"', src)
+    out += re.findall(r">\s*([^<>{}\n]{4,})\s*<", src)
+    return [s.strip() for s in out if s.strip()]
+
+
+class TestNoStrayProtectionCopy:
+    def test_no_template_uses_protect_outside_the_eviction_sense(self):
+        offenders = []
+        for path in TEMPLATES.rglob("*.html"):
+            for text in _user_facing_strings(path):
+                low = text.lower()
+                if "protect" not in low:
+                    continue
+                if any(p in low for p in ALLOWED_PROTECTED_PHRASES):
+                    continue
+                offenders.append(f"{path.relative_to(REPO)}: {text[:90]}")
+        assert not offenders, (
+            "protection vocabulary outside the eviction sense:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_audit_tool_and_readme_say_tracked(self):
+        for rel in ("tools/audit_cache.py", "README.md"):
+            src = (REPO / rel).read_text(encoding="utf-8")
+            assert "unprotected" not in src.lower(), f"{rel} still says unprotected"
+
+
+class TestIdentifiersMatchTheShippedUi:
+    """The audit table has said "Untracked" in the UI for a while; the model
+    said "unprotected". A pinned file was simultaneously "protected" (badge) and
+    "unprotected" (model), which is how new code kept regenerating the word."""
+
+    def test_no_unprotected_identifiers_remain(self):
+        offenders = []
+        for pat in ("web/**/*.py", "core/**/*.py", "tools/*.py", "web/templates/**/*.html"):
+            for path in REPO.glob(pat):
+                if "__pycache__" in str(path):
+                    continue
+                if "unprotected" in path.read_text(encoding="utf-8").lower():
+                    offenders.append(str(path.relative_to(REPO)))
+        assert not offenders, f"'unprotected' survives in: {offenders}"
+
+    def test_audit_results_exposes_the_renamed_fields(self):
+        from web.services.maintenance_service import AuditResults
+        fields = AuditResults.__dataclass_fields__
+        assert "untracked_files" in fields
+        assert "grouped_untracked" in fields
+        assert "unprotected_files" not in fields
+
+
+class TestMoverExcludedStatCard:
+    """The card labelled "Protected" counted raw exclude lines against a
+    denominator of files actually on cache, so a stale entry could render
+    "3 of 1 on cache". It also named the mover sense with the eviction word."""
+
+    def test_count_is_the_intersection_with_what_is_on_cache(self):
+        from web.services.maintenance_service import AuditResults
+        assert "excluded_on_cache_count" in AuditResults.__dataclass_fields__
+
+    def test_numerator_cannot_exceed_the_denominator(self):
+        from web.services.maintenance_service import MaintenanceService
+        svc = MaintenanceService.__new__(MaintenanceService)
+        cache_files = {"/mnt/cache/a.mkv", "/mnt/cache/b.mkv"}
+        # Three exclude lines, two of them stale (files no longer on cache).
+        exclude_files = {"/mnt/cache/a.mkv", "/mnt/cache/gone1.mkv", "/mnt/cache/gone2.mkv"}
+        assert len(exclude_files) > len(cache_files)          # the old numerator
+        assert len(exclude_files & cache_files) <= len(cache_files)  # the new one
+
+    def test_card_reads_mover_excluded_not_protected(self):
+        src = (TEMPLATES / "maintenance" / "partials" / "audit_results.html").read_text(encoding="utf-8")
+        assert "Mover-excluded" in src
+        assert "excluded_on_cache_count" in src
+
+
+class TestReservedSentenceIsShared:
+    def test_pages_source_it_from_one_constant(self):
+        from web.outcome_vocabulary import PROTECTED_SENTENCE, OUTCOMES
+        # Recently Added
+        assert OUTCOMES["held"].tooltip.startswith(PROTECTED_SENTENCE)
+        # Cached Files renders it through the template global rather than a copy
+        src = (TEMPLATES / "cache" / "partials" / "file_table.html").read_text(encoding="utf-8")
+        assert "{{ protected_sentence }}" in src
+        assert "Pinned — protected from eviction\"" not in src  # the old hand-copy
+
+    def test_the_constant_is_exposed_as_a_template_global(self):
+        src = (REPO / "web" / "config.py").read_text(encoding="utf-8")
+        assert 'templates.env.globals["protected_sentence"]' in src

--- a/tests/test_recently_added_css.py
+++ b/tests/test_recently_added_css.py
@@ -1,0 +1,134 @@
+"""Contrast gate for the Recently Added group-child rows.
+
+Asserting that a design token is *used* is not enough: several tokens satisfy
+that and still leave the row without visible hover feedback. So this resolves
+the declaration the same way a browser does — token lookup per theme, alpha
+compositing over the card surface — and checks the resting/hover delta is
+actually perceptible in both themes.
+
+Pure text + arithmetic, no browser. Follows the CSS-text precedent in
+tests/test_released_ui_state.py.
+"""
+
+import os
+import re
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+THEME_CSS = os.path.join(ROOT, "web/static/css/plex-theme.css")
+CUSTOM_CSS = os.path.join(ROOT, "web/static/css/custom.css")
+
+# Below this the row reads as static to a sighted user at a glance. HEAD's
+# hardcoded rgba scored 1.03 in light theme, which is why this file exists.
+MIN_HOVER_CONTRAST = 1.15
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _tokens(css, block_selector):
+    """Pull the --plex-* hex values out of one selector block."""
+    start = css.index(block_selector)
+    body = css[start:css.index("}", start)]
+    return {
+        name: value
+        for name, value in re.findall(r"(--plex-[\w-]+):\s*(#[0-9a-fA-F]{3,8})\s*;", body)
+    }
+
+
+def _rgb(value):
+    h = value.lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    return tuple(int(h[i:i + 2], 16) for i in (0, 2, 4))
+
+
+def _composite(fg, alpha, bg):
+    return tuple(round(f * alpha + b * (1 - alpha)) for f, b in zip(fg, bg))
+
+
+def _relative_luminance(rgb):
+    def channel(v):
+        v /= 255
+        return v / 12.92 if v <= 0.03928 else ((v + 0.055) / 1.055) ** 2.4
+    r, g, b = (channel(c) for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast(a, b):
+    hi, lo = sorted((_relative_luminance(a), _relative_luminance(b)), reverse=True)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+def _resolve(declaration, tokens, backdrop):
+    """Resolve a background value to RGB, compositing alpha over the backdrop."""
+    declaration = declaration.strip().rstrip(";").strip()
+    var_match = re.fullmatch(r"var\((--plex-[\w-]+)\)", declaration)
+    if var_match:
+        return _rgb(tokens[var_match.group(1)])
+    rgba_match = re.fullmatch(
+        r"rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)", declaration)
+    if rgba_match:
+        r, g, b, a = rgba_match.groups()
+        return _composite((int(r), int(g), int(b)), float(a) if a else 1.0, backdrop)
+    if declaration.startswith("#"):
+        return _rgb(declaration)
+    pytest.fail(f"Cannot resolve background {declaration!r} — extend this helper.")
+
+
+def _group_child_background():
+    css = _read(CUSTOM_CSS)
+    match = re.search(r"\.ra-group-child\s*\{([^}]*)\}", css)
+    assert match, ".ra-group-child rule not found in custom.css"
+    decl = re.search(r"background:\s*([^;]+);", match.group(1))
+    assert decl, ".ra-group-child has no background declaration"
+    return decl.group(1)
+
+
+@pytest.mark.parametrize("theme,selector", [
+    ("dark", ":root {"),
+    ("light", '[data-theme="light"] {'),
+])
+def test_group_child_rows_have_visible_hover_feedback(theme, selector):
+    """The rows are clickable (RecentlyAdded.toggleDetail on the title cell),
+    so the hover state has to be distinguishable from rest."""
+    theme_css = _read(THEME_CSS)
+    tokens = _tokens(theme_css, selector)
+    if theme == "light":
+        # Light overrides only what it changes; the rest inherits from :root.
+        base = _tokens(theme_css, ":root {")
+        tokens = {**base, **tokens}
+
+    card = _rgb(tokens["--plex-bg-card"])
+    resting = _resolve(_group_child_background(), tokens, card)
+    # tbody tr:hover (plex-theme.css) paints an opaque token over the row.
+    hover = _rgb(tokens["--plex-bg-hover"])
+
+    ratio = _contrast(resting, hover)
+    assert ratio >= MIN_HOVER_CONTRAST, (
+        f"{theme} theme: .ra-group-child rests at {resting} and hovers to {hover}, "
+        f"contrast {ratio:.3f} < {MIN_HOVER_CONTRAST}. The row would look static."
+    )
+
+
+def test_group_child_uses_a_theme_token():
+    """A hardcoded rgba cannot follow the theme, which is how the light-theme
+    hover died in the first place (CLAUDE.md design-token rule)."""
+    assert "var(--plex-" in _group_child_background()
+
+
+def test_no_light_theme_companion_outranks_the_hover_rule():
+    """A `[data-theme="light"] .ra-group-child` override scores (0,2,0) and
+    beats `tbody tr:hover` at (0,1,2), which removes hover feedback entirely
+    rather than fixing it. The one-line token swap avoids the trap by keeping
+    the selector at (0,1,0)."""
+    css = _read(CUSTOM_CSS)
+    offenders = re.findall(r'\[data-theme="[^"]+"\]\s+\.ra-group-child\s*\{[^}]*background',
+                           css)
+    assert not offenders, (
+        "A theme-scoped .ra-group-child background outranks tbody tr:hover. "
+        "Change the token on the base rule instead."
+    )

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -302,7 +302,9 @@ class TestWidget:
             r = client.get("/recently-added/widget")
         assert r.status_code == 200
         assert "on cache" in r.text
-        assert "not pinned" in r.text
+        # Third stat is the neutral "on array" count, not a "not pinned" nag.
+        assert "on array" in r.text
+        assert "not pinned" not in r.text
         assert "Dune" in r.text
 
     def test_widget_rows_expand_to_filename_and_size(self, client):

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -186,6 +186,88 @@ class TestPage:
         assert "_state.lib = 'all'" in r.text
 
 
+class TestDegradedEpisodeNumbering:
+    """An episode Plex could not number is still an episode."""
+
+    def _render(self, client, path, row):
+        p_svc, p_set, _ = _patch(_result([row]), settings={})
+        with p_svc, p_set:
+            return client.get(path)
+
+    def test_episode_without_numbering_keeps_its_show_name(self, client):
+        r = self._render(client, "/recently-added/list", _row(
+            rating_key="1", title="Holiday Special", media_type="episode",
+            pin_type="episode",
+            episode_info={"show": "The Show", "season": None, "episode": None}))
+
+        assert "The Show" in r.text
+        assert ">Movie<" not in r.text
+
+    def test_episode_with_no_episode_info_is_not_labelled_movie(self, client):
+        """The terminal arm: an episode row carrying no episode_info at all
+        fell into the movie branch and rendered a "Movie" caption directly
+        under the tv icon the same row had already chosen."""
+        r = self._render(client, "/recently-added/list", _row(
+            rating_key="1", title="Orphan", media_type="episode",
+            pin_type="episode", episode_info=None))
+
+        # Match the sub-label element itself — a bare "Movie" also occurs in
+        # the "Movies" library name elsewhere on the page.
+        assert ">Movie</div>" not in r.text
+        assert ">Episode</div>" in r.text
+
+    def test_missing_numbering_does_not_fabricate_s00e00(self, client):
+        """S00E00 is a real Specials episode 0, so inventing it for an unknown
+        episode makes the two indistinguishable."""
+        r = self._render(client, "/recently-added/list", _row(
+            rating_key="1", title="Holiday Special", media_type="episode",
+            pin_type="episode",
+            episode_info={"show": "The Show", "season": None, "episode": None}))
+
+        assert "S00E00" not in r.text
+        assert "Holiday Special" in r.text
+
+    def test_genuine_specials_episode_still_renders(self, client):
+        r = self._render(client, "/recently-added/list", _row(
+            rating_key="1", title="Xmas", media_type="episode", pin_type="episode",
+            episode_info={"show": "The Show", "season": 0, "episode": 7}))
+
+        assert "S00E07" in r.text
+
+    def test_malformed_index_does_not_raise(self, client):
+        """plexapi casts an unparseable index to float('nan'), and
+        '%02d'|format(nan) raises ValueError — a 500 on the page, not a bad
+        label. The isinstance guard is what prevents it."""
+        nan = float("nan")
+        r = self._render(client, "/recently-added/list", _row(
+            rating_key="1", title="Weird Ep", media_type="episode",
+            pin_type="episode",
+            episode_info={"show": "The Show", "season": nan, "episode": nan}))
+
+        assert r.status_code == 200
+        assert "The Show" in r.text
+
+    def test_widget_survives_the_same_row(self, client):
+        nan = float("nan")
+        r = self._render(client, "/recently-added/widget", _row(
+            rating_key="1", title="Weird Ep", media_type="episode",
+            pin_type="episode",
+            episode_info={"show": "The Show", "season": nan, "episode": nan}))
+
+        assert r.status_code == 200
+        assert "S00E00" not in r.text
+
+    def test_missing_show_name_does_not_leak_none_into_the_search_index(self, client):
+        """`None|lower` renders the literal "none", which would make every such
+        row match a search for "none"."""
+        r = self._render(client, "/recently-added/list", _row(
+            rating_key="1", title="Orphan Ep", media_type="episode",
+            pin_type="episode",
+            episode_info={"show": None, "season": 1, "episode": 2}))
+
+        assert 'data-title="orphan ep none' not in r.text
+
+
 class TestUnreadableLibraryStrip:
     """The page must not report an unread library as an empty one."""
 

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -1,0 +1,226 @@
+"""Route tests for the Recently Added view (issue #174).
+
+Mounts only the recently_added router on a minimal FastAPI app and patches the
+service + settings accessors, so these exercise the real Jinja2 templates
+without a live Plex server.
+
+Test isolation: earlier tests sometimes replace ``web.config`` (and friends) in
+``sys.modules`` with a MagicMock. Force-reload affected modules so route tests
+run against the real templates instance.
+"""
+
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _force_real_modules():
+    mocked_names = [
+        "web.config",
+        "web.routers",
+        "web.routers.recently_added",
+        "web.services",
+        "web.services.recently_added_service",
+        "web",
+    ]
+    for name in mocked_names:
+        mod = sys.modules.get(name)
+        if isinstance(mod, MagicMock):
+            del sys.modules[name]
+    import web  # noqa: F401
+    import web.config  # noqa: F401
+    import web.routers.recently_added  # noqa: F401
+    import web.services.recently_added_service  # noqa: F401
+
+
+_force_real_modules()
+
+from web.services.recently_added_service import RecentlyAddedRow
+
+
+def _row(rating_key="1", title="Dune", media_type="movie", library_title="Movies",
+         size=28_000_000_000, size_display="28.00 GB", location="cache",
+         state="on_cache_not_pinned", is_pinned=False, protected_by=None,
+         pin_type="movie", episode_info=None):
+    return RecentlyAddedRow(
+        rating_key=rating_key,
+        title=title,
+        media_type=media_type,
+        library_title=library_title,
+        file_path=f"/data/movies/{title}.mkv",
+        size=size,
+        size_display=size_display,
+        added_at=datetime.now(),
+        added_display="2 hr ago",
+        location=location,
+        state=state,
+        is_pinned=is_pinned,
+        is_ondeck="OnDeck" in (protected_by or []),
+        is_watchlist="Watchlist" in (protected_by or []),
+        is_cache_tracked=False,
+        protected_by=protected_by or [],
+        pin_type=pin_type,
+        episode_info=episode_info,
+    )
+
+
+def _summary(rows):
+    on_cache = sum(1 for r in rows if r.location == "cache")
+    return {
+        "total": len(rows),
+        "on_cache": on_cache,
+        "on_cache_not_pinned": sum(1 for r in rows if r.state == "on_cache_not_pinned"),
+        "on_array": sum(1 for r in rows if r.location == "array"),
+        "total_size": sum(r.size for r in rows),
+        "total_size_display": "28.00 GB",
+    }
+
+
+def _result(rows, available=True, error=None):
+    return {
+        "available": available,
+        "rows": rows,
+        "summary": _summary(rows),
+        "error": error,
+    }
+
+
+@pytest.fixture
+def client():
+    from web.routers import recently_added as ra_router
+
+    app = FastAPI()
+    app.include_router(ra_router.router, prefix="/recently-added")
+    return TestClient(app)
+
+
+def _patch(service_result, settings=None):
+    """Patch the router's service + settings accessors."""
+    fake_service = MagicMock()
+    fake_service.get_recently_added.return_value = service_result
+    fake_settings = MagicMock()
+    fake_settings.get_all.return_value = settings or {}
+    return (
+        patch("web.routers.recently_added.get_recently_added_service", return_value=fake_service),
+        patch("web.routers.recently_added.get_settings_service", return_value=fake_settings),
+        fake_service,
+    )
+
+
+class TestPage:
+    def test_page_renders_shell(self, client):
+        p_svc, p_set, _ = _patch(_result([]), settings={})
+        with p_svc, p_set:
+            r = client.get("/recently-added/")
+        assert r.status_code == 200
+        assert "Recently Added" in r.text
+        # Lazy-loads the list partial with the default window.
+        assert "/recently-added/list?days=7" in r.text
+
+    def test_page_uses_settings_default_window(self, client):
+        p_svc, p_set, _ = _patch(_result([]), settings={"recently_added_days": 30})
+        with p_svc, p_set:
+            r = client.get("/recently-added/")
+        assert r.status_code == 200
+        assert "/recently-added/list?days=30" in r.text
+
+
+class TestList:
+    def test_renders_states_and_pin_button(self, client):
+        rows = [
+            _row(rating_key="1", title="Dune", state="on_cache_not_pinned", location="cache"),
+            _row(rating_key="2", title="Civil War", state="on_array", location="array",
+                 size_display="62.00 GB"),
+            _row(rating_key="3", title="Wild Robot", state="pinned", location="cache", is_pinned=True),
+            _row(rating_key="4", title="Furiosa", state="protected", location="cache",
+                 protected_by=["OnDeck"]),
+        ]
+        p_svc, p_set, _ = _patch(_result(rows))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list", headers={"HX-Request": "true"})
+
+        assert r.status_code == 200
+        # State badges
+        assert "Not pinned" in r.text          # on_cache_not_pinned
+        assert "Not cached" in r.text          # on_array
+        assert "Pinned" in r.text              # pinned
+        assert "Protected" in r.text and "OnDeck" in r.text
+        # Pin button (macro) wires to the existing toggle endpoint
+        assert "/api/pinned/toggle" in r.text
+        # Array row shows byte-cost note
+        assert "copies ~62.00 GB to cache" in r.text
+
+    def test_clamps_invalid_days_to_default(self, client):
+        p_svc, p_set, fake_service = _patch(_result([]))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list?days=999")
+        assert r.status_code == 200
+        # 999 is not an allowed window → clamps to 7
+        fake_service.get_recently_added.assert_called_once()
+        assert fake_service.get_recently_added.call_args.kwargs["days"] == 7
+
+    def test_respects_allowed_days(self, client):
+        p_svc, p_set, fake_service = _patch(_result([]))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list?days=30")
+        assert r.status_code == 200
+        assert fake_service.get_recently_added.call_args.kwargs["days"] == 30
+        assert "selected" in r.text and "Last 30 days" in r.text
+
+    def test_no_days_uses_settings_default(self, client):
+        p_svc, p_set, fake_service = _patch(_result([]), settings={"recently_added_days": 1})
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert fake_service.get_recently_added.call_args.kwargs["days"] == 1
+
+    def test_unavailable_state(self, client):
+        p_svc, p_set, _ = _patch(_result([], available=False, error="Plex not configured."))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert r.status_code == 200
+        assert "unavailable" in r.text.lower()
+        assert "Plex not configured." in r.text
+
+    def test_empty_window_message(self, client):
+        p_svc, p_set, _ = _patch(_result([]))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list?days=7")
+        assert r.status_code == 200
+        assert "Nothing added in the last 7 days" in r.text
+
+    def test_episode_row_shows_show_and_code(self, client):
+        rows = [_row(rating_key="9", title="Future Days", media_type="episode",
+                     library_title="TV Shows", state="on_cache_not_pinned", location="cache",
+                     pin_type="episode",
+                     episode_info={"show": "The Last of Us", "season": 2, "episode": 1})]
+        p_svc, p_set, _ = _patch(_result(rows))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert "The Last of Us" in r.text
+        assert "S02E01" in r.text
+
+
+class TestWidget:
+    def test_widget_renders_counts(self, client):
+        rows = [
+            _row(rating_key="1", title="Dune", location="cache", state="on_cache_not_pinned"),
+            _row(rating_key="2", title="Civil War", location="array", state="on_array"),
+        ]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_days": 7})
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert r.status_code == 200
+        assert "on cache" in r.text
+        assert "not pinned" in r.text
+        assert "Dune" in r.text
+
+    def test_widget_unavailable(self, client):
+        p_svc, p_set, _ = _patch(_result([], available=False, error="No Plex."))
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert r.status_code == 200
+        assert "No Plex." in r.text

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -168,8 +168,52 @@ class TestPage:
         assert "function restore()" in r.text
         assert "_state.expanded" in r.text
 
+    def test_page_recovers_when_the_selected_library_leaves_the_window(self, client):
+        """Restoring a library that is no longer in the options leaves the
+        select at selectedIndex -1 / value "", which matches no row — every
+        row hides behind "No items match" under a blank dropdown.
+
+        Source-text assertion: there is no JS runtime in this suite, so this
+        pins the guard's presence, not its behaviour. It would also pass on a
+        commented-out guard. The behavioural half it depends on — that the
+        option set really does vary with the rows — is pinned by
+        TestList::test_library_options_follow_the_returned_rows below.
+        """
+        p_svc, p_set, _ = _patch(_result([]), settings={})
+        with p_svc, p_set:
+            r = client.get("/recently-added/")
+        assert "lib.selectedIndex === -1" in r.text
+        assert "_state.lib = 'all'" in r.text
+
 
 class TestList:
+    def test_library_options_follow_the_returned_rows(self, client):
+        """The Library filter is built per response from the rows it returned,
+        so a narrower window can drop a library the user had selected. This is
+        the server-side fact the selectedIndex -1 guard in restore() exists to
+        absorb; without it the guard would look like dead code."""
+        import re
+
+        def options(rows):
+            p_svc, p_set, _ = _patch(_result(rows), settings={})
+            with p_svc, p_set:
+                r = client.get("/recently-added/list")
+            block = re.search(r'<select[^>]*id="ra-lib-filter".*?</select>', r.text, re.S)
+            assert block, "Library filter select not rendered"
+            return set(re.findall(r'value="([^"]*)"', block.group(0)))
+
+        wide = options([
+            _row(rating_key="1", title="Dune", library_title="Movies"),
+            _row(rating_key="2", title="Nova", library_title="Documentaries"),
+        ])
+        narrow = options([_row(rating_key="1", title="Dune", library_title="Movies")])
+
+        assert "Documentaries" in wide
+        assert "Documentaries" not in narrow, (
+            "Library options no longer vary with the row set — re-check whether "
+            "restore()'s selectedIndex guard is still needed."
+        )
+
     def test_renders_states_and_pin_button(self, client):
         rows = [
             _row(rating_key="1", title="Dune", state="on_cache_not_pinned", location="cache"),

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -270,7 +270,7 @@ class TestExpandDetail:
         # +N hint badge + the associated file appears in a detail sub-row
         assert "+1" in r.text
         assert "Dune.en.srt" in r.text
-        assert "associated-sub-file" in r.text
+        assert "ra-detail-row" in r.text
 
 
 class TestWidget:

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -186,6 +186,46 @@ class TestPage:
         assert "_state.lib = 'all'" in r.text
 
 
+class TestUnreadableLibraryStrip:
+    """The page must not report an unread library as an empty one."""
+
+    def _get(self, client, path, rows, unreadable):
+        result = _result(rows)
+        result["unreadable_libraries"] = unreadable
+        p_svc, p_set, _ = _patch(result, settings={})
+        with p_svc, p_set:
+            return client.get(path)
+
+    def test_strip_names_the_libraries(self, client):
+        r = self._get(client, "/recently-added/list",
+                      [_row(rating_key="1", title="Dune")], ["Documentaries"])
+        assert "Couldn&#39;t read 1 library" in r.text or "Couldn't read 1 library" in r.text
+        assert "Documentaries" in r.text
+
+    def test_empty_state_does_not_claim_nothing_was_added(self, client):
+        """With a library unread, "Nothing added in the last 7 days" would be a
+        statement about media the app never looked at."""
+        r = self._get(client, "/recently-added/list", [], ["Movies"])
+        assert "Nothing added in the last" not in r.text
+        assert "No results from the libraries that answered." in r.text
+
+    def test_empty_state_is_unchanged_on_a_clean_sweep(self, client):
+        r = self._get(client, "/recently-added/list", [], [])
+        assert "Nothing added in the last" in r.text
+
+    def test_no_strip_when_every_library_answered(self, client):
+        r = self._get(client, "/recently-added/list",
+                      [_row(rating_key="1", title="Dune")], [])
+        assert "counts are incomplete" not in r.text
+        assert "read 1 librar" not in r.text
+
+    def test_widget_says_its_counts_are_incomplete(self, client):
+        r = self._get(client, "/recently-added/widget",
+                      [_row(rating_key="1", title="Dune")], ["Documentaries"])
+        assert "counts are incomplete" in r.text
+        assert "Documentaries" in r.text
+
+
 class TestList:
     def test_library_options_follow_the_returned_rows(self, client):
         """The Library filter is built per response from the rows it returned,

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -202,6 +202,24 @@ class TestList:
         assert r.status_code == 200
         assert "Nothing added in the last 7 days" in r.text
 
+    def test_truncation_note_when_capped(self, client):
+        # rows count reaches max_items → footer surfaces the "showing newest N" note.
+        rows = [_row(rating_key=str(i), title=f"M{i}") for i in range(3)]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_max_items": 3})
+        with p_svc, p_set:
+            r = client.get("/recently-added/list?days=7")
+        assert r.status_code == 200
+        assert "most recently added files" in r.text
+        assert "Max Items" in r.text
+
+    def test_no_truncation_note_under_cap(self, client):
+        rows = [_row(rating_key=str(i), title=f"M{i}") for i in range(3)]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_max_items": 250})
+        with p_svc, p_set:
+            r = client.get("/recently-added/list?days=7")
+        assert r.status_code == 200
+        assert "most recently added files" not in r.text
+
     def test_episode_row_shows_show_and_code(self, client):
         rows = [_row(rating_key="9", title="Future Days", media_type="episode",
                      library_title="TV Shows", state="on_cache_not_pinned", location="cache",

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -39,13 +39,13 @@ def _force_real_modules():
 
 _force_real_modules()
 
-from web.services.recently_added_service import RecentlyAddedRow
+from web.services.recently_added_service import RecentlyAddedRow, RecentlyAddedService
 
 
 def _row(rating_key="1", title="Dune", media_type="movie", library_title="Movies",
          size=28_000_000_000, size_display="28.00 GB", location="cache",
          state="on_cache_not_pinned", is_pinned=False, protected_by=None,
-         pin_type="movie", episode_info=None):
+         pin_type="movie", episode_info=None, associated_files=None):
     return RecentlyAddedRow(
         rating_key=rating_key,
         title=title,
@@ -65,7 +65,14 @@ def _row(rating_key="1", title="Dune", media_type="movie", library_title="Movies
         protected_by=protected_by or [],
         pin_type=pin_type,
         episode_info=episode_info,
+        associated_files=associated_files or [],
     )
+
+
+def _episode(rating_key, show, season, episode, title="Ep", **kw):
+    return _row(rating_key=rating_key, title=title, media_type="episode",
+                library_title="TV Shows", pin_type="episode",
+                episode_info={"show": show, "season": season, "episode": episode}, **kw)
 
 
 def _summary(rows):
@@ -102,6 +109,8 @@ def _patch(service_result, settings=None):
     """Patch the router's service + settings accessors."""
     fake_service = MagicMock()
     fake_service.get_recently_added.return_value = service_result
+    # Use the real grouping transform so the template renders real rows/groups.
+    fake_service.group_rows_for_display.side_effect = RecentlyAddedService.group_rows_for_display
     fake_settings = MagicMock()
     fake_settings.get_all.return_value = settings or {}
     return (
@@ -202,6 +211,49 @@ class TestList:
             r = client.get("/recently-added/list")
         assert "The Last of Us" in r.text
         assert "S02E01" in r.text
+
+
+class TestGrouping:
+    def test_multi_episode_show_renders_expandable_group(self, client):
+        rows = [
+            _episode("1", "The Last of Us", 2, 1, title="Future Days"),
+            _episode("2", "The Last of Us", 2, 2, title="Through the Valley"),
+            _episode("3", "The Last of Us", 2, 3, title="The Path"),
+        ]
+        p_svc, p_set, _ = _patch(_result(rows))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert r.status_code == 200
+        # One group header for the show + child rows
+        assert 'class="ra-group-header"' in r.text
+        assert "3 new episodes" in r.text
+        assert 'data-group-id="rag0"' in r.text
+        assert r.text.count('ra-group-child') >= 3
+        # Episode codes appear in child rows
+        assert "S02E01" in r.text and "S02E03" in r.text
+        # Per-episode pin actions present
+        assert "/api/pinned/toggle" in r.text
+
+    def test_single_episode_not_grouped(self, client):
+        rows = [_episode("9", "Severance", 1, 1, title="Solo")]
+        p_svc, p_set, _ = _patch(_result(rows))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert 'class="ra-group-header"' not in r.text
+        assert "Severance" in r.text
+
+
+class TestAssociatedFiles:
+    def test_associated_files_badge_and_popup(self, client):
+        rows = [_row(rating_key="1", title="Dune",
+                     associated_files=[{"filename": "Dune.en.srt", "size": "84 KB"}])]
+        p_svc, p_set, _ = _patch(_result(rows))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert r.status_code == 200
+        assert "associated-files-badge" in r.text
+        assert "+1" in r.text
+        assert "Dune.en.srt" in r.text
 
 
 class TestWidget:

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -46,7 +46,19 @@ from web.services.recently_added_service import RecentlyAddedRow, RecentlyAddedS
 def _row(rating_key="1", title="Dune", media_type="movie", library_title="Movies",
          size=28_000_000_000, size_display="28.00 GB", location="cache",
          state="on_cache_not_pinned", is_pinned=False, protected_by=None,
-         pin_type="movie", episode_info=None, associated_files=None, filename=None):
+         pin_type="movie", episode_info=None, associated_files=None, filename=None,
+         outcome=None, added_display="2 hr ago", pin_scope="", pin_holder_key="",
+         pin_holder_title=""):
+    # Rows are normally built by _enrich, which derives `outcome`. These are
+    # constructed directly, so map the legacy `state` onto a sensible outcome
+    # unless the test names one explicitly.
+    if outcome is None:
+        outcome = {
+            "pinned": "held",
+            "protected": "returns_when_done",
+            "on_cache_not_pinned": "moves_back",
+            "on_array": "stays_on_array",
+        }.get(state, "unmapped")
     return RecentlyAddedRow(
         rating_key=rating_key,
         title=title,
@@ -56,9 +68,13 @@ def _row(rating_key="1", title="Dune", media_type="movie", library_title="Movies
         size=size,
         size_display=size_display,
         added_at=datetime.now(),
-        added_display="2 hr ago",
+        added_display=added_display,
         location=location,
         state=state,
+        outcome=outcome,
+        pin_scope=pin_scope,
+        pin_holder_key=pin_holder_key,
+        pin_holder_title=pin_holder_title,
         is_pinned=is_pinned,
         is_ondeck="OnDeck" in (protected_by or []),
         is_watchlist="Watchlist" in (protected_by or []),
@@ -155,11 +171,14 @@ class TestList:
             r = client.get("/recently-added/list", headers={"HX-Request": "true"})
 
         assert r.status_code == 200
-        # State badges
-        assert "Not pinned" in r.text          # on_cache_not_pinned
-        assert "Not cached" in r.text          # on_array
-        assert "Pinned" in r.text              # pinned
-        assert "Protected" in r.text and "OnDeck" in r.text
+        # Outcome badges — named by what happens next, not by a state noun.
+        assert "Moves to array" in r.text          # on cache, no longer held
+        assert "Not on cache" in r.text            # on array
+        assert "Stays on cache" in r.text          # pinned
+        assert "Returns when watched" in r.text and "OnDeck" in r.text
+        # "Protected" survives only as the reserved tooltip sentence on pinned
+        # states — never as a badge for transient OnDeck/Watchlist membership.
+        assert "Pinned — protected from eviction." in r.text
         # Pin button (macro) wires to the existing toggle endpoint
         assert "/api/pinned/toggle" in r.text
         # Array row shows byte-cost note

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -139,21 +139,34 @@ def _patch(service_result, settings=None):
 
 
 class TestPage:
-    def test_page_renders_shell(self, client):
+    def test_page_lazy_loads_the_list(self, client):
         p_svc, p_set, _ = _patch(_result([]), settings={})
         with p_svc, p_set:
             r = client.get("/recently-added/")
         assert r.status_code == 200
         assert "Recently Added" in r.text
-        # Lazy-loads the list partial with the default window.
-        assert "/recently-added/list?days=7" in r.text
+        # The window is no longer pinned into the URL: #ra-content includes
+        # #ra-days-input instead, so a pin/unpin refetch re-sends whatever the
+        # user currently has selected rather than the page-load default. On the
+        # initial load that input isn't in the DOM yet, so no days param is sent
+        # and the router falls back to the persisted setting.
+        assert 'hx-get="/recently-added/list"' in r.text
+        assert 'hx-include="#ra-days-input"' in r.text
 
-    def test_page_uses_settings_default_window(self, client):
-        p_svc, p_set, _ = _patch(_result([]), settings={"recently_added_days": 30})
+    def test_page_refetches_the_list_on_pin_change(self, client):
+        """Pin/unpin must not leave the row's outcome badge asserting the old state."""
+        p_svc, p_set, _ = _patch(_result([]), settings={})
         with p_svc, p_set:
             r = client.get("/recently-added/")
-        assert r.status_code == 200
-        assert "/recently-added/list?days=30" in r.text
+        assert "pinned-updated from:body" in r.text
+
+    def test_page_preserves_the_users_view_across_a_swap(self, client):
+        """A refetch that reset the filters would trade one wrong state for another."""
+        p_svc, p_set, _ = _patch(_result([]), settings={})
+        with p_svc, p_set:
+            r = client.get("/recently-added/")
+        assert "function restore()" in r.text
+        assert "_state.expanded" in r.text
 
 
 class TestList:
@@ -214,6 +227,31 @@ class TestList:
         assert r.status_code == 200
         assert "unavailable" in r.text.lower()
         assert "Plex not configured." in r.text
+
+    def test_error_state_days_input_is_named_so_refresh_keeps_the_window(self, client):
+        """Refresh after a Plex outage must re-request the user's window.
+
+        The error branch keeps a hidden days input so `hx-include` has something
+        to send, but it had no `name` — and htmx's shouldInclude skips any
+        element with an empty name, so Refresh silently fell back to the
+        default window instead of the 30-day view the user was on.
+        """
+        p_svc, p_set, fake_service = _patch(
+            _result([], available=False, error="Plex not configured."),
+            settings={"recently_added_days": 7},
+        )
+        with p_svc, p_set:
+            r = client.get("/recently-added/list?days=30")
+            # The input carries a name, in either attribute order.
+            assert (re.search(r'<input[^>]*id="ra-days-input"[^>]*name="days"', r.text)
+                    or re.search(r'<input[^>]*name="days"[^>]*id="ra-days-input"', r.text)), \
+                "error-state days input has no name; hx-include will send nothing"
+            assert 'value="30"' in r.text
+
+            # Round trip: what Refresh would send actually reaches the service.
+            fake_service.get_recently_added.reset_mock()
+            client.get("/recently-added/list?days=30")
+        assert fake_service.get_recently_added.call_args.kwargs["days"] == 30
 
     def test_empty_window_message(self, client):
         p_svc, p_set, _ = _patch(_result([]))

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -186,6 +186,94 @@ class TestPage:
         assert "_state.lib = 'all'" in r.text
 
 
+class TestRowIdentity:
+    """Leaf rows need a stable identity for _state.details to key on."""
+
+    def _rows_html(self, client, rows):
+        p_svc, p_set, _ = _patch(_result(rows), settings={})
+        with p_svc, p_set:
+            return client.get("/recently-added/list").text
+
+    def _row_ids(self, html):
+        # Only leaf rows carry data-row-id, so no need to anchor on the <tr>
+        # and depend on the template's line wrapping.
+        import re
+        return re.findall(r'data-row-id="([^"]*)"', html)
+
+    def test_every_leaf_row_carries_a_row_id(self, client):
+        html = self._rows_html(client, [
+            _row(rating_key="1", title="Dune"),
+            _row(rating_key="2", title="Civil War"),
+        ])
+        ids = self._row_ids(html)
+        assert len(ids) == 2
+        assert all(i for i in ids), f"blank data-row-id in {ids}"
+
+    def test_row_ids_are_unique(self, client):
+        """A collision would make one row's detail expansion re-open another's."""
+        html = self._rows_html(client, [
+            _row(rating_key="1", title="Dune"),
+            _row(rating_key="2", title="Dune"),  # same title, different item
+        ])
+        ids = self._row_ids(html)
+        assert len(ids) == len(set(ids)) == 2
+
+    def test_row_without_a_rating_key_falls_back_to_its_filename(self, client):
+        """Plex does not always give a rating_key — the pin button is already
+        guarded for it — so identity cannot depend on one being present."""
+        html = self._rows_html(client, [
+            _row(rating_key="", title="Orphan", filename="Orphan.mkv"),
+        ])
+        assert self._row_ids(html) == ["Orphan.mkv"]
+
+    def test_group_children_carry_row_ids_too(self, client):
+        """Children are swapped and restored like any other leaf row."""
+        html = self._rows_html(client, [
+            _row(rating_key="1", title="Ep One", media_type="episode",
+                 library_title="TV", pin_type="episode",
+                 episode_info={"show": "The Show", "season": 1, "episode": 1}),
+            _row(rating_key="2", title="Ep Two", media_type="episode",
+                 library_title="TV", pin_type="episode",
+                 episode_info={"show": "The Show", "season": 1, "episode": 2}),
+        ])
+        ids = self._row_ids(html)
+        assert sorted(ids) == ["1", "2"]
+
+
+class TestDetailExpansionSurvivesASwap:
+    """Source-text assertions: this suite has no JS runtime, so these pin the
+    wiring's presence rather than its behaviour — they would also pass on a
+    commented-out implementation.
+
+    Two things carry the behavioural weight instead. TestRowIdentity above
+    pins the server-side fact the JS depends on (every leaf row has a unique,
+    stable data-row-id). And the round trip itself — expand, swap #ra-content,
+    restore, assert the same row re-opens and no other — was driven against
+    the real DOM in jsdom before this landed, including the negative case:
+    without data-row-id and the details map, restore leaves 0 of 3 sub-rows
+    open. That driver is not in the suite because it would add a Node
+    dependency to CI for one page's JS."""
+
+    def _page(self, client):
+        p_svc, p_set, _ = _patch(_result([]), settings={})
+        with p_svc, p_set:
+            return client.get("/recently-added/").text
+
+    def test_detail_state_is_tracked(self, client):
+        html = self._page(client)
+        assert "details: {}" in html
+        assert "_state.details[id] = true" in html
+
+    def test_detail_state_is_restored_after_a_swap(self, client):
+        html = self._page(client)
+        assert "_state.details[r.getAttribute('data-row-id')]" in html
+
+    def test_filtering_a_row_out_forgets_its_detail_state(self, client):
+        """Otherwise clearing a filter would re-open rows on its own."""
+        html = self._page(client)
+        assert "delete _state.details[id]" in html
+
+
 class TestDegradedEpisodeNumbering:
     """An episode Plex could not number is still an episode."""
 

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -9,6 +9,7 @@ Test isolation: earlier tests sometimes replace ``web.config`` (and friends) in
 run against the real templates instance.
 """
 
+import re
 import sys
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -246,7 +247,10 @@ class TestGrouping:
         # One group header for the show + child rows
         assert 'class="ra-group-header"' in r.text
         assert "3 new episodes" in r.text
-        assert 'data-group-id="rag0"' in r.text
+        # Header id and child rows agree (id format is opaque — minted by
+        # core.media_grouping, not positional).
+        gid = re.search(r'data-group-id="([^"]+)"', r.text).group(1)
+        assert f'data-group="{gid}"' in r.text
         assert r.text.count('ra-group-child') >= 3
         # Episode codes appear in child rows
         assert "S02E01" in r.text and "S02E03" in r.text
@@ -260,6 +264,19 @@ class TestGrouping:
             r = client.get("/recently-added/list")
         assert 'class="ra-group-header"' not in r.text
         assert "Severance" in r.text
+
+    def test_group_header_spanning_seasons_shows_range(self, client):
+        rows = [
+            _episode("1", "Sugar (2024)", 2, 3),
+            _episode("2", "Sugar (2024)", 1, 5),
+            _episode("3", "Sugar (2024)", 1, 7),
+        ]
+        p_svc, p_set, _ = _patch(_result(rows))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert 'class="ra-group-header"' in r.text
+        assert "Seasons 1–2" in r.text
+        assert "3 new episodes" in r.text
 
 
 class TestExpandDetail:
@@ -319,6 +336,49 @@ class TestWidget:
         assert "ra-w-detail" in r.text
         assert "Dune.2021.2160p.mkv" in r.text
         assert "28.00 GB" in r.text
+
+    def test_widget_groups_multi_episode_show(self, client):
+        # The dashboard card must group like the full page — six episodes of one
+        # show are one line, not six.
+        rows = [_episode(str(i), "Sugar (2024)", 1, i) for i in range(1, 7)]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_days": 7})
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert r.status_code == 200
+        assert r.text.count('class="ra-w-row"') == 1
+        assert "6 eps" in r.text
+        assert "Season 1" in r.text
+
+    def test_widget_grouping_frees_slots_for_other_titles(self, client):
+        # Before grouping, a burst of episodes filled all five widget slots and
+        # pushed newer movies off the card entirely.
+        rows = [_episode(str(i), "Sugar (2024)", 1, i) for i in range(1, 7)]
+        rows += [_row(rating_key="m1", title="Dune"), _row(rating_key="m2", title="Civil War")]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_days": 7})
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert r.status_code == 200
+        assert r.text.count('class="ra-w-row"') == 3
+        assert "Dune" in r.text and "Civil War" in r.text
+
+    def test_widget_group_expands_to_episode_files(self, client):
+        rows = [
+            _episode("1", "Sugar (2024)", 1, 1, filename="Sugar (2024) - S01E01.mkv"),
+            _episode("2", "Sugar (2024)", 1, 2, filename="Sugar (2024) - S01E02.mkv"),
+        ]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_days": 7})
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert "raWidgetToggle(this)" in r.text
+        assert "Sugar (2024) - S01E01.mkv" in r.text
+        assert "Sugar (2024) - S01E02.mkv" in r.text
+
+    def test_widget_caps_display_rows(self, client):
+        rows = [_row(rating_key=str(i), title=f"Movie {i}") for i in range(10)]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_days": 7})
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert r.text.count('class="ra-w-row"') == 5
 
     def test_widget_unavailable(self, client):
         p_svc, p_set, _ = _patch(_result([], available=False, error="No Plex."))

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -287,6 +287,19 @@ class TestWidget:
         assert "not pinned" in r.text
         assert "Dune" in r.text
 
+    def test_widget_rows_expand_to_filename_and_size(self, client):
+        rows = [_row(rating_key="1", title="Dune",
+                     filename="Dune.2021.2160p.mkv", size_display="28.00 GB")]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_days": 7})
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert r.status_code == 200
+        # Self-contained expand (the page-level RecentlyAdded JS isn't on the dashboard)
+        assert "raWidgetToggle(this)" in r.text
+        assert "ra-w-detail" in r.text
+        assert "Dune.2021.2160p.mkv" in r.text
+        assert "28.00 GB" in r.text
+
     def test_widget_unavailable(self, client):
         p_svc, p_set, _ = _patch(_result([], available=False, error="No Plex."))
         with p_svc, p_set:

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -45,7 +45,7 @@ from web.services.recently_added_service import RecentlyAddedRow, RecentlyAddedS
 def _row(rating_key="1", title="Dune", media_type="movie", library_title="Movies",
          size=28_000_000_000, size_display="28.00 GB", location="cache",
          state="on_cache_not_pinned", is_pinned=False, protected_by=None,
-         pin_type="movie", episode_info=None, associated_files=None):
+         pin_type="movie", episode_info=None, associated_files=None, filename=None):
     return RecentlyAddedRow(
         rating_key=rating_key,
         title=title,
@@ -66,6 +66,7 @@ def _row(rating_key="1", title="Dune", media_type="movie", library_title="Movies
         pin_type=pin_type,
         episode_info=episode_info,
         associated_files=associated_files or [],
+        filename=filename if filename is not None else f"{title}.mkv",
     )
 
 
@@ -243,17 +244,33 @@ class TestGrouping:
         assert "Severance" in r.text
 
 
-class TestAssociatedFiles:
-    def test_associated_files_badge_and_popup(self, client):
+class TestExpandDetail:
+    def test_row_is_expandable_with_filename_and_size(self, client):
         rows = [_row(rating_key="1", title="Dune",
+                     filename="Dune.2021.2160p.mkv", size_display="28.00 GB")]
+        p_svc, p_set, _ = _patch(_result(rows))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert r.status_code == 200
+        # Title cell is click-to-expand with a chevron
+        assert "RecentlyAdded.toggleDetail(this)" in r.text
+        assert "ra-detail-chevron" in r.text
+        # Detail sub-row carries the primary filename + size
+        assert "ra-detail-row" in r.text
+        assert "Dune.2021.2160p.mkv" in r.text
+        assert "28.00 GB" in r.text
+
+    def test_associated_files_listed_in_detail(self, client):
+        rows = [_row(rating_key="1", title="Dune", filename="Dune.mkv",
                      associated_files=[{"filename": "Dune.en.srt", "size": "84 KB"}])]
         p_svc, p_set, _ = _patch(_result(rows))
         with p_svc, p_set:
             r = client.get("/recently-added/list")
         assert r.status_code == 200
-        assert "associated-files-badge" in r.text
+        # +N hint badge + the associated file appears in a detail sub-row
         assert "+1" in r.text
         assert "Dune.en.srt" in r.text
+        assert "associated-sub-file" in r.text
 
 
 class TestWidget:

--- a/tests/test_recently_added_route.py
+++ b/tests/test_recently_added_route.py
@@ -405,3 +405,32 @@ class TestWidget:
             r = client.get("/recently-added/widget")
         assert r.status_code == 200
         assert "No Plex." in r.text
+
+
+class TestMissingAddedAt:
+    """`added_display` is Optional. The full page guarded it with `or '—'`; the
+    widget did not, so a row with no Plex `addedAt` rendered the literal string
+    "None" in the Added column."""
+
+    def test_widget_row_renders_a_dash_not_none(self, client):
+        rows = [_row(rating_key="1", title="Dune", added_display=None)]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_days": 7})
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert r.status_code == 200
+        assert ">None<" not in r.text
+
+    def test_widget_group_renders_a_dash_not_none(self, client):
+        rows = [_episode(str(i), "Sugar (2024)", 1, i, added_display=None) for i in (1, 2)]
+        p_svc, p_set, _ = _patch(_result(rows), settings={"recently_added_days": 7})
+        with p_svc, p_set:
+            r = client.get("/recently-added/widget")
+        assert r.status_code == 200
+        assert ">None<" not in r.text
+
+    def test_full_page_still_guards_it(self, client):
+        rows = [_row(rating_key="1", title="Dune", added_display=None)]
+        p_svc, p_set, _ = _patch(_result(rows))
+        with p_svc, p_set:
+            r = client.get("/recently-added/list")
+        assert ">None<" not in r.text

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -25,7 +25,7 @@ for _mod in [
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from core.plex_api import RecentlyAddedItem
-from web.services.recently_added_service import RecentlyAddedService
+from web.services.recently_added_service import RecentlyAddedService, RecentlyAddedRow
 
 
 class FakePathModifier:
@@ -136,6 +136,119 @@ class TestEnrichState:
         rows = _enrich(svc, [_item(size=28_000_000_000)])
         assert rows[0].size_display.endswith("GB")
         assert rows[0].added_display  # non-empty relative age
+
+
+def _make_row(rating_key="1", title="X", media_type="movie", library_title="Movies",
+              size=1000, location="cache", state="on_cache_not_pinned",
+              is_pinned=False, episode_info=None):
+    return RecentlyAddedRow(
+        rating_key=rating_key, title=title, media_type=media_type,
+        library_title=library_title, file_path=f"/data/{title}.mkv",
+        size=size, size_display="1.00 KB", added_at=datetime.now(),
+        added_display="now", location=location, state=state, is_pinned=is_pinned,
+        pin_type="episode" if media_type == "episode" else "movie",
+        episode_info=episode_info,
+    )
+
+
+class TestGroupRowsForDisplay:
+    def test_multi_episode_show_collapses_to_one_group(self):
+        rows = [
+            _make_row("1", "Ep One", "episode", "TV Shows", 100,
+                      episode_info={"show": "The Last of Us", "season": 2, "episode": 1}),
+            _make_row("2", "Ep Two", "episode", "TV Shows", 200,
+                      episode_info={"show": "The Last of Us", "season": 2, "episode": 2}),
+            _make_row("3", "Ep Three", "episode", "TV Shows", 300, location="array",
+                      state="on_array",
+                      episode_info={"show": "The Last of Us", "season": 2, "episode": 3}),
+        ]
+        display = RecentlyAddedService.group_rows_for_display(rows)
+        assert len(display) == 1
+        g = display[0]
+        assert g["kind"] == "show"
+        assert g["show"] == "The Last of Us"
+        assert g["season"] == 2
+        assert g["episode_count"] == 3
+        assert g["total_size"] == 600
+        # Mixed cache/array → both locations present
+        assert set(g["locations"]) == {"cache", "array"}
+        assert g["not_pinned_count"] == 2
+        # Episodes sorted by episode number
+        assert [e.episode_info["episode"] for e in g["episodes"]] == [1, 2, 3]
+
+    def test_single_episode_show_stays_a_row(self):
+        rows = [_make_row("1", "Solo", "episode", "TV Shows",
+                          episode_info={"show": "Severance", "season": 1, "episode": 1})]
+        display = RecentlyAddedService.group_rows_for_display(rows)
+        assert len(display) == 1
+        assert display[0]["kind"] == "row"
+
+    def test_movies_stay_rows_and_order_preserved(self):
+        rows = [
+            _make_row("1", "Dune", "movie"),
+            _make_row("2", "EpA", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 1}),
+            _make_row("3", "EpB", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 2}),
+            _make_row("4", "Civil War", "movie"),
+        ]
+        display = RecentlyAddedService.group_rows_for_display(rows)
+        # movie, show-group (anchored at first episode), movie
+        assert [d["kind"] for d in display] == ["row", "show", "row"]
+        assert display[0]["row"].title == "Dune"
+        assert display[1]["episode_count"] == 2
+        assert display[2]["row"].title == "Civil War"
+
+    def test_different_seasons_are_separate_groups(self):
+        rows = [
+            _make_row("1", "S1E1", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 1}),
+            _make_row("2", "S1E2", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 2}),
+            _make_row("3", "S2E1", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 2, "episode": 1}),
+        ]
+        display = RecentlyAddedService.group_rows_for_display(rows)
+        # Season 1 (2 eps) groups; Season 2 (1 ep) stays a row
+        kinds = sorted(d["kind"] for d in display)
+        assert kinds == ["row", "show"]
+
+
+class TestScanAssociatedFiles:
+    def test_matches_subtitles_and_sidecars(self, tmp_path):
+        d = tmp_path / "Movies"
+        d.mkdir()
+        video = d / "Dune.mkv"
+        video.write_bytes(b"x")
+        (d / "Dune.en.srt").write_bytes(b"sub")
+        (d / "Dune.nfo").write_bytes(b"nfo")
+        (d / "Dune-poster.jpg").write_bytes(b"img")
+        (d / "Unrelated.txt").write_bytes(b"no")
+
+        svc = RecentlyAddedService()
+        found = svc._scan_associated_files(str(video))
+        names = {f["filename"] for f in found}
+        assert names == {"Dune.en.srt", "Dune.nfo", "Dune-poster.jpg"}
+        # Each carries a size display
+        assert all(f["size"] for f in found)
+
+    def test_missing_directory_returns_empty(self):
+        svc = RecentlyAddedService()
+        assert svc._scan_associated_files("/nope/does/not/exist/Movie.mkv") == []
+
+    def test_enrich_only_scans_cache_resident_items(self):
+        svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
+        svc._scan_associated_files = lambda p: [{"filename": "Movie.en.srt", "size": "1 KB"}]
+        rows = _enrich(svc, [_item()])
+        assert rows[0].location == "cache"
+        assert rows[0].associated_files == [{"filename": "Movie.en.srt", "size": "1 KB"}]
+
+    def test_enrich_skips_scan_for_array_items(self):
+        svc = _service(on_disk={"/mnt/user0/movies/Movie.mkv"})
+        svc._scan_associated_files = lambda p: [{"filename": "should-not-appear", "size": "1 KB"}]
+        rows = _enrich(svc, [_item()])
+        assert rows[0].location == "array"
+        assert rows[0].associated_files == []
 
 
 class TestSummary:

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -290,6 +290,108 @@ class TestScanAssociatedFiles:
         svc = RecentlyAddedService()
         assert svc._scan_associated_files("/nope/does/not/exist/Movie.mkv") == []
 
+    def test_local_extras_are_not_associated_files(self, tmp_path):
+        """Plex stores extras beside the feature. Each is its own media item."""
+        d = tmp_path / "Movies"
+        d.mkdir()
+        video = d / "Dune.mkv"
+        video.write_bytes(b"x")
+        (d / "Dune-trailer.mkv").write_bytes(b"x")
+        (d / "Dune-behindthescenes.mkv").write_bytes(b"x")
+        (d / "Dune.en.srt").write_bytes(b"sub")
+        (d / "Dune.nfo").write_bytes(b"nfo")
+
+        svc = RecentlyAddedService()
+        names = {f["filename"] for f in svc._scan_associated_files(str(video))}
+        # Exact set, so an over-broad filter fails here too.
+        assert names == {"Dune.en.srt", "Dune.nfo"}
+
+    def test_plexcached_backups_are_not_associated_files(self, tmp_path):
+        """splitext() leaves the real extension behind, so the naive stem test
+        accepted these: splitext("Dune.mkv.plexcached")[0] is "Dune.mkv", which
+        startswith("Dune."). Both the video and the subtitle backup slipped
+        through. Do not simplify the .plexcached clause away."""
+        d = tmp_path / "Movies"
+        d.mkdir()
+        video = d / "Dune.mkv"
+        video.write_bytes(b"x")
+        (d / "Dune.en.srt").write_bytes(b"sub")
+        (d / "Dune.mkv.plexcached").write_bytes(b"x")
+        (d / "Dune.en.srt.plexcached").write_bytes(b"x")
+
+        assert os.path.splitext("Dune.mkv.plexcached")[0] == "Dune.mkv"
+        svc = RecentlyAddedService()
+        names = {f["filename"] for f in svc._scan_associated_files(str(video))}
+        assert names == {"Dune.en.srt"}
+
+    def test_exotic_sidecars_survive_the_video_filter(self, tmp_path):
+        """Guard against the exclusion being too broad. VIDEO_EXTENSIONS and
+        SUBTITLE_EXTENSIONS are disjoint and must stay that way."""
+        d = tmp_path / "Movies"
+        d.mkdir()
+        video = d / "Dune.mkv"
+        video.write_bytes(b"x")
+        keep = ["Dune.idx", "Dune.sub", "Dune.sup", "Dune.en.ass",
+                "Dune.bif", "Dune.edl", "Dune-clearlogo.png"]
+        for n in keep:
+            (d / n).write_bytes(b"x")
+
+        svc = RecentlyAddedService()
+        names = {f["filename"] for f in svc._scan_associated_files(str(video))}
+        assert names == set(keep)
+
+    def test_space_separated_sidecar_is_claimed(self, tmp_path):
+        """The shared stem rule accepts any non-alphanumeric boundary, so the
+        common "<stem> poster.jpg" naming is picked up. The hand-rolled test
+        this replaced only allowed "." and "-" and dropped it."""
+        d = tmp_path / "Movies"
+        d.mkdir()
+        video = d / "Dune (2021).mkv"
+        video.write_bytes(b"x")
+        (d / "Dune (2021) poster.jpg").write_bytes(b"img")
+
+        svc = RecentlyAddedService()
+        names = {f["filename"] for f in svc._scan_associated_files(str(video))}
+        assert names == {"Dune (2021) poster.jpg"}
+
+    def test_prefix_sharing_movies_do_not_steal_sidecars(self, tmp_path):
+        """Boundary-awareness comes from the shared helper: "Movie 10.en.srt"
+        must not be claimed by the stem "Movie 1"."""
+        d = tmp_path / "Movies"
+        d.mkdir()
+        video = d / "Movie 1.mkv"
+        video.write_bytes(b"x")
+        (d / "Movie 1.en.srt").write_bytes(b"sub")
+        (d / "Movie 10.mkv").write_bytes(b"x")
+        (d / "Movie 10.en.srt").write_bytes(b"sub")
+
+        svc = RecentlyAddedService()
+        names = {f["filename"] for f in svc._scan_associated_files(str(video))}
+        assert names == {"Movie 1.en.srt"}
+
+    def test_is_a_subset_of_what_the_core_pipeline_attaches(self, tmp_path):
+        """Cross-module invariant: this display scan must never list a file the
+        caching pipeline would not treat as a sidecar. Subset, not equality —
+        the scan additionally requires the stem prefix, so it legitimately
+        drops directory-level artwork that _find_sibling_files returns."""
+        from core.file_operations import SiblingFileFinder
+
+        d = tmp_path / "Movies"
+        d.mkdir()
+        video = d / "Dune.mkv"
+        video.write_bytes(b"x")
+        for n in ["Dune-trailer.mkv", "Dune.en.srt", "Dune.nfo",
+                  "Dune-poster.jpg", "Dune.mkv.plexcached", "poster.jpg"]:
+            (d / n).write_bytes(b"x")
+
+        svc = RecentlyAddedService()
+        scanned = {f["filename"] for f in svc._scan_associated_files(str(video))}
+        pipeline = {
+            os.path.basename(p)
+            for p in SiblingFileFinder()._find_sibling_files(str(d), str(video))
+        }
+        assert scanned <= pipeline, f"listed non-sidecars: {scanned - pipeline}"
+
     def test_enrich_only_scans_cache_resident_items(self):
         svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
         svc._scan_associated_files = lambda p: [{"filename": "Movie.en.srt", "size": "1 KB"}]

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -65,7 +65,12 @@ def _service(on_disk):
     return svc
 
 
-def _enrich(svc, items, pinned=None, ondeck=None, watchlist=None, timestamps=None):
+def _enrich(svc, items, pinned=None, ondeck=None, watchlist=None, timestamps=None,
+            pin_path_map=..., exclude=None, released=None, watched_move=True):
+    # Default the pin map to "resolved, nothing pinned" so existing tests keep
+    # exercising the normal path rather than the indeterminate one.
+    if pin_path_map is ...:
+        pin_path_map = {}
     return svc._enrich(
         items,
         FakePathModifier(),
@@ -73,6 +78,10 @@ def _enrich(svc, items, pinned=None, ondeck=None, watchlist=None, timestamps=Non
         ondeck_keys=set(ondeck or []),
         watchlist_keys=set(watchlist or []),
         timestamps_keys=set(timestamps or []),
+        pin_path_map=pin_path_map,
+        exclude_paths=set(exclude) if exclude is not None else None,
+        released_paths=set(released) if released is not None else None,
+        watched_move=watched_move,
     )
 
 
@@ -367,3 +376,107 @@ class TestSummary:
         assert summary["on_cache"] == 2            # A + B physically on cache
         assert summary["on_cache_not_pinned"] == 1  # only A is actionable
         assert summary["on_array"] == 1            # C
+
+
+class TestPinResolution:
+    """Pin state must come from the resolved pin map, not raw key membership.
+
+    `pinned_media.json` holds only the scope's key, so an episode of a pinned
+    SHOW never appears there. Keying on the episode's own rating_key made every
+    such episode render "Not pinned" with a live Pin button, while /cache showed
+    the identical files as Pinned.
+    """
+
+    def test_show_pin_covers_its_episodes(self):
+        item = _item("9001", "Ep", "episode", "/data/tv/Show/S01E01.mkv",
+                     episode_info={"show": "Show", "season": 1, "episode": 1})
+        svc = _service(["/mnt/cache/tv/Show/S01E01.mkv"])
+        # The show pin (rk 5000) resolves down to this episode's Plex path.
+        rows = _enrich(svc, [item],
+                       pin_path_map={"/data/tv/Show/S01E01.mkv": ("5000", "show", "Show")})
+
+        assert rows[0].is_pinned is True
+        assert rows[0].outcome == "held"
+        assert rows[0].pin_scope == "show"
+        assert rows[0].pin_holder_key == "5000"
+        assert rows[0].pin_holder_title == "Show"
+
+    def test_direct_movie_pin_reports_itself_as_the_holder(self):
+        item = _item("42", "Dune", "movie", "/data/movies/Dune.mkv")
+        svc = _service(["/mnt/cache/movies/Dune.mkv"])
+        rows = _enrich(svc, [item],
+                       pin_path_map={"/data/movies/Dune.mkv": ("42", "movie", "Dune")})
+
+        assert rows[0].pin_scope == "movie"
+        assert rows[0].pin_holder_key == "42"
+
+    def test_pinned_but_not_on_cache_is_arriving_not_held(self):
+        item = _item("42", "Dune", "movie", "/data/movies/Dune.mkv")
+        svc = _service(["/mnt/user0/movies/Dune.mkv"])  # array only
+        rows = _enrich(svc, [item],
+                       pin_path_map={"/data/movies/Dune.mkv": ("42", "movie", "Dune")})
+
+        assert rows[0].is_pinned is True
+        assert rows[0].outcome == "arriving"
+
+    def test_unresolvable_pins_render_indeterminate_not_unpinned(self):
+        # Rendering "not pinned" here would put a live Pin button on a pinned
+        # row; one click unpins it and starts a background eviction.
+        item = _item("42", "Dune", "movie", "/data/movies/Dune.mkv")
+        svc = _service(["/mnt/cache/movies/Dune.mkv"])
+        rows = _enrich(svc, [item], pin_path_map=None)
+
+        assert rows[0].outcome == "pin_unknown"
+
+    def test_unresolvable_pins_still_honour_a_direct_key_match(self):
+        # Degraded but true: a direct item pin is knowable from the tracker
+        # alone. Only inherited show/season coverage needs Plex.
+        item = _item("42", "Dune", "movie", "/data/movies/Dune.mkv")
+        svc = _service(["/mnt/cache/movies/Dune.mkv"])
+        rows = _enrich(svc, [item], pinned=["42"], pin_path_map=None)
+
+        assert rows[0].is_pinned is True
+        assert rows[0].outcome == "pin_unknown"  # still indeterminate overall
+
+    def test_empty_map_means_definitively_nothing_pinned(self):
+        item = _item("42", "Dune", "movie", "/data/movies/Dune.mkv")
+        svc = _service(["/mnt/cache/movies/Dune.mkv"])
+        rows = _enrich(svc, [item], pin_path_map={},
+                       exclude=["/mnt/cache/movies/Dune.mkv"])
+
+        assert rows[0].is_pinned is False
+        assert rows[0].outcome == "moves_back"
+
+
+class TestMoverOutcomes:
+    def test_cached_file_absent_from_exclude_list_is_the_movers_call(self):
+        item = _item("1", "Fresh", "movie", "/data/movies/Fresh.mkv")
+        svc = _service(["/mnt/cache/movies/Fresh.mkv"])
+        rows = _enrich(svc, [item], exclude=[])
+
+        assert rows[0].is_mover_protected is False
+        assert rows[0].outcome == "mover_decides"
+
+    def test_released_file_is_flagged(self):
+        item = _item("1", "Rel", "movie", "/data/movies/Rel.mkv")
+        svc = _service(["/mnt/cache/movies/Rel.mkv"])
+        rows = _enrich(svc, [item], exclude=[], released=["/mnt/cache/movies/Rel.mkv"])
+
+        assert rows[0].is_released is True
+        assert rows[0].outcome == "mover_decides"
+
+    def test_watched_move_off_is_reported_on_cached_rows(self):
+        item = _item("1", "Held", "movie", "/data/movies/Held.mkv")
+        svc = _service(["/mnt/cache/movies/Held.mkv"])
+        rows = _enrich(svc, [item], exclude=["/mnt/cache/movies/Held.mkv"],
+                       watched_move=False)
+
+        assert rows[0].outcome == "held_by_setting"
+
+    def test_ondeck_cached_file_returns_when_watched(self):
+        item = _item("1", "OD", "movie", "/data/movies/OD.mkv")
+        svc = _service(["/mnt/cache/movies/OD.mkv"])
+        rows = _enrich(svc, [item], ondeck=["/mnt/user/movies/OD.mkv"],
+                       exclude=["/mnt/cache/movies/OD.mkv"])
+
+        assert rows[0].outcome == "returns_when_done"

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -1,0 +1,158 @@
+"""Tests for RecentlyAddedService enrichment + summary logic.
+
+``_enrich`` is pure given its inputs (raw items, a path converter, the tracker
+key sets, and the file-existence probe), so these tests exercise it directly
+without a live Plex server or real filesystem.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+for _mod in [
+    'apscheduler', 'apscheduler.schedulers',
+    'apscheduler.schedulers.background', 'apscheduler.triggers',
+    'apscheduler.triggers.cron', 'apscheduler.triggers.interval',
+    'plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+    'plexapi.library', 'plexapi.exceptions', 'requests',
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.plex_api import RecentlyAddedItem
+from web.services.recently_added_service import RecentlyAddedService
+
+
+class FakePathModifier:
+    """Maps /data/... -> /mnt/user/... -> /mnt/cache/... predictably."""
+
+    def convert_plex_to_real(self, plex):
+        if plex and plex.startswith("/data"):
+            return ("/mnt/user" + plex[len("/data"):], None)
+        return (None, None)
+
+    def convert_real_to_cache(self, real):
+        if real and real.startswith("/mnt/user"):
+            return ("/mnt/cache" + real[len("/mnt/user"):], None)
+        return (None, None)
+
+
+def _item(rating_key="1", title="Movie", media_type="movie",
+          plex_path="/data/movies/Movie.mkv", size=1000, episode_info=None):
+    return RecentlyAddedItem(
+        file_path=plex_path,
+        rating_key=rating_key,
+        title=title,
+        media_type=media_type,
+        added_at=datetime.now() - timedelta(hours=2),
+        library_title="Movies",
+        library_section_id=1,
+        size=size,
+        episode_info=episode_info,
+    )
+
+
+def _service(on_disk):
+    """Service whose file-existence probe returns True only for `on_disk`."""
+    svc = RecentlyAddedService()
+    svc._file_exists = lambda path, _set=set(on_disk): path in _set
+    return svc
+
+
+def _enrich(svc, items, pinned=None, ondeck=None, watchlist=None, timestamps=None):
+    return svc._enrich(
+        items,
+        FakePathModifier(),
+        pinned_keys=set(pinned or []),
+        ondeck_keys=set(ondeck or []),
+        watchlist_keys=set(watchlist or []),
+        timestamps_keys=set(timestamps or []),
+    )
+
+
+class TestEnrichState:
+    def test_on_cache_not_pinned_is_actionable_state(self):
+        svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
+        rows = _enrich(svc, [_item()])
+        assert len(rows) == 1
+        r = rows[0]
+        assert r.location == "cache"
+        assert r.state == "on_cache_not_pinned"
+        assert r.protected_by == []
+
+    def test_on_array_when_only_array_file_exists(self):
+        svc = _service(on_disk={"/mnt/user0/movies/Movie.mkv"})
+        rows = _enrich(svc, [_item()])
+        assert rows[0].location == "array"
+        assert rows[0].state == "on_array"
+
+    def test_pinned_takes_precedence_over_location(self):
+        svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
+        rows = _enrich(svc, [_item(rating_key="42")], pinned=["42"])
+        assert rows[0].is_pinned is True
+        assert rows[0].state == "pinned"
+        assert rows[0].protected_by == ["Pinned"]
+
+    def test_ondeck_membership_keyed_by_real_path(self):
+        svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
+        rows = _enrich(svc, [_item()], ondeck=["/mnt/user/movies/Movie.mkv"])
+        assert rows[0].is_ondeck is True
+        assert rows[0].state == "protected"
+        assert rows[0].protected_by == ["OnDeck"]
+
+    def test_watchlist_membership_keyed_by_plex_path(self):
+        svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
+        rows = _enrich(svc, [_item()], watchlist=["/data/movies/Movie.mkv"])
+        assert rows[0].is_watchlist is True
+        assert rows[0].state == "protected"
+        assert rows[0].protected_by == ["Watchlist"]
+
+    def test_unknown_location_for_unmapped_path(self):
+        svc = _service(on_disk=set())
+        rows = _enrich(svc, [_item(plex_path="/somewhere/else/x.mkv")])
+        assert rows[0].location == "unknown"
+        assert rows[0].state == "unknown"
+
+    def test_cache_tracked_flag_from_timestamps(self):
+        svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
+        rows = _enrich(svc, [_item()], timestamps=["/mnt/cache/movies/Movie.mkv"])
+        assert rows[0].is_cache_tracked is True
+
+    def test_episode_pin_type_and_metadata(self):
+        svc = _service(on_disk={"/mnt/cache/tv/Show/Ep.mkv"})
+        ep = _item(media_type="episode", plex_path="/data/tv/Show/Ep.mkv",
+                   episode_info={"show": "Show", "season": 1, "episode": 3})
+        rows = _enrich(svc, [ep])
+        assert rows[0].pin_type == "episode"
+        assert rows[0].episode_info == {"show": "Show", "season": 1, "episode": 3}
+
+    def test_display_fields_formatted(self):
+        svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
+        rows = _enrich(svc, [_item(size=28_000_000_000)])
+        assert rows[0].size_display.endswith("GB")
+        assert rows[0].added_display  # non-empty relative age
+
+
+class TestSummary:
+    def test_summary_counts(self):
+        svc = _service(on_disk={
+            "/mnt/cache/movies/A.mkv",
+            "/mnt/cache/movies/B.mkv",
+            "/mnt/user0/movies/C.mkv",
+        })
+        rows = _enrich(svc, [
+            _item(rating_key="1", title="A", plex_path="/data/movies/A.mkv"),          # cache, not pinned
+            _item(rating_key="2", title="B", plex_path="/data/movies/B.mkv"),          # cache, pinned
+            _item(rating_key="3", title="C", plex_path="/data/movies/C.mkv"),          # array
+        ], pinned=["2"])
+
+        summary = svc._summary(rows)
+        assert summary["total"] == 3
+        assert summary["on_cache"] == 2            # A + B physically on cache
+        assert summary["on_cache_not_pinned"] == 1  # only A is actionable
+        assert summary["on_array"] == 1            # C

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -394,17 +394,119 @@ class TestScanAssociatedFiles:
 
     def test_enrich_only_scans_cache_resident_items(self):
         svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
-        svc._scan_associated_files = lambda p: [{"filename": "Movie.en.srt", "size": "1 KB"}]
+        svc._scan_associated_files = lambda p, *_: [{"filename": "Movie.en.srt", "size": "1 KB"}]
         rows = _enrich(svc, [_item()])
         assert rows[0].location == "cache"
         assert rows[0].associated_files == [{"filename": "Movie.en.srt", "size": "1 KB"}]
 
     def test_enrich_skips_scan_for_array_items(self):
         svc = _service(on_disk={"/mnt/user0/movies/Movie.mkv"})
-        svc._scan_associated_files = lambda p: [{"filename": "should-not-appear", "size": "1 KB"}]
+        svc._scan_associated_files = lambda p, *_: [{"filename": "should-not-appear", "size": "1 KB"}]
         rows = _enrich(svc, [_item()])
         assert rows[0].location == "array"
         assert rows[0].associated_files == []
+
+
+class TestScanDirectoryMemo:
+    """N rows in one directory must scan it once, without changing any result."""
+
+    def _dir(self, tmp_path, videos, sidecars):
+        d = tmp_path / "Movies"
+        d.mkdir()
+        for n in list(videos) + list(sidecars):
+            (d / n).write_bytes(b"x")
+        return d
+
+    def test_one_scandir_per_directory_not_per_row(self, tmp_path, monkeypatch):
+        d = self._dir(tmp_path, ["A.mkv", "B.mkv", "C.mkv"],
+                      ["A.en.srt", "B.en.srt", "C.en.srt"])
+        real = os.scandir
+        calls = []
+
+        def counting(path):
+            calls.append(path)
+            return real(path)
+
+        monkeypatch.setattr(os, "scandir", counting)
+        svc = RecentlyAddedService()
+        cache = {}
+        for name in ("A.mkv", "B.mkv", "C.mkv"):
+            svc._scan_associated_files(str(d / name), cache)
+        assert len(calls) == 1, f"scanned {len(calls)} times, expected 1"
+
+    def test_without_the_memo_each_row_scans(self, tmp_path, monkeypatch):
+        """Pins the behaviour the memo is optimising, so the test above cannot
+        pass for the wrong reason."""
+        d = self._dir(tmp_path, ["A.mkv", "B.mkv"], ["A.en.srt", "B.en.srt"])
+        real = os.scandir
+        calls = []
+        monkeypatch.setattr(os, "scandir", lambda p: (calls.append(p), real(p))[1])
+        svc = RecentlyAddedService()
+        for name in ("A.mkv", "B.mkv"):
+            svc._scan_associated_files(str(d / name))
+        assert len(calls) == 2
+
+    def test_memo_caches_the_listing_not_the_filtered_result(self, tmp_path):
+        """The trap: two videos in one directory have different stems, so a
+        memo keyed only on the directory must re-filter per row. Caching the
+        filtered result would give every row the first row's sidecars."""
+        d = self._dir(tmp_path, ["A.mkv", "B.mkv"],
+                      ["A.en.srt", "A.nfo", "B.en.srt"])
+        svc = RecentlyAddedService()
+        cache = {}
+        a = {f["filename"] for f in svc._scan_associated_files(str(d / "A.mkv"), cache)}
+        b = {f["filename"] for f in svc._scan_associated_files(str(d / "B.mkv"), cache)}
+        assert a == {"A.en.srt", "A.nfo"}
+        assert b == {"B.en.srt"}
+
+    def test_memoised_output_matches_unmemoised(self, tmp_path):
+        d = self._dir(tmp_path, ["A.mkv", "B.mkv"],
+                      ["A.en.srt", "A-poster.jpg", "B.en.srt", "stray.txt"])
+        svc = RecentlyAddedService()
+        cache = {}
+        for name in ("A.mkv", "B.mkv"):
+            assert (svc._scan_associated_files(str(d / name), cache)
+                    == svc._scan_associated_files(str(d / name)))
+
+    def test_sidecar_whose_stat_fails_is_still_listed(self, tmp_path):
+        """A sidecar the mover is moving out from under the scan is real; it
+        just has no size to show. An implementation that skipped on OSError
+        would silently drop it."""
+        d = self._dir(tmp_path, ["A.mkv"], ["A.en.srt"])
+
+        class Boom:
+            name = "A.nfo"
+
+            def is_file(self):
+                return True
+
+            def stat(self):
+                raise OSError("EACCES")
+
+        svc = RecentlyAddedService()
+        cache = {str(d): list(os.scandir(str(d))) + [Boom()]}
+        found = svc._scan_associated_files(str(d / "A.mkv"), cache)
+        by_name = {f["filename"]: f["size"] for f in found}
+        assert by_name["A.nfo"] == ""
+        assert by_name["A.en.srt"]
+
+    def test_missing_directory_is_cached_as_empty(self, tmp_path):
+        svc = RecentlyAddedService()
+        cache = {}
+        missing = str(tmp_path / "nope" / "Movie.mkv")
+        assert svc._scan_associated_files(missing, cache) == []
+        assert svc._scan_associated_files(missing, cache) == []
+        assert cache[os.path.dirname(missing)] == []
+
+    def test_enrich_passes_a_fresh_cache_per_call(self):
+        """A cache that outlived the call would go stale — the service is a
+        module-level singleton shared across requests."""
+        svc = _service(on_disk={"/mnt/cache/movies/Movie.mkv"})
+        seen = []
+        svc._scan_associated_files = lambda p, c=None: (seen.append(id(c)), [])[1]
+        _enrich(svc, [_item()])
+        _enrich(svc, [_item()])
+        assert len(seen) == 2 and seen[0] != seen[1]
 
 
 class TestGetRecentlyAddedEndToEnd:

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -5,10 +5,11 @@ key sets, and the file-existence probe), so these tests exercise it directly
 without a live Plex server or real filesystem.
 """
 
+import json
 import os
 import sys
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -249,6 +250,60 @@ class TestScanAssociatedFiles:
         rows = _enrich(svc, [_item()])
         assert rows[0].location == "array"
         assert rows[0].associated_files == []
+
+
+class TestGetRecentlyAddedEndToEnd:
+    """Exercise the real get_recently_added() path (config load → connect →
+    fetch → enrich), which the mocked-service route tests don't cover. This is
+    the regression guard for the MultiPathModifier import (a wrong class name
+    here surfaces as a 500 in the browser)."""
+
+    def _settings(self, tmp_path):
+        data = {
+            "PLEX_URL": "http://x", "PLEX_TOKEN": "t", "number_episodes": 5,
+            "valid_sections": [1], "days_to_monitor": 7, "users_toggle": True,
+            "watchlist_toggle": True, "watchlist_episodes": 3, "watched_move": True,
+            "cache_dir": "/mnt/cache/", "max_concurrent_moves_array": 2,
+            "max_concurrent_moves_cache": 2, "prefetch_minimum_minutes": 0,
+            "path_mappings": [{
+                "name": "Movies", "plex_path": "/data/", "real_path": "/mnt/user/",
+                "cache_path": "/mnt/cache/", "enabled": True, "cacheable": True,
+                "section_id": 1,
+            }],
+        }
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        return p
+
+    def test_enriches_real_items_without_error(self, tmp_path):
+        from core.plex_api import RecentlyAddedItem
+
+        items = [
+            RecentlyAddedItem(file_path="/data/movies/Dune.mkv", rating_key="101",
+                              title="Dune", media_type="movie",
+                              added_at=datetime.now() - timedelta(hours=2),
+                              library_title="Movies", library_section_id="1", size=28000),
+            RecentlyAddedItem(file_path="/data/tv/Show/S01E01.mkv", rating_key="201",
+                              title="Ep1", media_type="episode", added_at=None,
+                              library_title="TV", library_section_id="1", size=5000,
+                              episode_info={"show": "Show", "season": 1, "episode": 1}),
+        ]
+        svc = RecentlyAddedService()
+        svc.settings_file = str(self._settings(tmp_path))
+
+        fake_pm = MagicMock()
+        fake_pm.connect.return_value = None
+        fake_pm.get_recently_added_media.return_value = items
+
+        with patch("core.plex_api.PlexManager", return_value=fake_pm):
+            res = svc.get_recently_added(days=7, max_items=100)
+
+        assert res["available"] is True
+        assert res["error"] is None
+        assert len(res["rows"]) == 2
+        # The episode with added_at=None must still enrich (no crash on None age).
+        ep = next(r for r in res["rows"] if r.media_type == "episode")
+        assert ep.added_display is None
 
 
 class TestSummary:

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -150,7 +150,7 @@ class TestEnrichState:
 
 def _make_row(rating_key="1", title="X", media_type="movie", library_title="Movies",
               size=1000, location="cache", state="on_cache_not_pinned",
-              is_pinned=False, episode_info=None):
+              is_pinned=False, episode_info=None, show_rating_key=""):
     return RecentlyAddedRow(
         rating_key=rating_key, title=title, media_type=media_type,
         library_title=library_title, file_path=f"/data/{title}.mkv",
@@ -158,6 +158,7 @@ def _make_row(rating_key="1", title="X", media_type="movie", library_title="Movi
         added_display="now", location=location, state=state, is_pinned=is_pinned,
         pin_type="episode" if media_type == "episode" else "movie",
         episode_info=episode_info,
+        show_rating_key=show_rating_key,
     )
 
 
@@ -496,3 +497,56 @@ class TestMoverOutcomes:
                        exclude=["/mnt/cache/movies/OD.mkv"])
 
         assert rows[0].outcome == "returns_when_done"
+
+
+class TestShowIdentityGrouping:
+    """Groups key on the show's rating key, not its display title.
+
+    Two distinct shows can share a title — "The Office" (US) and "The Office"
+    (UK) — and keying on the title merged them into one group with interleaved
+    children and a nonsense season range.
+    """
+
+    def test_same_titled_shows_in_one_library_stay_separate(self):
+        rows = [
+            _make_row("101", "US-E1", "episode", "TV Shows", show_rating_key="10",
+                      episode_info={"show": "The Office", "season": 9, "episode": 1}),
+            _make_row("102", "US-E2", "episode", "TV Shows", show_rating_key="10",
+                      episode_info={"show": "The Office", "season": 9, "episode": 2}),
+            _make_row("201", "UK-E5", "episode", "TV Shows", show_rating_key="20",
+                      episode_info={"show": "The Office", "season": 2, "episode": 5}),
+        ]
+        display = RecentlyAddedService.group_rows_for_display(rows)
+
+        # US groups (2 eps); the lone UK episode stays its own row.
+        assert [d["kind"] for d in display] == ["show", "row"]
+        assert display[0]["episode_count"] == 2
+        # The header shows the title, not the rating key it now groups on.
+        assert display[0]["show"] == "The Office"
+        # Previously "Seasons 2–9" — the merge's most visible symptom.
+        assert display[0]["season_display"] == "Season 9"
+
+    def test_missing_show_rating_key_falls_back_to_the_title(self):
+        # A Plex server that omits grandparentRatingKey keeps today's behaviour,
+        # so this change can only split merged groups, never merge separate ones.
+        rows = [
+            _make_row("1", "E1", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 1}),
+            _make_row("2", "E2", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 2}),
+        ]
+        display = RecentlyAddedService.group_rows_for_display(rows)
+        assert [d["kind"] for d in display] == ["show"]
+        assert display[0]["episode_count"] == 2
+        assert display[0]["show"] == "Show"
+
+    def test_same_show_key_across_libraries_still_separate(self):
+        # library_title remains part of the key.
+        rows = [
+            _make_row("1", "E1", "episode", "TV Shows", show_rating_key="10",
+                      episode_info={"show": "Show", "season": 1, "episode": 1}),
+            _make_row("2", "E2", "episode", "Anime", show_rating_key="10",
+                      episode_info={"show": "Show", "season": 1, "episode": 2}),
+        ]
+        display = RecentlyAddedService.group_rows_for_display(rows)
+        assert [d["kind"] for d in display] == ["row", "row"]

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -393,13 +393,29 @@ class TestPinResolution:
         svc = _service(["/mnt/cache/tv/Show/S01E01.mkv"])
         # The show pin (rk 5000) resolves down to this episode's Plex path.
         rows = _enrich(svc, [item],
-                       pin_path_map={"/data/tv/Show/S01E01.mkv": ("5000", "show", "Show")})
+                       pin_path_map={"/data/tv/Show/S01E01.mkv": ("5000", "show", "Show")},
+                       exclude=["/mnt/cache/tv/Show/S01E01.mkv"])
 
         assert rows[0].is_pinned is True
         assert rows[0].outcome == "held"
         assert rows[0].pin_scope == "show"
         assert rows[0].pin_holder_key == "5000"
         assert rows[0].pin_holder_title == "Show"
+
+    def test_pinned_file_missing_from_the_exclude_list_is_flagged(self):
+        # Pinning writes no exclude line, so a file pinned while already on
+        # cache is exempt from PlexCache eviction while the Unraid mover can
+        # still relocate it. Claiming plain "held" would promise mover
+        # protection the pin has not bought.
+        item = _item("42", "Dune", "movie", "/data/movies/Dune.mkv")
+        svc = _service(["/mnt/cache/movies/Dune.mkv"])
+        rows = _enrich(svc, [item],
+                       pin_path_map={"/data/movies/Dune.mkv": ("42", "movie", "Dune")},
+                       exclude=[])
+
+        assert rows[0].is_pinned is True
+        assert rows[0].is_mover_protected is False
+        assert rows[0].outcome == "held_mover_gap"
 
     def test_direct_movie_pin_reports_itself_as_the_holder(self):
         item = _item("42", "Dune", "movie", "/data/movies/Dune.mkv")

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -200,7 +200,7 @@ class TestGroupRowsForDisplay:
         assert display[1]["episode_count"] == 2
         assert display[2]["row"].title == "Civil War"
 
-    def test_different_seasons_are_separate_groups(self):
+    def test_seasons_merge_into_one_show_group(self):
         rows = [
             _make_row("1", "S1E1", "episode", "TV Shows",
                       episode_info={"show": "Show", "season": 1, "episode": 1}),
@@ -210,9 +210,52 @@ class TestGroupRowsForDisplay:
                       episode_info={"show": "Show", "season": 2, "episode": 1}),
         ]
         display = RecentlyAddedService.group_rows_for_display(rows)
-        # Season 1 (2 eps) groups; Season 2 (1 ep) stays a row
-        kinds = sorted(d["kind"] for d in display)
-        assert kinds == ["row", "show"]
+        # A season rollover must not split one show into two adjacent rows.
+        assert [d["kind"] for d in display] == ["show"]
+        g = display[0]
+        assert g["episode_count"] == 3
+        assert g["seasons"] == [1, 2]
+        assert g["season_display"] == "Seasons 1–2"
+        # No single season to name → the plain `season` field is None
+        assert g["season"] is None
+        # Sorted by (season, episode) so the rollover reads in order
+        assert [(e.episode_info["season"], e.episode_info["episode"]) for e in g["episodes"]] == [
+            (1, 1), (1, 2), (2, 1)
+        ]
+
+    def test_single_season_group_names_that_season(self):
+        rows = [
+            _make_row("1", "E1", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 3, "episode": 1}),
+            _make_row("2", "E2", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 3, "episode": 2}),
+        ]
+        g = RecentlyAddedService.group_rows_for_display(rows)[0]
+        assert g["season"] == 3
+        assert g["season_display"] == "Season 3"
+
+    def test_same_show_in_two_libraries_stays_separate(self):
+        rows = [
+            _make_row("1", "E1", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 1}),
+            _make_row("2", "E2", "episode", "Anime",
+                      episode_info={"show": "Show", "season": 1, "episode": 2}),
+        ]
+        display = RecentlyAddedService.group_rows_for_display(rows)
+        assert [d["kind"] for d in display] == ["row", "row"]
+
+    def test_group_added_display_is_newest_episode(self):
+        # Rows arrive newest-first, so the group's age is the first member's.
+        rows = [
+            _make_row("1", "E2", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 2}),
+            _make_row("2", "E1", "episode", "TV Shows",
+                      episode_info={"show": "Show", "season": 1, "episode": 1}),
+        ]
+        rows[0].added_display = "1 hr ago"
+        rows[1].added_display = "9 hr ago"
+        g = RecentlyAddedService.group_rows_for_display(rows)[0]
+        assert g["added_display"] == "1 hr ago"
 
 
 class TestScanAssociatedFiles:

--- a/tests/test_recently_added_service.py
+++ b/tests/test_recently_added_service.py
@@ -25,7 +25,7 @@ for _mod in [
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from core.plex_api import RecentlyAddedItem
+from core.plex_api import RecentlyAddedItem, RecentlyAddedResult
 from web.services.recently_added_service import RecentlyAddedService, RecentlyAddedRow
 
 
@@ -407,6 +407,69 @@ class TestScanAssociatedFiles:
         assert rows[0].associated_files == []
 
 
+class TestUnreadableLibraries:
+    """A library Plex refused to list must reach the template, not vanish."""
+
+    def _settings(self, tmp_path):
+        data = {
+            "PLEX_URL": "http://x", "PLEX_TOKEN": "t", "number_episodes": 5,
+            "valid_sections": [1], "days_to_monitor": 7, "users_toggle": True,
+            "watchlist_toggle": True, "watchlist_episodes": 3, "watched_move": True,
+            "cache_dir": "/mnt/cache/", "max_concurrent_moves_array": 2,
+            "max_concurrent_moves_cache": 2, "prefetch_minimum_minutes": 0,
+            "path_mappings": [{
+                "name": "Movies", "plex_path": "/data/", "real_path": "/mnt/user/",
+                "cache_path": "/mnt/cache/", "enabled": True, "cacheable": True,
+                "section_id": 1,
+            }],
+        }
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        return p
+
+    def _run(self, tmp_path, result):
+        svc = RecentlyAddedService()
+        svc.settings_file = str(self._settings(tmp_path))
+        fake_pm = MagicMock()
+        fake_pm.connect.return_value = None
+        fake_pm.get_recently_added_media.return_value = result
+        with patch("core.plex_api.PlexManager", return_value=fake_pm):
+            return svc.get_recently_added(days=7, max_items=100)
+
+    def test_partial_failure_keeps_the_page_but_names_the_library(self, tmp_path):
+        item = RecentlyAddedItem(
+            file_path="/data/movies/Dune.mkv", rating_key="1", title="Dune",
+            media_type="movie", added_at=datetime.now(), library_title="Movies",
+            library_section_id=1, size=1000,
+        )
+        res = self._run(tmp_path, RecentlyAddedResult(
+            items=[item], unreadable_libraries=["Documentaries"]))
+
+        assert res["available"] is True
+        assert res["unreadable_libraries"] == ["Documentaries"]
+
+    def test_total_failure_reads_as_failure_not_as_empty(self, tmp_path):
+        """Every attempted library failed, so there are no counts to show.
+        Rendering zeroed stat cards under a warning would assert numbers the
+        app cannot know."""
+        res = self._run(tmp_path, RecentlyAddedResult(
+            items=[], unreadable_libraries=["Movies", "TV Shows"]))
+
+        assert res["available"] is False
+        assert "Movies" in res["error"] and "TV Shows" in res["error"]
+
+    def test_clean_sweep_reports_nothing_unreadable(self, tmp_path):
+        res = self._run(tmp_path, RecentlyAddedResult(items=[]))
+
+        assert res["available"] is True
+        assert res["unreadable_libraries"] == []
+
+    def test_empty_result_carries_the_key(self):
+        """Shape symmetry — every consumer can read it without a guard."""
+        svc = RecentlyAddedService()
+        assert svc._empty_result("boom")["unreadable_libraries"] == []
+
+
 class TestScanDirectoryMemo:
     """N rows in one directory must scan it once, without changing any result."""
 
@@ -533,7 +596,7 @@ class TestGetRecentlyAddedEndToEnd:
         return p
 
     def test_enriches_real_items_without_error(self, tmp_path):
-        from core.plex_api import RecentlyAddedItem
+        from core.plex_api import RecentlyAddedItem, RecentlyAddedResult
 
         items = [
             RecentlyAddedItem(file_path="/data/movies/Dune.mkv", rating_key="101",
@@ -550,7 +613,7 @@ class TestGetRecentlyAddedEndToEnd:
 
         fake_pm = MagicMock()
         fake_pm.connect.return_value = None
-        fake_pm.get_recently_added_media.return_value = items
+        fake_pm.get_recently_added_media.return_value = RecentlyAddedResult(items=items)
 
         with patch("core.plex_api.PlexManager", return_value=fake_pm):
             res = svc.get_recently_added(days=7, max_items=100)

--- a/tests/test_recently_added_settings_roundtrip.py
+++ b/tests/test_recently_added_settings_roundtrip.py
@@ -1,0 +1,72 @@
+"""The Recently Added display settings must survive a Cache-tab save.
+
+`recently_added_days` / `recently_added_max_items` were originally wired into
+`save_cache_settings()` only. The Cache tab renders them from
+`get_cache_settings()`, so the read side omitting them made the form show a
+default and write that default back over the user's stored value on the next
+save of any unrelated Cache field.
+"""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+sys.modules.setdefault('apscheduler', MagicMock())
+sys.modules.setdefault('apscheduler.schedulers', MagicMock())
+sys.modules.setdefault('apscheduler.schedulers.background', MagicMock())
+sys.modules.setdefault('apscheduler.triggers', MagicMock())
+sys.modules.setdefault('apscheduler.triggers.cron', MagicMock())
+sys.modules.setdefault('apscheduler.triggers.interval', MagicMock())
+sys.modules.setdefault('plexapi', MagicMock())
+sys.modules.setdefault('plexapi.server', MagicMock())
+
+
+@pytest.fixture
+def service(tmp_path):
+    settings_file = tmp_path / "plexcache_settings.json"
+    settings_file.write_text("{}", encoding="utf-8")
+    with patch("web.services.settings_service.SETTINGS_FILE", settings_file), \
+         patch("web.services.settings_service.DATA_DIR", tmp_path):
+        from web.services.settings_service import SettingsService
+        svc = SettingsService()
+        yield svc
+
+
+def _store(service, data):
+    with open(service.settings_file, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+    service._cached_settings = None
+
+
+class TestRecentlyAddedSettingsRoundTrip:
+    def test_get_cache_settings_reads_stored_values(self, service):
+        _store(service, {"recently_added_days": 30, "recently_added_max_items": 400})
+        cache = service.get_cache_settings()
+        assert cache["recently_added_days"] == 30
+        assert cache["recently_added_max_items"] == 400
+
+    def test_defaults_match_the_router(self, service):
+        _store(service, {})
+        cache = service.get_cache_settings()
+        from web.routers.recently_added import DEFAULT_DAYS, DEFAULT_MAX_ITEMS
+        assert cache["recently_added_days"] == DEFAULT_DAYS
+        assert cache["recently_added_max_items"] == DEFAULT_MAX_ITEMS
+
+    def test_saving_an_unrelated_cache_field_preserves_them(self, service):
+        _store(service, {"recently_added_days": 30, "recently_added_max_items": 400})
+
+        # Simulate the Cache tab round-trip: the form is populated from
+        # get_cache_settings(), the user edits one unrelated field, and the
+        # whole form posts back.
+        form = service.get_cache_settings()
+        form["cache_limit"] = "500GB"
+        service.save_cache_settings(form)
+
+        service._cached_settings = None
+        reloaded = service.get_cache_settings()
+        assert reloaded["cache_limit"] == "500GB"
+        assert reloaded["recently_added_days"] == 30
+        assert reloaded["recently_added_max_items"] == 400

--- a/tests/test_release_to_mover.py
+++ b/tests/test_release_to_mover.py
@@ -716,7 +716,7 @@ class TestFullAuditWithReleasedFiles:
                           return_value=([], [], set(), set())), \
              patch.object(MaintenanceService, "_cache_to_array_path", return_value=None), \
              patch.object(MaintenanceService, "_get_pinned_cache_paths", return_value=set()), \
-             patch.object(MaintenanceService, "_group_unprotected_by_directory", return_value=[]):
+             patch.object(MaintenanceService, "_group_untracked_by_directory", return_value=[]):
             return service.run_full_audit()
 
     def test_mover_relocated_a_released_file_is_not_stale(self):
@@ -734,10 +734,10 @@ class TestFullAuditWithReleasedFiles:
 
         assert results.stale_timestamp_entries == ["/mnt/cache/Genuine.mkv"]
 
-    def test_released_file_still_on_cache_is_not_unprotected(self, tmp_path):
+    def test_released_file_still_on_cache_is_not_untracked(self, tmp_path):
         """A released file is absent from the exclude list on purpose.
 
-        Listing it as unprotected recommends sync_to_array — the exact array
+        Listing it as untracked recommends sync_to_array — the exact array
         write release exists to avoid — and exposes it to the bulk
         "Add to Exclude" action.
         """
@@ -751,7 +751,7 @@ class TestFullAuditWithReleasedFiles:
             released_files={released},
         )
 
-        flagged = {f.cache_path for f in results.unprotected_files}
+        flagged = {f.cache_path for f in results.untracked_files}
         assert flagged == {genuine}
 
     def test_released_files_do_not_affect_health(self, tmp_path):

--- a/tests/test_resolve_pins_to_paths.py
+++ b/tests/test_resolve_pins_to_paths.py
@@ -248,7 +248,7 @@ class TestOrphanCleanup:
         tracker.add_pin("999", "movie", "Gone")
 
         with caplog.at_level(logging.WARNING):
-            resolved, orphaned = resolve_pins_to_paths(server, tracker, "highest")
+            resolved, orphaned = resolve_pins_to_paths(server, tracker, "highest", prune=True)
 
         assert resolved == []
         assert orphaned == ["999"]
@@ -263,12 +263,67 @@ class TestOrphanCleanup:
         tracker.add_pin("100", "movie", "Alive")
         tracker.add_pin("999", "movie", "Gone")
 
-        resolved, orphaned = resolve_pins_to_paths(server, tracker, "highest")
+        resolved, orphaned = resolve_pins_to_paths(server, tracker, "highest", prune=True)
 
         assert [p for p, _, _ in resolved] == ["/plex/Alive.mkv"]
         assert orphaned == ["999"]
         assert tracker.is_pinned("100") is True
         assert tracker.is_pinned("999") is False
+
+
+class TestPruneIsOptIn:
+    """Read-only callers must never delete a pin.
+
+    The resolver runs on plain page renders (Cached Files, Recently Added, the
+    dashboard widget). A rating_key can be transiently absent from Plex — the
+    window Sonarr/Radarr's "Empty Trash after every scan" opens mid-upgrade —
+    and pruning there silently and permanently drops the user's pin.
+    """
+
+    def test_default_reports_orphans_without_removing_them(self, tracker):
+        server = FakePlexServer({})
+        tracker.add_pin("999", "movie", "Gone")
+
+        resolved, orphaned = resolve_pins_to_paths(server, tracker, "highest")
+
+        assert resolved == []
+        # Still reported, so the caller can surface it...
+        assert orphaned == ["999"]
+        # ...but the pin survives.
+        assert tracker.is_pinned("999") is True
+        assert tracker.get_pin("999") is not None
+
+    def test_default_does_not_warn_about_removal(self, tracker, caplog):
+        server = FakePlexServer({})
+        tracker.add_pin("999", "movie", "Gone")
+
+        with caplog.at_level(logging.WARNING):
+            resolve_pins_to_paths(server, tracker, "highest")
+
+        # No WARNING claiming a removal that did not happen.
+        assert not any("removing pin" in r.message for r in caplog.records)
+
+    def test_repeated_read_only_resolves_never_erode_the_tracker(self, tracker):
+        # Simulates a dashboard left open across many widget refreshes while the
+        # item is missing from Plex.
+        server = FakePlexServer({})
+        tracker.add_pin("999", "movie", "Gone")
+
+        for _ in range(10):
+            resolve_pins_to_paths(server, tracker, "highest")
+
+        assert tracker.is_pinned("999") is True
+
+    def test_resolvable_pins_are_unaffected_by_the_flag(self, tracker):
+        movie = FakeMovie("Alive", [FakeMedia("1080", "/plex/Alive.mkv")])
+        server = FakePlexServer({100: movie})
+        tracker.add_pin("100", "movie", "Alive")
+
+        for prune in (False, True):
+            resolved, orphaned = resolve_pins_to_paths(server, tracker, "highest", prune=prune)
+            assert [p for p, _, _ in resolved] == ["/plex/Alive.mkv"]
+            assert orphaned == []
+            assert tracker.is_pinned("100") is True
 
     def test_empty_tracker_returns_empty(self, tracker):
         server = FakePlexServer({})
@@ -428,7 +483,9 @@ class TestFetchItemRetryOnTimeout:
                 raise FakeNotFound("gone")
 
         tracker.add_pin("999", "movie", "DeletedMovie")
-        resolved, orphaned = resolve_pins_to_paths(ServerWithMissingItem(), tracker, "highest")
+        resolved, orphaned = resolve_pins_to_paths(
+            ServerWithMissingItem(), tracker, "highest", prune=True
+        )
 
         assert calls["n"] == 1  # no retry for NotFound
         assert orphaned == ["999"]

--- a/tests/test_share_alignment.py
+++ b/tests/test_share_alignment.py
@@ -1,0 +1,136 @@
+"""Tests for Unraid share alignment validation.
+
+Unraid merges a share's pool tier and array tier under one /mnt/user/<share>/
+path. Caching only works when the cache destination is the *same* share as the
+media: a file moves between tiers and the path Plex reads never changes. Point
+the cache at a different share and the cached copy lands where Plex isn't
+looking, leaving only the .plexcached stub (issues #189, #196).
+
+These tests pin the real configurations from both reports so the checks can't
+silently regress into missing them.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules['fcntl'] = MagicMock()
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.system_utils import check_cache_share_alignment, extract_unraid_share
+
+
+class TestExtractUnraidShare:
+    @pytest.mark.parametrize("path,expected", [
+        ("/mnt/user/Movies/Action/", "Movies"),
+        ("/mnt/user0/data/media/movies/", "data"),
+        ("/mnt/disk3/data/media/", "data"),
+        ("/mnt/disk12/Plex_Media/Videos/", "Plex_Media"),
+        ("/mnt/cache_downloads/Movies/", "Movies"),
+        ("/mnt/ssd_cache/plex/Cache/movies/", "plex"),
+        ("/mnt/user/Movies", "Movies"),          # no trailing slash
+        ("  /mnt/user/Movies/  ", "Movies"),      # surrounding whitespace
+        ("/mnt/user//Movies//Action/", "Movies"),  # duplicate separators
+    ])
+    def test_resolves_share(self, path, expected):
+        assert extract_unraid_share(path) == expected
+
+    @pytest.mark.parametrize("path", [
+        "/mnt/cache/",        # bare mount, no share segment
+        "/mnt/user/",
+        "/mnt/user",
+        "/mnt/",
+        "/movies/",           # container-relative fragment
+        "/srv/media/movies/",  # not an Unraid layout
+        "",
+        None,
+    ])
+    def test_returns_none_when_undeterminable(self, path):
+        assert extract_unraid_share(path) is None
+
+
+class TestReportedConfigurations:
+    """The exact mappings from #189 and #196, and configs known to be correct."""
+
+    def test_issue_196_current_config_is_flagged(self):
+        """Media in `data`, host cache path a bare container fragment."""
+        w = check_cache_share_alignment(
+            "/mnt/user/data/media/movies/", "/mnt/cache/movies/", "/movies/"
+        )
+        assert w is not None
+        assert w["kind"] == "cache_not_under_mnt"
+        assert w["real_share"] == "data"
+
+    def test_issue_189_current_config_is_flagged(self):
+        """Media in `Plex_Media`, cache pointed at the separate `plexdb` share."""
+        w = check_cache_share_alignment(
+            "/mnt/user/Plex_Media/Videos/TV Shows/",
+            "/mnt/cache/Videos/TV Shows/",
+            "/mnt/user/plexdb/Media Cache/Videos/TV Shows/",
+        )
+        assert w is not None
+        assert w["kind"] == "share_mismatch"
+        assert w["real_share"] == "Plex_Media"
+        assert w["cache_share"] == "plexdb"
+
+    def test_issue_189_after_fix_is_clean(self):
+        assert check_cache_share_alignment(
+            "/mnt/user/Plex_Media/Videos/TV Shows/",
+            "/mnt/cache/Plex_Media/Videos/TV Shows/",
+            "/mnt/plexdatabase/Plex_Media/Videos/TV Shows/",
+        ) is None
+
+    def test_issue_196_after_fix_is_clean(self):
+        assert check_cache_share_alignment(
+            "/mnt/user/data/media/movies/",
+            "/mnt/cache/data/media/movies/",
+            "/mnt/ssd_cache/data/media/movies/",
+        ) is None
+
+    def test_known_good_config_is_clean(self):
+        """A working two-tier setup: array-direct real path, pool host cache."""
+        assert check_cache_share_alignment(
+            "/mnt/user0/TV Shows/", "/mnt/cache/TV Shows/", "/mnt/cache_downloads/TV Shows/"
+        ) is None
+
+
+class TestMismatchDetection:
+    def test_different_shares_without_host_cache(self):
+        w = check_cache_share_alignment("/mnt/user/Movies/", "/mnt/cache/OtherShare/")
+        assert w["kind"] == "share_mismatch"
+        assert (w["real_share"], w["cache_share"]) == ("Movies", "OtherShare")
+
+    def test_same_share_across_tiers_is_clean(self):
+        assert check_cache_share_alignment("/mnt/user/Movies/", "/mnt/cache/Movies/") is None
+
+    def test_host_cache_path_wins_over_container_path(self):
+        """Docker remaps the container prefix, so the host path is authoritative."""
+        # Container path alone would look mismatched (Movies vs media)...
+        assert check_cache_share_alignment("/mnt/user/media/Movies/", "/mnt/cache/Movies/") is not None
+        # ...but the real host path agrees, so no warning.
+        assert check_cache_share_alignment(
+            "/mnt/user/media/Movies/", "/mnt/cache/Movies/", "/mnt/pool/media/Movies/"
+        ) is None
+
+    def test_message_names_both_shares(self):
+        w = check_cache_share_alignment("/mnt/user/Movies/", "/mnt/cache/Downloads/")
+        assert "Movies" in w["message"] and "Downloads" in w["message"]
+
+
+class TestStaysQuiet:
+    """The check is advisory. It must not fire on layouts it can't reason about."""
+
+    @pytest.mark.parametrize("real,cache,host", [
+        ("/srv/media/movies/", "/fast/movies/", None),   # non-Unraid layout
+        ("/mnt/user/Movies/", "", None),                  # no cache configured
+        ("", "/mnt/cache/Movies/", None),                 # no real path
+        ("/mnt/user/Movies/", "/mnt/cache/", None),       # bare cache mount
+    ])
+    def test_no_warning(self, real, cache, host):
+        assert check_cache_share_alignment(real, cache, host) is None
+
+    def test_non_mnt_real_path_skips_even_with_odd_cache(self):
+        """Anchored on the media path — if that isn't Unraid-shaped, stay silent."""
+        assert check_cache_share_alignment("/srv/media/", "/movies/", "/movies/") is None

--- a/tests/test_system_utils.py
+++ b/tests/test_system_utils.py
@@ -339,3 +339,31 @@ class TestCreateDirWithOwnership:
         assert mock_chown.call_args_list, "chown should be attempted"
         for call in mock_chown.call_args_list:
             assert call.args[1:] == (src_stat.st_uid, src_stat.st_gid)
+
+
+class TestFormatCacheAgeDayTier:
+    """The hour tier used to be terminal, so a 30-day-old item read "696 hr ago"."""
+
+    def test_boundary_at_24_hours(self):
+        from core.system_utils import format_cache_age
+        assert format_cache_age(datetime.now() - timedelta(hours=23, minutes=59)) == "23 hr ago"
+        assert "day" in format_cache_age(datetime.now() - timedelta(hours=24, minutes=1))
+
+    def test_singular_day(self):
+        from core.system_utils import format_cache_age
+        assert format_cache_age(datetime.now() - timedelta(hours=25)) == "1 day ago"
+
+    def test_plural_days(self):
+        from core.system_utils import format_cache_age
+        assert format_cache_age(datetime.now() - timedelta(days=3)) == "3 days ago"
+
+    def test_the_window_that_motivated_this(self):
+        from core.system_utils import format_cache_age
+        # Recently Added's widest window is 30 days (ALLOWED_DAYS).
+        assert format_cache_age(datetime.now() - timedelta(days=29)) == "29 days ago"
+
+    def test_shorter_tiers_are_unchanged(self):
+        from core.system_utils import format_cache_age
+        assert format_cache_age(datetime.now() - timedelta(seconds=5)) == "just now"
+        assert format_cache_age(datetime.now() - timedelta(minutes=5)) == "5 min ago"
+        assert format_cache_age(datetime.now() - timedelta(hours=2)) == "2 hr ago"

--- a/tests/test_template_syntax.py
+++ b/tests/test_template_syntax.py
@@ -1,0 +1,46 @@
+"""Every Jinja template under web/templates/ must parse.
+
+A syntax error in a template is invisible until someone loads the page that
+uses it — the CI py_compile step covers web/routers/ and web/services/, but
+nothing reaches the templates. Rendering each one is not practical (they need
+request context, globals and populated models), but parsing is: it catches the
+whole class of nesting and tag errors, which is what actually breaks here.
+
+The concrete case this was written for: a merge resolved a conflict correctly
+but also pulled in an adjacent, non-conflicting `{% endif %}`, leaving
+cache/partials/file_table.html with one more endif than if. Balanced by eye,
+unbalanced to Jinja.
+"""
+
+import pathlib
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+from jinja2.exceptions import TemplateSyntaxError
+
+TEMPLATE_ROOT = pathlib.Path(__file__).resolve().parent.parent / "web" / "templates"
+
+
+def _template_paths():
+    return sorted(TEMPLATE_ROOT.rglob("*.html"))
+
+
+def _template_ids():
+    return [p.relative_to(TEMPLATE_ROOT).as_posix() for p in _template_paths()]
+
+
+@pytest.mark.parametrize("template_path", _template_paths(), ids=_template_ids())
+def test_template_parses(template_path):
+    """The template is syntactically valid Jinja."""
+    relative = template_path.relative_to(TEMPLATE_ROOT).as_posix()
+    env = Environment(loader=FileSystemLoader(str(TEMPLATE_ROOT)))
+
+    try:
+        env.parse(template_path.read_text(encoding="utf-8"), filename=relative)
+    except TemplateSyntaxError as exc:
+        pytest.fail(f"{relative}:{exc.lineno} — {exc.message}")
+
+
+def test_template_root_is_populated():
+    """Guard the guard: an empty glob would make every check above vacuous."""
+    assert len(_template_paths()) > 50

--- a/tests/test_unprotected_grouping.py
+++ b/tests/test_unprotected_grouping.py
@@ -1,0 +1,97 @@
+"""Tests for the audit's unprotected-files grouping.
+
+This table pairs a video with its own sidecars for remediation, so it keys on
+*directory* rather than show — but it uses the same ordered-bucket rule from
+``core.media_grouping`` as every other grouped list, so these lock in the
+ordering and primary/children semantics.
+"""
+
+import pytest
+
+pytest.importorskip("web.services.maintenance_service")
+
+from web.services.maintenance_service import MaintenanceService, UnprotectedFile
+
+
+def _f(cache_path, size=100):
+    import os
+    return UnprotectedFile(
+        cache_path=cache_path,
+        filename=os.path.basename(cache_path),
+        size=size,
+        size_display=f"{size} B",
+        has_plexcached_backup=False,
+        backup_path=None,
+        has_array_duplicate=False,
+        array_path=None,
+        recommended_action="add_to_exclude",
+    )
+
+
+def _group(files):
+    return MaintenanceService._group_unprotected_by_directory(
+        MaintenanceService.__new__(MaintenanceService), files
+    )
+
+
+class TestGroupUnprotectedByDirectory:
+    def test_video_with_sidecars_becomes_one_group(self):
+        result = _group([
+            _f("/mnt/cache/Movies/Dune/Dune.mkv", 900),
+            _f("/mnt/cache/Movies/Dune/Dune.en.srt", 50),
+            _f("/mnt/cache/Movies/Dune/Dune.nfo", 50),
+        ])
+        assert len(result) == 1
+        assert result[0]["primary"].filename == "Dune.mkv"
+        assert [c.filename for c in result[0]["children"]] == ["Dune.en.srt", "Dune.nfo"]
+        assert result[0]["folder"] == "Dune"
+        assert result[0]["total_size_display"] == "1000 B"
+
+    def test_lone_video_is_not_grouped(self):
+        result = _group([_f("/mnt/cache/Movies/Dune/Dune.mkv")])
+        assert len(result) == 1
+        assert result[0]["children"] == []
+        assert result[0]["folder"] is None
+
+    def test_sidecars_without_video_group_under_folder(self):
+        result = _group([
+            _f("/mnt/cache/Movies/Dune/Dune.en.srt", 30),
+            _f("/mnt/cache/Movies/Dune/Dune.nfo", 20),
+        ])
+        assert len(result) == 1
+        assert result[0]["primary"].filename == "Dune.en.srt"
+        assert [c.filename for c in result[0]["children"]] == ["Dune.nfo"]
+        assert result[0]["folder"] == "Dune"
+
+    def test_separate_directories_stay_separate(self):
+        result = _group([
+            _f("/mnt/cache/Movies/Dune/Dune.mkv"),
+            _f("/mnt/cache/Movies/Dune/Dune.srt"),
+            _f("/mnt/cache/TV/Sugar/S01E01.mkv"),
+            _f("/mnt/cache/TV/Sugar/S01E01.srt"),
+        ])
+        assert len(result) == 2
+        assert [g["folder"] for g in result] == ["Dune", "Sugar"]
+
+    def test_directory_order_follows_first_seen_file(self):
+        # Interleaved input must not reorder the directories — a group anchors
+        # where its first file appeared.
+        result = _group([
+            _f("/mnt/cache/B/b.mkv"),
+            _f("/mnt/cache/A/a.mkv"),
+            _f("/mnt/cache/B/b.srt"),
+            _f("/mnt/cache/A/a.srt"),
+        ])
+        assert [g["folder"] for g in result] == ["B", "A"]
+
+    def test_two_videos_in_one_directory_keep_first_as_primary(self):
+        result = _group([
+            _f("/mnt/cache/TV/Sugar/S01E01.mkv"),
+            _f("/mnt/cache/TV/Sugar/S01E02.mkv"),
+        ])
+        assert len(result) == 1
+        assert result[0]["primary"].filename == "S01E01.mkv"
+        assert [c.filename for c in result[0]["children"]] == ["S01E02.mkv"]
+
+    def test_empty_input(self):
+        assert _group([]) == []

--- a/tests/test_untracked_grouping.py
+++ b/tests/test_untracked_grouping.py
@@ -1,4 +1,4 @@
-"""Tests for the audit's unprotected-files grouping.
+"""Tests for the audit's untracked-files grouping.
 
 This table pairs a video with its own sidecars for remediation, so it keys on
 *directory* rather than show — but it uses the same ordered-bucket rule from
@@ -10,12 +10,12 @@ import pytest
 
 pytest.importorskip("web.services.maintenance_service")
 
-from web.services.maintenance_service import MaintenanceService, UnprotectedFile
+from web.services.maintenance_service import MaintenanceService, UntrackedFile
 
 
 def _f(cache_path, size=100):
     import os
-    return UnprotectedFile(
+    return UntrackedFile(
         cache_path=cache_path,
         filename=os.path.basename(cache_path),
         size=size,
@@ -29,12 +29,12 @@ def _f(cache_path, size=100):
 
 
 def _group(files):
-    return MaintenanceService._group_unprotected_by_directory(
+    return MaintenanceService._group_untracked_by_directory(
         MaintenanceService.__new__(MaintenanceService), files
     )
 
 
-class TestGroupUnprotectedByDirectory:
+class TestGroupUntrackedByDirectory:
     def test_video_with_sidecars_becomes_one_group(self):
         result = _group([
             _f("/mnt/cache/Movies/Dune/Dune.mkv", 900),

--- a/tools/audit_cache.py
+++ b/tools/audit_cache.py
@@ -400,7 +400,7 @@ def add_to_exclude(dry_run=True):
     cache_files = get_cache_files()
     exclude_files = get_exclude_files()
     released_files = get_released_files()
-    # Released files are unprotected by design — re-protecting them here would
+    # Released files are left out of the exclude list by design — re-adding them would
     # silently undo the release and set up a release/re-protect oscillation.
     orphaned = cache_files - exclude_files - released_files
 
@@ -711,7 +711,7 @@ def main():
     print("=" * 80)
 
     if on_cache_not_in_exclude:
-        print(f"\n⚠️  WARNING: {len(on_cache_not_in_exclude)} files on cache are NOT protected!")
+        print(f"\n⚠️  WARNING: {len(on_cache_not_in_exclude)} files on cache are NOT tracked!")
         print("   Run the script to add them to exclude list, or sync them back to array.")
     else:
         print("\n✅ All cache files are properly tracked in exclude list.")
@@ -740,7 +740,7 @@ def main():
             print("  --sync-to-array --execute     Apply changes")
 
         if has_backup or no_backup:
-            print(f"\nTo protect all {len(on_cache_not_in_exclude)} unprotected files (add to exclude list):")
+            print(f"\nTo track all {len(on_cache_not_in_exclude)} untracked files (add to exclude list):")
             print("  --add-to-exclude           Dry run (preview)")
             print("  --add-to-exclude --execute    Apply changes")
 

--- a/web/config.py
+++ b/web/config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from fastapi.templating import Jinja2Templates
 
 from web import __version__
-from core.system_utils import SystemDetector
+from core.system_utils import SystemDetector, check_cache_share_alignment
 
 # Paths
 WEB_DIR = Path(__file__).parent
@@ -68,6 +68,21 @@ templates.env.globals["is_unraid"] = _detector.is_unraid
 templates.env.globals["is_docker"] = IS_DOCKER
 templates.env.globals["web_version"] = __version__
 templates.env.globals["product_version"] = PLEXCACHE_PRODUCT_VERSION
+
+# Share alignment check — exposed as a template global so every code path that
+# renders a mapping card gets it, rather than each route remembering to attach it.
+def _share_warning(mapping) -> dict:
+    """Return a share-alignment warning for a path mapping dict, or None."""
+    if not mapping:
+        return None
+    return check_cache_share_alignment(
+        mapping.get("real_path", ""),
+        mapping.get("cache_path", ""),
+        mapping.get("host_cache_path"),
+    )
+
+
+templates.env.globals["share_warning"] = _share_warning
 
 # Searchable Settings index — exposed as JSON for client-side search.
 # See web/settings_search_index.py for the source of truth. Module lives outside

--- a/web/config.py
+++ b/web/config.py
@@ -100,6 +100,13 @@ templates.env.globals["outcome_tooltip"] = _outcome_tooltip
 # by a trailing period before this was shared.
 templates.env.globals["protected_sentence"] = PROTECTED_SENTENCE
 
+# SxxEyy formatting, shared with the Python callers in pinned_service so a
+# template cannot fabricate an S00E00 for an episode whose numbering Plex did
+# not supply — and so a malformed index (which plexapi casts to NaN, not None)
+# cannot raise inside a format filter.
+from core.media_grouping import format_season_episode as _format_season_episode
+templates.env.globals["format_season_episode"] = _format_season_episode
+
 
 def get_time_format() -> str:
     """Read time_format from settings JSON. Returns '12h' or '24h' (default)."""

--- a/web/config.py
+++ b/web/config.py
@@ -93,8 +93,12 @@ templates.env.globals["settings_search_index_json"] = json.dumps(get_search_inde
 
 # Outcome vocabulary for Recently Added. Same reason as above for living outside
 # web/services/ — see web/outcome_vocabulary.py.
-from web.outcome_vocabulary import outcome_tooltip as _outcome_tooltip
+from web.outcome_vocabulary import outcome_tooltip as _outcome_tooltip, PROTECTED_SENTENCE
 templates.env.globals["outcome_tooltip"] = _outcome_tooltip
+# The reserved "protected from eviction" sentence, so the pages that assert it
+# can't drift apart — the Cached Files badge and Recently Added already differed
+# by a trailing period before this was shared.
+templates.env.globals["protected_sentence"] = PROTECTED_SENTENCE
 
 
 def get_time_format() -> str:

--- a/web/config.py
+++ b/web/config.py
@@ -91,6 +91,11 @@ templates.env.globals["share_warning"] = _share_warning
 from web.settings_search_index import get_search_index
 templates.env.globals["settings_search_index_json"] = json.dumps(get_search_index())
 
+# Outcome vocabulary for Recently Added. Same reason as above for living outside
+# web/services/ — see web/outcome_vocabulary.py.
+from web.outcome_vocabulary import outcome_tooltip as _outcome_tooltip
+templates.env.globals["outcome_tooltip"] = _outcome_tooltip
+
 
 def get_time_format() -> str:
     """Read time_format from settings JSON. Returns '12h' or '24h' (default)."""

--- a/web/main.py
+++ b/web/main.py
@@ -12,7 +12,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from web import __version__
 from web.config import templates, STATIC_DIR, PROJECT_ROOT, CONFIG_DIR, SETTINGS_FILE
-from web.routers import dashboard, cache, settings, operations, logs, api, maintenance, setup, auth, pinned
+from web.routers import dashboard, cache, settings, operations, logs, api, maintenance, setup, auth, pinned, recently_added
 from web.services import get_scheduler_service, get_settings_service
 from web.services.web_cache import init_web_cache, get_web_cache_service
 import os
@@ -210,6 +210,7 @@ app.include_router(maintenance.router, prefix="/maintenance", tags=["maintenance
 app.include_router(setup.router, tags=["setup"])
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(pinned.router, prefix="/api/pinned", tags=["pinned"])
+app.include_router(recently_added.router, prefix="/recently-added", tags=["recently-added"])
 
 
 # Middleware to redirect to setup wizard if not configured

--- a/web/outcome_vocabulary.py
+++ b/web/outcome_vocabulary.py
@@ -30,10 +30,21 @@ class Outcome:
     tooltip: str
 
 
-# Reserved sentence. The word "Protected" is deliberately confined to states
-# where a pin genuinely exempts the file from eviction — it is not used for
-# OnDeck/Watchlist, which only add +15 to the priority score
-# (core/file_operations.py) rather than exempting anything.
+# Reserved sentence. The word "Protected" is confined to states where a pin
+# genuinely exempts the file from eviction — never for OnDeck/Watchlist, which
+# only add +15 to the priority score (core/file_operations.py) rather than
+# exempting anything.
+#
+# Two things this sentence must NOT be trimmed back to:
+#   * "only from eviction" would be too narrow. A pin also short-circuits the
+#     watched move-back to array (core/file_operations.py:3814), and therefore
+#     also blocks release-to-mover, so the move-back clause belongs in every
+#     copy of this text.
+#   * eviction exemption is NOT the same as mover exemption. Pinning writes no
+#     exclude-file line (PinnedService.toggle_pin never touches it), so a file
+#     pinned while already on cache is exempt from PlexCache eviction while the
+#     Unraid mover can still relocate it, until a run adds the exclude entry.
+#     That gap is its own outcome (`held_mover_gap`) rather than a footnote.
 _PROTECTED_SENTENCE = "Pinned — protected from eviction."
 
 # Ordered weakest-first. `stays_on_array` is deliberately outside the ranking
@@ -65,27 +76,50 @@ OUTCOMES: Dict[str, Outcome] = {o.key: o for o in (
     Outcome(
         key="returns_when_done", label="Returns when watched", badge="badge-info",
         icon="clock", tier=4,
-        tooltip=("Held on cache while it's on OnDeck or a Watchlist. PlexCache "
-                 "moves it back once it drops off, after the retention hold. An "
-                 "active playback session or a hard link delays that further."),
+        tooltip=("On OnDeck or a Watchlist, so PlexCache defers moving it back "
+                 "to the array — that's a deferral, not an eviction exemption; "
+                 "it can still be evicted if the pool runs short. Once it drops "
+                 "off, the retention hold, an active playback session or a hard "
+                 "link can each delay the move further."),
     ),
+    # Deliberately NOT labelled "Stays on cache": watched_move only governs the
+    # move-back to array. Eviction is a separate path with no watched_move
+    # awareness, so this file can still be evicted, and a "stays" promise would
+    # be false. It also collided with `held`'s label at group level, where the
+    # badge colour that distinguished them is gone.
     Outcome(
-        key="held_by_setting", label="Stays on cache", badge="badge-info",
+        key="held_by_setting", label="Not moved back", badge="badge-info",
         icon="sliders-horizontal", tier=5,
         tooltip=("Move Watched to Array is off in Settings → Cache, so PlexCache "
-                 "never moves anything back. This stays on the cache pool."),
+                 "never moves anything back to the array. Eviction is separate — "
+                 "if the cache pool runs short this can still be evicted."),
     ),
     Outcome(
         key="arriving", label="Pinned, not on cache yet", badge="badge-pinned",
         icon="arrow-down-to-line", tier=6,
-        tooltip=(_PROTECTED_SENTENCE + " It isn't on the cache pool yet — the "
-                 "next PlexCache run copies it across."),
+        # No eviction claim: there is nothing on cache to evict, so the reserved
+        # sentence would be vacuous here. The copy promise is hedged because
+        # _apply_cache_limit has no pin awareness and can skip a pinned file
+        # when the pool is full.
+        tooltip=("Pinned. PlexCache copies it to cache on the next run, then "
+                 "keeps it there. If the pool has no room that run, it waits and "
+                 "retries — Cache Pinned Now copies it immediately, ignoring "
+                 "your cache limits."),
+    ),
+    Outcome(
+        key="held_mover_gap", label="Stays on cache", badge="badge-pinned",
+        icon="pin", tier=7,
+        tooltip=(_PROTECTED_SENTENCE + " PlexCache won't move it back to the "
+                 "array either. It isn't in the Unraid mover's exclude list yet, "
+                 "so the mover could still relocate it — the next PlexCache run "
+                 "fixes that."),
     ),
     Outcome(
         key="held", label="Stays on cache", badge="badge-pinned",
-        icon="pin", tier=7,
-        tooltip=(_PROTECTED_SENTENCE + " PlexCache also keeps it out of the "
-                 "Unraid mover's reach and never moves it back, until you unpin."),
+        icon="pin", tier=8,
+        tooltip=(_PROTECTED_SENTENCE + " PlexCache won't move it back to the "
+                 "array, and the Unraid mover is told to skip it. Both hold "
+                 "until you unpin."),
     ),
     Outcome(
         key="stays_on_array", label="Not on cache", badge="badge-muted",

--- a/web/outcome_vocabulary.py
+++ b/web/outcome_vocabulary.py
@@ -59,28 +59,29 @@ OUTCOMES: Dict[str, Outcome] = {o.key: o for o in (
         key="unmapped", label="Unmapped", badge="badge-muted",
         icon="help-circle", tier=1,
         tooltip=("No path mapping covers this library, so PlexCache can't tell "
-                 "where the file lives — check Settings → Libraries."),
+                 "where the file lives. Check Settings → Libraries."),
     ),
     Outcome(
         key="mover_decides", label="Mover's call", badge="badge-released",
         icon="send", tier=2,
-        tooltip=("PlexCache isn't holding this back from the Unraid mover. The "
-                 "mover relocates it on its own schedule, not ours."),
+        tooltip=("PlexCache isn't holding this back. The Unraid mover relocates "
+                 "it on its own schedule."),
     ),
     Outcome(
         key="moves_back", label="Moves to array", badge="badge-muted",
         icon="arrow-down", tier=3,
-        tooltip=("No longer on OnDeck or a Watchlist, so PlexCache moves it "
-                 "back to the array."),
+        tooltip=("No longer on OnDeck or a Watchlist, so PlexCache moves it back "
+                 "to the array."),
     ),
     Outcome(
         key="returns_when_done", label="Returns when watched", badge="badge-info",
         icon="clock", tier=4,
-        tooltip=("On OnDeck or a Watchlist, so PlexCache defers moving it back "
-                 "to the array — that's a deferral, not an eviction exemption; "
-                 "it can still be evicted if the pool runs short. Once it drops "
-                 "off, the retention hold, an active playback session or a hard "
-                 "link can each delay the move further."),
+        # The last sentence is load-bearing, not padding: OnDeck/Watchlist only
+        # add +15 to the priority score, so this is a move-back deferral and not
+        # the eviction exemption the label could be read as.
+        tooltip=("Held while it's on OnDeck or a Watchlist. PlexCache moves it "
+                 "back once it drops off. This defers the move — it doesn't "
+                 "prevent eviction."),
     ),
     # Deliberately NOT labelled "Stays on cache": watched_move only governs the
     # move-back to array. Eviction is a separate path with no watched_move
@@ -90,9 +91,8 @@ OUTCOMES: Dict[str, Outcome] = {o.key: o for o in (
     Outcome(
         key="held_by_setting", label="Not moved back", badge="badge-info",
         icon="sliders-horizontal", tier=5,
-        tooltip=("Move Watched to Array is off in Settings → Cache, so PlexCache "
-                 "never moves anything back to the array. Eviction is separate — "
-                 "if the cache pool runs short this can still be evicted."),
+        tooltip=("Move Watched to Array is off, so PlexCache never moves "
+                 "anything back. It can still be evicted if the pool runs short."),
     ),
     Outcome(
         key="arriving", label="Pinned, not on cache yet", badge="badge-pinned",
@@ -101,31 +101,27 @@ OUTCOMES: Dict[str, Outcome] = {o.key: o for o in (
         # sentence would be vacuous here. The copy promise is hedged because
         # _apply_cache_limit has no pin awareness and can skip a pinned file
         # when the pool is full.
-        tooltip=("Pinned. PlexCache copies it to cache on the next run, then "
-                 "keeps it there. If the pool has no room that run, it waits and "
-                 "retries — Cache Pinned Now copies it immediately, ignoring "
-                 "your cache limits."),
+        tooltip=("Pinned, but not on cache yet. The next run copies it across. "
+                 "Cache Pinned Now copies it immediately, ignoring cache limits."),
     ),
     Outcome(
         key="held_mover_gap", label="Stays on cache", badge="badge-pinned",
         icon="pin", tier=7,
         tooltip=(_PROTECTED_SENTENCE + " PlexCache won't move it back to the "
-                 "array either. It isn't in the Unraid mover's exclude list yet, "
-                 "so the mover could still relocate it — the next PlexCache run "
-                 "fixes that."),
+                 "array either. Not in the Unraid mover's exclude list yet, so "
+                 "the mover could still relocate it — the next run fixes that."),
     ),
     Outcome(
         key="held", label="Stays on cache", badge="badge-pinned",
         icon="pin", tier=8,
         tooltip=(_PROTECTED_SENTENCE + " PlexCache won't move it back to the "
-                 "array, and the Unraid mover is told to skip it. Both hold "
-                 "until you unpin."),
+                 "array, and the Unraid mover is told to skip it."),
     ),
     Outcome(
         key="stays_on_array", label="Not on cache", badge="badge-muted",
         icon="server", tier=99,
-        tooltip=("On the spinning array. PlexCache pulls it to cache only if it "
-                 "lands on OnDeck or a Watchlist, or if you pin it."),
+        tooltip=("On the array. PlexCache caches it only if it lands on OnDeck "
+                 "or a Watchlist, or you pin it."),
     ),
 )}
 

--- a/web/outcome_vocabulary.py
+++ b/web/outcome_vocabulary.py
@@ -76,12 +76,8 @@ OUTCOMES: Dict[str, Outcome] = {o.key: o for o in (
     Outcome(
         key="returns_when_done", label="Returns when watched", badge="badge-info",
         icon="clock", tier=4,
-        # The last sentence is load-bearing, not padding: OnDeck/Watchlist only
-        # add +15 to the priority score, so this is a move-back deferral and not
-        # the eviction exemption the label could be read as.
         tooltip=("Held while it's on OnDeck or a Watchlist. PlexCache moves it "
-                 "back once it drops off. This defers the move — it doesn't "
-                 "prevent eviction."),
+                 "back once it drops off."),
     ),
     # Deliberately NOT labelled "Stays on cache": watched_move only governs the
     # move-back to array. Eviction is a separate path with no watched_move
@@ -98,18 +94,17 @@ OUTCOMES: Dict[str, Outcome] = {o.key: o for o in (
         key="arriving", label="Pinned, not on cache yet", badge="badge-pinned",
         icon="arrow-down-to-line", tier=6,
         # No eviction claim: there is nothing on cache to evict, so the reserved
-        # sentence would be vacuous here. The copy promise is hedged because
+        # sentence would be vacuous here. No "immediately" promise either —
         # _apply_cache_limit has no pin awareness and can skip a pinned file
-        # when the pool is full.
-        tooltip=("Pinned, but not on cache yet. The next run copies it across. "
-                 "Cache Pinned Now copies it immediately, ignoring cache limits."),
+        # when the pool is full, so the copy is not guaranteed on any one run.
+        tooltip=("Pinned, but not on cache yet. The next run copies it across."),
     ),
     Outcome(
         key="held_mover_gap", label="Stays on cache", badge="badge-pinned",
         icon="pin", tier=7,
         tooltip=(PROTECTED_SENTENCE + " PlexCache won't move it back to the "
                  "array either. Not in the Unraid mover's exclude list yet, so "
-                 "the mover could still relocate it — the next run fixes that."),
+                 "the mover could still relocate it."),
     ),
     Outcome(
         key="held", label="Stays on cache", badge="badge-pinned",

--- a/web/outcome_vocabulary.py
+++ b/web/outcome_vocabulary.py
@@ -1,0 +1,102 @@
+"""Outcome vocabulary for the Recently Added view.
+
+Names each row by *what happens to the file next* rather than by a state noun,
+because that is the question the page exists to answer ("will this still be on
+fast storage tomorrow?"). A state noun can assert protection the code does not
+actually provide; an outcome cannot.
+
+Lives outside ``web/services/`` deliberately: ``web.config`` imports it as a
+template global, and routing it through the services package would trigger a
+circular import via ``cache_service`` -> ``web.config``. Same reason
+``web/settings_search_index.py`` sits here.
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """One row state, named by what happens to the file next.
+
+    ``tier`` orders states weakest-first for the group-header reduction: a show
+    group must never look safer than its worst episode.
+    """
+    key: str
+    label: str
+    badge: str        # CSS class from plex-theme.css
+    icon: str         # lucide icon name ("" for none)
+    tier: int
+    tooltip: str
+
+
+# Reserved sentence. The word "Protected" is deliberately confined to states
+# where a pin genuinely exempts the file from eviction — it is not used for
+# OnDeck/Watchlist, which only add +15 to the priority score
+# (core/file_operations.py) rather than exempting anything.
+_PROTECTED_SENTENCE = "Pinned — protected from eviction."
+
+# Ordered weakest-first. `stays_on_array` is deliberately outside the ranking
+# (see _group_outcome): a file that never arrived on cache cannot leave it.
+OUTCOMES: Dict[str, Outcome] = {o.key: o for o in (
+    Outcome(
+        key="pin_unknown", label="Pin state unknown", badge="badge-muted",
+        icon="", tier=0,
+        tooltip="Couldn't check pins — Plex didn't answer. Refresh to retry.",
+    ),
+    Outcome(
+        key="unmapped", label="Unmapped", badge="badge-muted",
+        icon="help-circle", tier=1,
+        tooltip=("No path mapping covers this library, so PlexCache can't tell "
+                 "where the file lives — check Settings → Libraries."),
+    ),
+    Outcome(
+        key="mover_decides", label="Mover's call", badge="badge-released",
+        icon="send", tier=2,
+        tooltip=("PlexCache isn't holding this back from the Unraid mover. The "
+                 "mover relocates it on its own schedule, not ours."),
+    ),
+    Outcome(
+        key="moves_back", label="Moves to array", badge="badge-muted",
+        icon="arrow-down", tier=3,
+        tooltip=("No longer on OnDeck or a Watchlist, so PlexCache moves it "
+                 "back to the array."),
+    ),
+    Outcome(
+        key="returns_when_done", label="Returns when watched", badge="badge-info",
+        icon="clock", tier=4,
+        tooltip=("Held on cache while it's on OnDeck or a Watchlist. PlexCache "
+                 "moves it back once it drops off, after the retention hold. An "
+                 "active playback session or a hard link delays that further."),
+    ),
+    Outcome(
+        key="held_by_setting", label="Stays on cache", badge="badge-info",
+        icon="sliders-horizontal", tier=5,
+        tooltip=("Move Watched to Array is off in Settings → Cache, so PlexCache "
+                 "never moves anything back. This stays on the cache pool."),
+    ),
+    Outcome(
+        key="arriving", label="Pinned, not on cache yet", badge="badge-pinned",
+        icon="arrow-down-to-line", tier=6,
+        tooltip=(_PROTECTED_SENTENCE + " It isn't on the cache pool yet — the "
+                 "next PlexCache run copies it across."),
+    ),
+    Outcome(
+        key="held", label="Stays on cache", badge="badge-pinned",
+        icon="pin", tier=7,
+        tooltip=(_PROTECTED_SENTENCE + " PlexCache also keeps it out of the "
+                 "Unraid mover's reach and never moves it back, until you unpin."),
+    ),
+    Outcome(
+        key="stays_on_array", label="Not on cache", badge="badge-muted",
+        icon="server", tier=99,
+        tooltip=("On the spinning array. PlexCache pulls it to cache only if it "
+                 "lands on OnDeck or a Watchlist, or if you pin it."),
+    ),
+)}
+
+
+def outcome_tooltip(key: str) -> str:
+    """Tooltip for an outcome key (empty string when unrecognised)."""
+    entry = OUTCOMES.get(key)
+    return entry.tooltip if entry else ""

--- a/web/outcome_vocabulary.py
+++ b/web/outcome_vocabulary.py
@@ -45,7 +45,7 @@ class Outcome:
 #     pinned while already on cache is exempt from PlexCache eviction while the
 #     Unraid mover can still relocate it, until a run adds the exclude entry.
 #     That gap is its own outcome (`held_mover_gap`) rather than a footnote.
-_PROTECTED_SENTENCE = "Pinned — protected from eviction."
+PROTECTED_SENTENCE = "Pinned — protected from eviction."
 
 # Ordered weakest-first. `stays_on_array` is deliberately outside the ranking
 # (see _group_outcome): a file that never arrived on cache cannot leave it.
@@ -107,14 +107,14 @@ OUTCOMES: Dict[str, Outcome] = {o.key: o for o in (
     Outcome(
         key="held_mover_gap", label="Stays on cache", badge="badge-pinned",
         icon="pin", tier=7,
-        tooltip=(_PROTECTED_SENTENCE + " PlexCache won't move it back to the "
+        tooltip=(PROTECTED_SENTENCE + " PlexCache won't move it back to the "
                  "array either. Not in the Unraid mover's exclude list yet, so "
                  "the mover could still relocate it — the next run fixes that."),
     ),
     Outcome(
         key="held", label="Stays on cache", badge="badge-pinned",
         icon="pin", tier=8,
-        tooltip=(_PROTECTED_SENTENCE + " PlexCache won't move it back to the "
+        tooltip=(PROTECTED_SENTENCE + " PlexCache won't move it back to the "
                  "array, and the Unraid mover is told to skip it."),
     ),
     Outcome(

--- a/web/routers/recently_added.py
+++ b/web/routers/recently_added.py
@@ -1,0 +1,117 @@
+"""Recently Added routes.
+
+A visibility view (issue #174): surfaces recently-added Plex media and where
+each item physically lives (cache vs array). It does NOT cache anything itself —
+caching happens through the existing Watchlist/OnDeck pipeline or an explicit
+Pin (reuses ``/api/pinned/toggle``).
+
+* ``GET /recently-added``        — full page shell (lazy-loads the list partial)
+* ``GET /recently-added/list``   — HTMX partial: stat cards + filter bar + table
+* ``GET /recently-added/widget`` — compact dashboard card
+"""
+
+import logging
+
+from fastapi import APIRouter, Request, Query
+from fastapi.responses import HTMLResponse
+
+from web.config import templates
+from web.services import get_recently_added_service, get_settings_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Allowed "Added Within" windows (days). Mirrors the filter dropdown.
+ALLOWED_DAYS = (1, 7, 30)
+DEFAULT_DAYS = 7
+DEFAULT_MAX_ITEMS = 100
+
+
+def _resolve_days(requested: int) -> int:
+    """Clamp an arbitrary days value to an allowed window."""
+    return requested if requested in ALLOWED_DAYS else DEFAULT_DAYS
+
+
+def _settings_defaults():
+    """Read display defaults from settings, falling back to module defaults."""
+    try:
+        settings = get_settings_service().get_all()
+    except Exception:
+        settings = {}
+    days = settings.get("recently_added_days", DEFAULT_DAYS)
+    max_items = settings.get("recently_added_max_items", DEFAULT_MAX_ITEMS)
+    try:
+        days = _resolve_days(int(days))
+    except (TypeError, ValueError):
+        days = DEFAULT_DAYS
+    try:
+        max_items = max(1, min(int(max_items), 500))
+    except (TypeError, ValueError):
+        max_items = DEFAULT_MAX_ITEMS
+    return days, max_items
+
+
+@router.get("/", response_class=HTMLResponse)
+def recently_added_page(request: Request):
+    """Full Recently Added page (the table itself lazy-loads via HTMX)."""
+    default_days, _ = _settings_defaults()
+    return templates.TemplateResponse(
+        request,
+        "recently_added/index.html",
+        {
+            "page_title": "Recently Added",
+            "default_days": default_days,
+            "allowed_days": ALLOWED_DAYS,
+        },
+    )
+
+
+@router.get("/list", response_class=HTMLResponse)
+def recently_added_list(
+    request: Request,
+    days: int = Query(None, description="Added-within window in days"),
+):
+    """HTMX partial: stat cards + filter bar + table for the chosen window."""
+    default_days, max_items = _settings_defaults()
+    days = _resolve_days(days) if days is not None else default_days
+
+    service = get_recently_added_service()
+    result = service.get_recently_added(days=days, max_items=max_items)
+
+    # Distinct library titles (for the Library filter dropdown).
+    libraries = sorted({r.library_title for r in result["rows"] if r.library_title})
+
+    return templates.TemplateResponse(
+        request,
+        "recently_added/partials/list.html",
+        {
+            "available": result["available"],
+            "error": result["error"],
+            "rows": result["rows"],
+            "summary": result["summary"],
+            "libraries": libraries,
+            "days": days,
+            "allowed_days": ALLOWED_DAYS,
+        },
+    )
+
+
+@router.get("/widget", response_class=HTMLResponse)
+def recently_added_widget(request: Request):
+    """Compact dashboard card: counts + the few most recent titles."""
+    default_days, max_items = _settings_defaults()
+    service = get_recently_added_service()
+    result = service.get_recently_added(days=default_days, max_items=max_items)
+
+    return templates.TemplateResponse(
+        request,
+        "recently_added/partials/widget.html",
+        {
+            "available": result["available"],
+            "error": result["error"],
+            "summary": result["summary"],
+            "rows": result["rows"][:5],
+            "days": default_days,
+        },
+    )

--- a/web/routers/recently_added.py
+++ b/web/routers/recently_added.py
@@ -25,7 +25,11 @@ router = APIRouter()
 # Allowed "Added Within" windows (days). Mirrors the filter dropdown.
 ALLOWED_DAYS = (1, 7, 30)
 DEFAULT_DAYS = 7
-DEFAULT_MAX_ITEMS = 100
+# Counts individual media files. TV episodes are collapsed into per-show groups
+# for display, but each episode file still consumes one slot here — so keep the
+# cap generous enough that recent movies aren't crowded out by a burst of
+# episodes. Users with very large libraries can raise it in Settings (up to 500).
+DEFAULT_MAX_ITEMS = 250
 
 
 def _resolve_days(requested: int) -> int:
@@ -96,6 +100,10 @@ def recently_added_list(
             "libraries": libraries,
             "days": days,
             "allowed_days": ALLOWED_DAYS,
+            "max_items": max_items,
+            # The fetch caps at max_items (newest first); if we hit it, older
+            # media is hidden — surface that rather than silently truncating.
+            "capped": result["summary"].get("total", 0) >= max_items,
         },
     )
 

--- a/web/routers/recently_added.py
+++ b/web/routers/recently_added.py
@@ -81,6 +81,8 @@ def recently_added_list(
 
     # Distinct library titles (for the Library filter dropdown).
     libraries = sorted({r.library_title for r in result["rows"] if r.library_title})
+    # Collapse multi-episode TV runs into expandable show groups.
+    groups = service.group_rows_for_display(result["rows"])
 
     return templates.TemplateResponse(
         request,
@@ -89,6 +91,7 @@ def recently_added_list(
             "available": result["available"],
             "error": result["error"],
             "rows": result["rows"],
+            "groups": groups,
             "summary": result["summary"],
             "libraries": libraries,
             "days": days,

--- a/web/routers/recently_added.py
+++ b/web/routers/recently_added.py
@@ -30,6 +30,9 @@ DEFAULT_DAYS = 7
 # cap generous enough that recent movies aren't crowded out by a burst of
 # episodes. Users with very large libraries can raise it in Settings (up to 500).
 DEFAULT_MAX_ITEMS = 250
+# Display rows on the compact dashboard card. Counted *after* grouping, so a
+# six-episode show spends one slot rather than six.
+WIDGET_ROWS = 5
 
 
 def _resolve_days(requested: int) -> int:
@@ -115,6 +118,10 @@ def recently_added_widget(request: Request):
     service = get_recently_added_service()
     result = service.get_recently_added(days=default_days, max_items=max_items)
 
+    # Same grouping as the full page — collapse first, then take the top rows,
+    # so a multi-episode show doesn't crowd everything else off the card.
+    groups = service.group_rows_for_display(result["rows"])
+
     return templates.TemplateResponse(
         request,
         "recently_added/partials/widget.html",
@@ -122,7 +129,7 @@ def recently_added_widget(request: Request):
             "available": result["available"],
             "error": result["error"],
             "summary": result["summary"],
-            "rows": result["rows"][:5],
+            "groups": groups[:WIDGET_ROWS],
             "days": default_days,
         },
     )

--- a/web/routers/recently_added.py
+++ b/web/routers/recently_added.py
@@ -104,6 +104,9 @@ def recently_added_list(
             "days": days,
             "allowed_days": ALLOWED_DAYS,
             "max_items": max_items,
+            # Libraries Plex refused to list. Their rows are missing from the
+            # table, the counts and the filter above, so the page has to say so.
+            "unreadable_libraries": result.get("unreadable_libraries") or [],
             # The fetch caps at max_items (newest first); if we hit it, older
             # media is hidden — surface that rather than silently truncating.
             "capped": result["summary"].get("total", 0) >= max_items,
@@ -131,5 +134,6 @@ def recently_added_widget(request: Request):
             "summary": result["summary"],
             "groups": groups[:WIDGET_ROWS],
             "days": default_days,
+            "unreadable_libraries": result.get("unreadable_libraries") or [],
         },
     )

--- a/web/services/__init__.py
+++ b/web/services/__init__.py
@@ -19,6 +19,11 @@ from web.services.maintenance_runner import (
 )
 from web.services.import_service import ImportService, ImportSummary, get_import_service
 from web.services.pinned_service import PinnedService, get_pinned_service
+from web.services.recently_added_service import (
+    RecentlyAddedService,
+    RecentlyAddedRow,
+    get_recently_added_service,
+)
 
 __all__ = [
     "CacheService",
@@ -50,4 +55,7 @@ __all__ = [
     "get_import_service",
     "PinnedService",
     "get_pinned_service",
+    "RecentlyAddedService",
+    "RecentlyAddedRow",
+    "get_recently_added_service",
 ]

--- a/web/services/__init__.py
+++ b/web/services/__init__.py
@@ -7,7 +7,7 @@ from web.services.scheduler_service import SchedulerService, ScheduleConfig, get
 from web.services.maintenance_service import (
     MaintenanceService,
     AuditResults,
-    UnprotectedFile,
+    UntrackedFile,
     OrphanedBackup,
     DuplicateFile,
     ActionResult,
@@ -39,7 +39,7 @@ __all__ = [
     "get_scheduler_service",
     "MaintenanceService",
     "AuditResults",
-    "UnprotectedFile",
+    "UntrackedFile",
     "OrphanedBackup",
     "DuplicateFile",
     "ActionResult",

--- a/web/services/maintenance_service.py
+++ b/web/services/maintenance_service.py
@@ -16,6 +16,7 @@ from typing import Callable, Dict, List, Optional, Set, Any, Tuple
 from web.config import DATA_DIR, CONFIG_DIR, SETTINGS_FILE
 from core.system_utils import get_array_direct_path, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file, create_dir_with_ownership, sweep_empty_folders
 from core.file_operations import PLEXCACHED_EXTENSION, VIDEO_EXTENSIONS, SUBTITLE_EXTENSIONS, MEDIA_EXTENSIONS
+from core.media_grouping import group_ordered
 
 
 def _strip_plexcached(path: str) -> str:
@@ -541,15 +542,17 @@ class MaintenanceService:
         return None
 
     def _group_unprotected_by_directory(self, files: List[UnprotectedFile]) -> List[dict]:
-        """Group unprotected files by directory, with video as primary and sidecars as children."""
-        from collections import OrderedDict
-        groups: OrderedDict[str, List[UnprotectedFile]] = OrderedDict()
-        for f in files:
-            directory = os.path.dirname(f.cache_path)
-            groups.setdefault(directory, []).append(f)
+        """Group unprotected files by directory, with video as primary and sidecars as children.
 
+        Keys on directory rather than show — this table pairs a video with its
+        own sidecars for remediation, not episodes with each other — but the
+        bucketing itself is the app-wide rule from ``core.media_grouping``, so
+        ordering behaves the same as every other grouped list.
+        """
         result = []
-        for directory, dir_files in groups.items():
+        for directory, dir_files in group_ordered(
+            files, lambda f: os.path.dirname(f.cache_path)
+        ):
             # Find the video file (if any) to use as primary
             video = None
             children = []

--- a/web/services/maintenance_service.py
+++ b/web/services/maintenance_service.py
@@ -39,7 +39,7 @@ def _strip_plexcached(path: str) -> str:
 
 
 @dataclass
-class UnprotectedFile:
+class UntrackedFile:
     """A cache file not in the exclude list (at risk from Unraid mover)"""
     cache_path: str
     filename: str
@@ -102,10 +102,14 @@ class AuditResults:
     cache_file_count: int
     exclude_entry_count: int
     timestamp_entry_count: int
+    # Exclude entries whose file is actually on cache. The stat card renders
+    # "N of M on cache", and exclude_entry_count includes stale lines for files
+    # that are gone — which made N exceed M and render impossible values.
+    excluded_on_cache_count: int = 0
 
     # Issues
-    unprotected_files: List[UnprotectedFile] = field(default_factory=list)
-    grouped_unprotected: List[dict] = field(default_factory=list)  # Grouped by directory
+    untracked_files: List[UntrackedFile] = field(default_factory=list)
+    grouped_untracked: List[dict] = field(default_factory=list)  # Grouped by directory
     orphaned_plexcached: List[OrphanedBackup] = field(default_factory=list)
     extensionless_files: List[ExtensionlessFile] = field(default_factory=list)
     stale_exclude_entries: List[str] = field(default_factory=list)
@@ -113,7 +117,7 @@ class AuditResults:
     duplicates: List[DuplicateFile] = field(default_factory=list)
     # Pinned cache files missing from the exclude list — would be eaten by the
     # Unraid mover on its next run. User declared these always-cached, so an
-    # unprotected pinned file is a user-visible contract violation, not just
+    # pinned file missing from the exclude list is a user-visible contract violation, not just
     # "untracked". Next run restores protection automatically.
     pinned_missing_from_exclude: List[str] = field(default_factory=list)
 
@@ -249,7 +253,7 @@ class MaintenanceService:
         Used as a safety net in the cleanup actions so a transiently-missing
         pinned file is never dropped from the exclude list or timestamps.
         Failure returns an empty set — the cleanups fall back to their
-        original (unprotected) behavior rather than aborting.
+        original (unfiltered) behavior rather than aborting.
         """
         try:
             from web.services import get_pinned_service
@@ -497,7 +501,7 @@ class MaintenanceService:
 
         A released file is deliberately absent from the exclude list: PlexCache
         handed relocation to the mover and stopped protecting it, without
-        moving any bytes. So it is neither an unprotected file that needs
+        moving any bytes. So it is neither an untracked file that needs
         fixing nor — once the mover finally takes it — a stale timestamp entry.
         Treating it as either turns the feature working correctly into a
         recurring health warning.
@@ -541,8 +545,8 @@ class MaintenanceService:
                 return array_file.replace(array_dir, cache_dirs[i], 1)
         return None
 
-    def _group_unprotected_by_directory(self, files: List[UnprotectedFile]) -> List[dict]:
-        """Group unprotected files by directory, with video as primary and sidecars as children.
+    def _group_untracked_by_directory(self, files: List[UntrackedFile]) -> List[dict]:
+        """Group untracked files by directory, with video as primary and sidecars as children.
 
         Keys on directory rather than show — this table pairs a video with its
         own sidecars for remediation, not episodes with each other — but the
@@ -639,7 +643,8 @@ class MaintenanceService:
         results = AuditResults(
             cache_file_count=len(cache_files),
             exclude_entry_count=len(exclude_files),
-            timestamp_entry_count=len(timestamp_files)
+            timestamp_entry_count=len(timestamp_files),
+            excluded_on_cache_count=len(exclude_files & cache_files),
         )
 
         # Walk the array exactly once: collects orphaned/extensionless files and
@@ -656,7 +661,7 @@ class MaintenanceService:
         # Cutoff for "invalid" timestamps - before year 2000 or in the future
         min_valid_date = datetime(2000, 1, 1)
 
-        # Single pass over cache files: detect unprotected + duplicate in one loop.
+        # Single pass over cache files: detect untracked + duplicate in one loop.
         phase_start = time.monotonic()
         for cache_path in cache_files:
             array_path = self._cache_to_array_path(cache_path)
@@ -678,8 +683,8 @@ class MaintenanceService:
                     size_display=format_bytes(dup_size)
                 ))
 
-            # Unprotected: on cache but not in exclude list. Released files are
-            # unprotected on purpose — flagging them would recommend
+            # Untracked: on cache but not in exclude list. Released files are
+            # untracked on purpose — flagging them would recommend
             # sync_to_array (the exact array write release avoids) and let the
             # bulk "Add to Exclude" action silently re-protect them.
             if cache_path in exclude_files or cache_path in released_files:
@@ -716,7 +721,7 @@ class MaintenanceService:
 
             recommended = "fix_with_backup" if (has_backup or has_dup) else "sync_to_array"
 
-            results.unprotected_files.append(UnprotectedFile(
+            results.untracked_files.append(UntrackedFile(
                 cache_path=cache_path,
                 filename=filename,
                 size=size,
@@ -732,11 +737,11 @@ class MaintenanceService:
             ))
         main_loop_duration = time.monotonic() - phase_start
 
-        # Sort unprotected files by filename (default)
-        results.unprotected_files.sort(key=lambda f: f.filename.lower())
+        # Sort untracked files by filename (default)
+        results.untracked_files.sort(key=lambda f: f.filename.lower())
 
         # Group by directory: video file as primary, sidecars as children
-        results.grouped_unprotected = self._group_unprotected_by_directory(results.unprotected_files)
+        results.grouped_untracked = self._group_untracked_by_directory(results.untracked_files)
 
         # Find stale exclude entries (in exclude but not on cache)
         results.stale_exclude_entries = sorted(list(exclude_files - cache_files))
@@ -778,9 +783,9 @@ class MaintenanceService:
 
         total_duration = time.monotonic() - audit_start
         logging.info(
-            "run_full_audit: %d cache files, %d unprotected, %d duplicates, "
+            "run_full_audit: %d cache files, %d untracked, %d duplicates, "
             "%d orphaned .plexcached in %.2fs",
-            len(cache_files), len(results.unprotected_files),
+            len(cache_files), len(results.untracked_files),
             len(results.duplicates), len(results.orphaned_plexcached),
             total_duration,
         )
@@ -1079,7 +1084,7 @@ class MaintenanceService:
         return {
             "status": results.health_status,
             "total_issues": results.total_issues,
-            "unprotected_count": len(results.unprotected_files),
+            "untracked_count": len(results.untracked_files),
             "orphaned_count": len(results.orphaned_plexcached),
             "stale_exclude_count": len(results.stale_exclude_entries),
             "stale_timestamp_count": len(results.stale_timestamp_entries),
@@ -1440,7 +1445,7 @@ class MaintenanceService:
                         bytes_progress_callback: Optional[Callable] = None,
                         max_workers: int = 1,
                         active_callback: Optional[Callable] = None) -> ActionResult:
-        """Fix unprotected files that have .plexcached backup - delete cache copy, restore backup"""
+        """Fix untracked files that have .plexcached backup - delete cache copy, restore backup"""
         if not paths:
             return ActionResult(success=False, message="No paths provided")
 
@@ -1761,7 +1766,7 @@ class MaintenanceService:
         )
 
     def add_to_exclude(self, paths: List[str], dry_run: bool = True) -> ActionResult:
-        """Add unprotected cache files to exclude list (no backup created)"""
+        """Add untracked cache files to exclude list (no backup created)"""
         if not paths:
             return ActionResult(success=False, message="No paths provided")
 

--- a/web/services/pinned_service.py
+++ b/web/services/pinned_service.py
@@ -36,6 +36,7 @@ from core.pinned_media import (
     resolve_size_setting,
     sum_pinned_bytes_on_disk,
 )
+from core.media_grouping import format_season_episode
 
 
 logger = logging.getLogger(__name__)
@@ -209,9 +210,7 @@ class PinnedService:
                     ep_num = getattr(ep, "index", None)
                     ep_title = getattr(ep, "title", "") or ""
                     ep_show_label = show_label or getattr(ep, "grandparentTitle", "") or ""
-                    se_code = ""
-                    if isinstance(season_num, int) and isinstance(ep_num, int):
-                        se_code = f"S{season_num:02d}E{ep_num:02d}"
+                    se_code = format_season_episode(season_num, ep_num)
                     parts = [p for p in (ep_show_label, se_code, ep_title) if p]
                     display_title = " — ".join(parts) if parts else ep_title
                     size_bytes = self._estimate_item_size(
@@ -446,9 +445,7 @@ class PinnedService:
             season_num = getattr(item, "parentIndex", None)
             ep_num = getattr(item, "index", None)
             ep_title = getattr(item, "title", "") or fallback
-            se_code = ""
-            if isinstance(season_num, int) and isinstance(ep_num, int):
-                se_code = f"S{season_num:02d}E{ep_num:02d}"
+            se_code = format_season_episode(season_num, ep_num)
             parts = [p for p in (show_label, se_code, ep_title) if p]
             return " — ".join(parts) if parts else fallback
         except Exception:
@@ -647,9 +644,7 @@ class PinnedService:
                 season_num = getattr(item, "parentIndex", None)
                 ep_num = getattr(item, "index", None)
                 ep_title = getattr(item, "title", "") or ""
-                se_code = ""
-                if isinstance(season_num, int) and isinstance(ep_num, int):
-                    se_code = f"S{season_num:02d}E{ep_num:02d}"
+                se_code = format_season_episode(season_num, ep_num)
                 if se_code and ep_title:
                     result["scope_text"] = f"{se_code} — {ep_title}"
                 elif se_code:

--- a/web/services/pinned_service.py
+++ b/web/services/pinned_service.py
@@ -744,6 +744,62 @@ class PinnedService:
         """
         return set(self.resolve_all_to_cache_path_map().keys())
 
+    def resolve_all_to_plex_path_map(
+        self, plex: Optional[Any] = None
+    ) -> Optional[Dict[str, Tuple[str, str, str]]]:
+        """Return ``{plex_path: (rating_key, pin_type, title)}`` for every pin.
+
+        Keyed on the **Plex** path, not the cache path, for two reasons:
+
+        * Callers that already hold Plex paths (Recently Added works from
+          ``part.file``) can join with zero conversions. The two converters in
+          this codebase disagree — ``PinnedService._plex_to_cache`` walks
+          ``path_mappings`` in raw settings order and ignores ``cacheable``,
+          while ``MultiPathModifier`` sorts longest-prefix-first and honours it
+          (``core/file_operations.py``) — so a cache-path join silently misses
+          on overlapping prefixes, and can't match rows whose cache path is None.
+        * It is upgrade-resilient by construction: both sides re-read the
+          current ``part.file`` from the same server in the same request. For
+          that reason the result must **not** be memoised — a TTL cache is
+          exactly what would break resilience to a Sonarr/Radarr file swap.
+
+        Returns:
+            ``{}`` when the tracker holds no pins — definitively nothing pinned.
+            ``None`` when pins exist but could not be resolved (no connection,
+            resolver error). Callers must render that as *indeterminate*, never
+            as "not pinned": showing a live Pin button on an actually-pinned row
+            means one click unpins it and starts a background eviction.
+
+        Never prunes: ``resolve_pins_to_paths`` is called with the default
+        ``prune=False`` so a render cannot delete a pin.
+        """
+        if not self._tracker.list_pins():
+            return {}
+
+        server = plex if plex is not None else self._get_plex_server()
+        if server is None:
+            return None
+
+        try:
+            resolved, _orphaned = resolve_pins_to_paths(
+                server, self._tracker, self._get_preference()
+            )
+        except Exception as e:
+            logger.warning(
+                f"PinnedService.resolve_all_to_plex_path_map failed: {e}"
+            )
+            return None
+
+        titles = {
+            str(p.get("rating_key")): p.get("title", "")
+            for p in self._tracker.list_pins()
+        }
+        path_map: Dict[str, Tuple[str, str, str]] = {}
+        for plex_path, rk, pin_type in resolved:
+            if plex_path not in path_map:
+                path_map[plex_path] = (rk, pin_type, titles.get(str(rk), ""))
+        return path_map
+
     def resolve_all_to_cache_path_map(self) -> Dict[str, Tuple[str, str]]:
         """Return ``{cache_path: (rating_key, pin_type)}`` for every pin.
 

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -256,6 +256,9 @@ class RecentlyAddedService:
         released_paths = released_paths if released_paths is not None else set()
 
         rows: List[RecentlyAddedRow] = []
+        # Local to this call, so it cannot outlive the request or be shared
+        # between threadpool workers — the service itself is a singleton.
+        dir_cache: Dict[str, list] = {}
         for item in items:
             real_path, _ = path_modifier.convert_plex_to_real(item.file_path)
             cache_path, _ = (
@@ -348,7 +351,9 @@ class RecentlyAddedService:
                 protected_by=protected_by,
                 pin_type="episode" if item.media_type == "episode" else "movie",
                 episode_info=item.episode_info,
-                associated_files=self._scan_associated_files(cache_path) if on_cache else [],
+                associated_files=(
+                    self._scan_associated_files(cache_path, dir_cache) if on_cache else []
+                ),
                 filename=os.path.basename(item.file_path) if item.file_path else "",
                 other_versions=self._other_versions(item),
                 outcome=outcome,
@@ -501,7 +506,8 @@ class RecentlyAddedService:
             })
         return display
 
-    def _scan_associated_files(self, video_cache_path: Optional[str]) -> List[Dict[str, str]]:
+    def _scan_associated_files(self, video_cache_path: Optional[str],
+                               dir_cache: Optional[Dict[str, list]] = None) -> List[Dict[str, str]]:
         """Find subtitle/sidecar files sharing a cache-resident video's basename.
 
         Two shared rules, in order: :func:`is_sidecar_candidate` decides what
@@ -513,6 +519,16 @@ class RecentlyAddedService:
 
         Cache-only: array/unknown items are never probed. Returns
         ``[{filename, size}]`` sorted by name, for display only.
+
+        Args:
+            video_cache_path: The video's cache-side path.
+            dir_cache: Optional ``{directory: [DirEntry]}`` memo so that N rows
+                sharing a directory scan it once instead of N times — the cost
+                tracks directory *size*, so a flat library is where this pays.
+                It caches the raw listing, never the filtered result: two videos
+                in one directory have different stems and must each be matched
+                against the full listing. Pass a fresh dict per request; a
+                longer-lived one would go stale (the service is a singleton).
         """
         if not video_cache_path:
             return []
@@ -521,32 +537,43 @@ class RecentlyAddedService:
         stem = os.path.splitext(video_name)[0]
         if not directory or not stem:
             return []
+
+        entries = None if dir_cache is None else dir_cache.get(directory)
+        if entries is None:
+            try:
+                with os.scandir(directory) as it:
+                    # DirEntry, not (name, size): is_file() stays served from
+                    # the cached d_type and stat() stays on matches only.
+                    entries = list(it)
+            except OSError:
+                entries = []
+            if dir_cache is not None:
+                dir_cache[directory] = entries
+
         found: List[Dict[str, str]] = []
-        try:
-            with os.scandir(directory) as it:
-                for entry in it:
-                    if entry.name == video_name:
-                        continue
-                    # Name-only checks first: neither needs a stat, so an
-                    # excluded entry costs no syscall.
-                    if not is_sidecar_candidate(entry.name):
-                        continue
-                    try:
-                        if not entry.is_file():
-                            continue
-                    except OSError:
-                        continue
-                    if name_matches_video_stem(entry.name, stem):
-                        try:
-                            size = entry.stat().st_size
-                        except OSError:
-                            size = 0
-                        found.append({
-                            "filename": entry.name,
-                            "size": format_bytes(size) if size else "",
-                        })
-        except OSError:
-            return []
+        for entry in entries:
+            if entry.name == video_name:
+                continue
+            # Name-only checks first: neither needs a stat, so an
+            # excluded entry costs no syscall.
+            if not is_sidecar_candidate(entry.name):
+                continue
+            try:
+                if not entry.is_file():
+                    continue
+            except OSError:
+                continue
+            if name_matches_video_stem(entry.name, stem):
+                try:
+                    size = entry.stat().st_size
+                except OSError:
+                    # Still list it — a sidecar the mover is moving out from
+                    # under the scan is real, it just has no size to show.
+                    size = 0
+                found.append({
+                    "filename": entry.name,
+                    "size": format_bytes(size) if size else "",
+                })
         return sorted(found, key=lambda f: f["filename"])
 
     @staticmethod

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -119,17 +119,21 @@ class RecentlyAddedService:
             logger.warning(f"RecentlyAddedService: fetch failed: {e}")
             return self._empty_result(f"Could not fetch recently added media: {e}")
 
-        from core.file_operations import PathModifier
-        path_modifier = PathModifier(config.paths.path_mappings)
+        try:
+            from core.file_operations import MultiPathModifier
+            path_modifier = MultiPathModifier(config.paths.path_mappings)
 
-        rows = self._enrich(
-            items,
-            path_modifier,
-            pinned_keys=self._json_keys(self.pinned_file),
-            ondeck_keys=self._json_keys(self.ondeck_file),
-            watchlist_keys=self._json_keys(self.watchlist_file),
-            timestamps_keys=self._json_keys(self.timestamps_file),
-        )
+            rows = self._enrich(
+                items,
+                path_modifier,
+                pinned_keys=self._json_keys(self.pinned_file),
+                ondeck_keys=self._json_keys(self.ondeck_file),
+                watchlist_keys=self._json_keys(self.watchlist_file),
+                timestamps_keys=self._json_keys(self.timestamps_file),
+            )
+        except Exception as e:
+            logger.warning(f"RecentlyAddedService: enrichment failed: {e}")
+            return self._empty_result(f"Could not process recently added media: {e}")
 
         return {
             "available": True,

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -1,0 +1,263 @@
+"""Recently Added service (web layer).
+
+Surfaces recently-added Plex media and where each item physically lives
+(cache vs array), so users can see new content and Pin items they want held
+on cache. This view does NOT cache anything itself — caching happens through
+the existing Watchlist/OnDeck pipeline or an explicit Pin. See issue #174 and
+FUTURE_ENHANCEMENTS.md #7.
+
+Enrichment per item cross-references the existing trackers/exclude list to
+derive a display state:
+
+* ``pinned``               — rating_key is in the pin tracker (always cached)
+* ``protected``            — currently OnDeck or Watchlist (transient)
+* ``on_cache_not_pinned``  — physically on cache but not pinned (the actionable
+                             case; the mover may move it on its next run)
+* ``on_array``             — on the array, not cached
+* ``unknown``              — location could not be resolved (unmapped path)
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from web.config import DATA_DIR, SETTINGS_FILE
+from core.system_utils import get_array_direct_path, format_bytes, format_cache_age
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RecentlyAddedRow:
+    """A recently-added item enriched with location + protection state."""
+    rating_key: str
+    title: str
+    media_type: str               # "movie" | "episode"
+    library_title: str
+    file_path: str                # Plex path
+    size: int
+    size_display: str
+    added_at: Optional[datetime]
+    added_display: Optional[str]  # "2 hr ago" etc. (None if no timestamp)
+    location: str                 # "cache" | "array" | "unknown"
+    state: str                    # see module docstring
+    is_pinned: bool = False
+    is_ondeck: bool = False
+    is_watchlist: bool = False
+    is_cache_tracked: bool = False
+    protected_by: List[str] = field(default_factory=list)  # ["Pinned"], ["OnDeck"], ...
+    pin_type: str = "movie"       # scope passed to /api/pinned/toggle
+    episode_info: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "rating_key": self.rating_key,
+            "title": self.title,
+            "media_type": self.media_type,
+            "library_title": self.library_title,
+            "file_path": self.file_path,
+            "size": self.size,
+            "size_display": self.size_display,
+            "added_display": self.added_display,
+            "location": self.location,
+            "state": self.state,
+            "is_pinned": self.is_pinned,
+            "is_ondeck": self.is_ondeck,
+            "is_watchlist": self.is_watchlist,
+            "is_cache_tracked": self.is_cache_tracked,
+            "protected_by": self.protected_by,
+            "pin_type": self.pin_type,
+            "episode_info": self.episode_info,
+        }
+
+
+class RecentlyAddedService:
+    """Business logic for the Recently Added view."""
+
+    def __init__(self):
+        self.settings_file = SETTINGS_FILE
+        self.pinned_file = DATA_DIR / "pinned_media.json"
+        self.ondeck_file = DATA_DIR / "ondeck_tracker.json"
+        self.watchlist_file = DATA_DIR / "watchlist_tracker.json"
+        self.timestamps_file = DATA_DIR / "timestamps.json"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_recently_added(self, days: int = 7, max_items: int = 100) -> Dict[str, Any]:
+        """Fetch + enrich recently-added media.
+
+        Returns a dict ``{available, rows, summary, error}``. ``available`` is
+        False (with ``error`` set) when Plex isn't configured/reachable; the
+        caller renders an empty state in that case.
+        """
+        try:
+            from core.config import ConfigManager
+            config = ConfigManager(str(self.settings_file))
+            config.load_config()
+        except Exception as e:
+            logger.warning(f"RecentlyAddedService: settings not loadable: {e}")
+            return self._empty_result("PlexCache is not configured yet.")
+
+        if not config.plex.plex_url or not config.plex.plex_token:
+            return self._empty_result("Plex server is not configured.")
+
+        plex_manager = self._connect_plex(config)
+        if plex_manager is None:
+            return self._empty_result("Could not connect to the Plex server.")
+
+        valid_sections = config.plex.valid_sections or []
+        try:
+            items = plex_manager.get_recently_added_media(valid_sections, days, max_items)
+        except Exception as e:
+            logger.warning(f"RecentlyAddedService: fetch failed: {e}")
+            return self._empty_result(f"Could not fetch recently added media: {e}")
+
+        from core.file_operations import PathModifier
+        path_modifier = PathModifier(config.paths.path_mappings)
+
+        rows = self._enrich(
+            items,
+            path_modifier,
+            pinned_keys=self._json_keys(self.pinned_file),
+            ondeck_keys=self._json_keys(self.ondeck_file),
+            watchlist_keys=self._json_keys(self.watchlist_file),
+            timestamps_keys=self._json_keys(self.timestamps_file),
+        )
+
+        return {
+            "available": True,
+            "rows": rows,
+            "summary": self._summary(rows),
+            "error": None,
+        }
+
+    # ------------------------------------------------------------------
+    # Enrichment (pure — unit-testable without Plex/filesystem)
+    # ------------------------------------------------------------------
+
+    def _enrich(self, items, path_modifier, pinned_keys, ondeck_keys,
+                watchlist_keys, timestamps_keys) -> List[RecentlyAddedRow]:
+        rows: List[RecentlyAddedRow] = []
+        for item in items:
+            real_path, _ = path_modifier.convert_plex_to_real(item.file_path)
+            cache_path, _ = (
+                path_modifier.convert_real_to_cache(real_path) if real_path else (None, None)
+            )
+
+            on_cache = bool(cache_path) and self._file_exists(cache_path)
+            array_direct = get_array_direct_path(real_path) if real_path else None
+            on_array = bool(array_direct) and self._file_exists(array_direct)
+            location = "cache" if on_cache else ("array" if on_array else "unknown")
+
+            is_pinned = item.rating_key in pinned_keys if item.rating_key else False
+            is_ondeck = bool(real_path) and real_path in ondeck_keys
+            is_watchlist = item.file_path in watchlist_keys
+            is_cache_tracked = bool(cache_path) and cache_path in timestamps_keys
+
+            protected_by: List[str] = []
+            if is_pinned:
+                protected_by.append("Pinned")
+            if is_ondeck:
+                protected_by.append("OnDeck")
+            if is_watchlist:
+                protected_by.append("Watchlist")
+
+            if is_pinned:
+                state = "pinned"
+            elif is_ondeck or is_watchlist:
+                state = "protected"
+            elif location == "cache":
+                state = "on_cache_not_pinned"
+            elif location == "array":
+                state = "on_array"
+            else:
+                state = "unknown"
+
+            rows.append(RecentlyAddedRow(
+                rating_key=item.rating_key or "",
+                title=item.title,
+                media_type=item.media_type,
+                library_title=item.library_title,
+                file_path=item.file_path,
+                size=item.size,
+                size_display=format_bytes(item.size) if item.size else "",
+                added_at=item.added_at,
+                added_display=format_cache_age(item.added_at),
+                location=location,
+                state=state,
+                is_pinned=is_pinned,
+                is_ondeck=is_ondeck,
+                is_watchlist=is_watchlist,
+                is_cache_tracked=is_cache_tracked,
+                protected_by=protected_by,
+                pin_type="episode" if item.media_type == "episode" else "movie",
+                episode_info=item.episode_info,
+            ))
+        return rows
+
+    @staticmethod
+    def _summary(rows: List[RecentlyAddedRow]) -> Dict[str, Any]:
+        on_cache = sum(1 for r in rows if r.location == "cache")
+        on_cache_not_pinned = sum(1 for r in rows if r.state == "on_cache_not_pinned")
+        on_array = sum(1 for r in rows if r.location == "array")
+        total_size = sum(r.size for r in rows)
+        return {
+            "total": len(rows),
+            "on_cache": on_cache,
+            "on_cache_not_pinned": on_cache_not_pinned,
+            "on_array": on_array,
+            "total_size": total_size,
+            "total_size_display": format_bytes(total_size) if total_size else "0 B",
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _connect_plex(self, config):
+        """Build + connect a PlexManager from loaded config. None on failure."""
+        try:
+            from core.plex_api import PlexManager
+            plex_manager = PlexManager(
+                config.plex.plex_url,
+                config.plex.plex_token,
+                plex_db_path=getattr(config.plex, "plex_db_path", "") or "",
+            )
+            plex_manager.connect()
+            return plex_manager
+        except Exception as e:
+            logger.warning(f"RecentlyAddedService: Plex connection failed: {e}")
+            return None
+
+    @staticmethod
+    def _file_exists(path: str) -> bool:
+        """Wrapper around os.path.exists (patch point for tests)."""
+        try:
+            return os.path.exists(path)
+        except OSError:
+            return False
+
+    def _json_keys(self, path: Path) -> set:
+        """Return the top-level key set of a JSON object file (empty on error)."""
+        if not path.exists():
+            return set()
+        try:
+            import json
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return set(data.keys()) if isinstance(data, dict) else set()
+        except (json.JSONDecodeError, IOError, OSError):
+            return set()
+
+    def _empty_result(self, error: str) -> Dict[str, Any]:
+        return {
+            "available": False,
+            "rows": [],
+            "summary": self._summary([]),
+            "error": error,
+        }

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -158,19 +158,28 @@ class RecentlyAddedService:
         # describes the file PlexCache would actually manage.
         version_preference = getattr(config.plex, "pinned_preferred_resolution", "highest") or "highest"
         try:
-            items = plex_manager.get_recently_added_media(
+            fetched = plex_manager.get_recently_added_media(
                 valid_sections, days, max_items, version_preference=version_preference
             )
         except Exception as e:
             logger.warning(f"RecentlyAddedService: fetch failed: {e}")
             return self._empty_result(f"Could not fetch recently added media: {e}")
 
+        unreadable = list(fetched.unreadable_libraries)
+        # Every attempted library failed and nothing came back: that is a
+        # failure, not an empty result. Saying so beats three zeroed stat cards
+        # under a warning, which would assert counts the app cannot know.
+        if unreadable and not fetched.items:
+            return self._empty_result(
+                "Could not read any library: " + ", ".join(unreadable)
+            )
+
         try:
             from core.file_operations import MultiPathModifier
             path_modifier = MultiPathModifier(config.paths.path_mappings)
 
             rows = self._enrich(
-                items,
+                fetched.items,
                 path_modifier,
                 pinned_keys=self._json_keys(self.pinned_file),
                 ondeck_keys=self._json_keys(self.ondeck_file),
@@ -192,6 +201,7 @@ class RecentlyAddedService:
             "rows": rows,
             "summary": self._summary(rows),
             "error": None,
+            "unreadable_libraries": unreadable,
         }
 
     # ------------------------------------------------------------------
@@ -678,11 +688,14 @@ class RecentlyAddedService:
             return set()
 
     def _empty_result(self, error: str) -> Dict[str, Any]:
+        # Carries unreadable_libraries for shape symmetry with the success
+        # result; the unavailable card renders `error` and never reads it.
         return {
             "available": False,
             "rows": [],
             "summary": self._summary([]),
             "error": error,
+            "unreadable_libraries": [],
         }
 
 

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -74,6 +74,9 @@ class RecentlyAddedRow:
     pin_scope: str = ""           # "movie" | "show" | "season" | "episode"
     pin_holder_key: str = ""      # rating_key of the holding pin
     pin_holder_title: str = ""
+    # The show's rating key, for episodes. Grouping keys on this rather than the
+    # display title so two same-titled shows in one library stay separate.
+    show_rating_key: str = ""
     is_mover_protected: bool = False  # in the Unraid mover exclude list
     is_released: bool = False
 
@@ -353,6 +356,7 @@ class RecentlyAddedService:
                 pin_holder_title=pin_holder_title,
                 is_mover_protected=is_mover_protected,
                 is_released=is_released,
+                show_rating_key=getattr(item, "show_rating_key", "") or "",
             ))
         return rows
 
@@ -442,7 +446,10 @@ class RecentlyAddedService:
         def key_fn(row: RecentlyAddedRow):
             info = row.episode_info or {}
             if row.media_type == "episode" and info.get("show"):
-                return ("show", row.library_title, info.get("show"))
+                # Identity, not display title. The `or` fallback keeps today's
+                # behaviour when Plex omits grandparentRatingKey, so this can
+                # only ever split a merged group, never merge separate ones.
+                return ("show", row.library_title, row.show_rating_key or info.get("show"))
             return None
 
         display: List[Dict[str, Any]] = []
@@ -470,7 +477,9 @@ class RecentlyAddedService:
                 # key, not from list position, and free of user content that
                 # could break the data-* attribute it lands in.
                 "group_id": stable_group_id("ra", key[1], key[2]),
-                "show": key[2],
+                # Label from a member, not from the key — the key now holds the
+                # show's rating key whenever Plex supplies one.
+                "show": (members[0].episode_info or {}).get("show"),
                 # Kept for callers that want a plain season number; None once a
                 # group spans more than one season. Prefer season_display.
                 "season": seasons[0] if len(seasons) == 1 else None,
@@ -560,6 +569,16 @@ class RecentlyAddedService:
                 config.plex.plex_url,
                 config.plex.plex_token,
                 plex_db_path=getattr(config.plex, "plex_db_path", "") or "",
+                # plexapi keeps this on the session (PlexServer._timeout ->
+                # query()), so it caps each per-library recentlyAdded() sweep
+                # too, not just the handshake. Deliberately NOT lowered to the
+                # 10s used elsewhere: those sites are connect-and-validate
+                # handshakes, while this one pulls up to `recently_added_max_items`
+                # per library off an array that may be spun down — and
+                # get_recently_added_media() swallows a per-section failure with
+                # `continue`, so a short leash produces a silently short list
+                # rather than a faster error.
+                timeout=30,
             )
             plex_manager.connect()
             return plex_manager

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -210,7 +210,11 @@ class RecentlyAddedService:
         if is_pinned and location != "cache":
             return "arriving"
         if is_pinned:
-            return "held"
+            # Pinning writes no exclude-file line, so a file pinned while
+            # already on cache is exempt from PlexCache eviction while the
+            # Unraid mover can still relocate it. Distinguish the two rather
+            # than promising mover protection the pin hasn't bought yet.
+            return "held" if is_mover_protected else "held_mover_gap"
         if location == "array":
             return "stays_on_array"
         # On cache, not pinned. Exclude-file membership is the mechanically

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -51,6 +51,7 @@ class RecentlyAddedRow:
     protected_by: List[str] = field(default_factory=list)  # ["Pinned"], ["OnDeck"], ...
     pin_type: str = "movie"       # scope passed to /api/pinned/toggle
     episode_info: Optional[Dict[str, Any]] = None
+    associated_files: List[Dict[str, str]] = field(default_factory=list)  # [{filename, size}]
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -71,6 +72,7 @@ class RecentlyAddedRow:
             "protected_by": self.protected_by,
             "pin_type": self.pin_type,
             "episode_info": self.episode_info,
+            "associated_files": self.associated_files,
         }
 
 
@@ -197,8 +199,110 @@ class RecentlyAddedService:
                 protected_by=protected_by,
                 pin_type="episode" if item.media_type == "episode" else "movie",
                 episode_info=item.episode_info,
+                associated_files=self._scan_associated_files(cache_path) if on_cache else [],
             ))
         return rows
+
+    @staticmethod
+    def group_rows_for_display(rows: List[RecentlyAddedRow]) -> List[Dict[str, Any]]:
+        """Collapse multi-episode TV runs into expandable show groups.
+
+        Returns an ordered list of display items, each either:
+
+        * ``{"kind": "row", "row": RecentlyAddedRow}`` — a movie or a standalone
+          episode (a show+season with only one episode in the window), or
+        * ``{"kind": "show", "group_id", "show", "season", "library_title",
+          "episodes": [...], "episode_count", "total_size", "total_size_display",
+          "locations": [...], "not_pinned_count", "pinned_count"}``.
+
+        Order follows first-seen position (rows arrive newest-first), so a show
+        group anchors where its first episode appeared.
+        """
+        groups: Dict[Any, List[RecentlyAddedRow]] = {}
+        order: List[Any] = []
+        for idx, row in enumerate(rows):
+            info = row.episode_info or {}
+            if row.media_type == "episode" and info.get("show"):
+                key = ("show", row.library_title, info.get("show"), info.get("season"))
+            else:
+                key = ("single", idx)
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append(row)
+
+        display: List[Dict[str, Any]] = []
+        gid = 0
+        for key in order:
+            members = groups[key]
+            if key[0] == "show" and len(members) > 1:
+                eps = sorted(members, key=lambda r: ((r.episode_info or {}).get("episode") or 0))
+                total_size = sum(r.size for r in eps)
+                locations: List[str] = []
+                for r in eps:
+                    if r.location not in locations:
+                        locations.append(r.location)
+                display.append({
+                    "kind": "show",
+                    "group_id": f"rag{gid}",
+                    "show": key[2],
+                    "season": key[3],
+                    "library_title": key[1],
+                    "episodes": eps,
+                    "episode_count": len(eps),
+                    "total_size": total_size,
+                    "total_size_display": format_bytes(total_size) if total_size else "",
+                    "locations": locations,
+                    "not_pinned_count": sum(1 for r in eps if r.state == "on_cache_not_pinned"),
+                    "pinned_count": sum(1 for r in eps if r.is_pinned),
+                })
+                gid += 1
+            else:
+                for r in members:
+                    display.append({"kind": "row", "row": r})
+        return display
+
+    def _scan_associated_files(self, video_cache_path: Optional[str]) -> List[Dict[str, str]]:
+        """Find subtitle/sidecar files sharing a cache-resident video's basename.
+
+        Scans the video's directory for siblings whose stem matches the video's
+        stem (exact, or with a ``.``/``-`` suffix — catches ``Movie.en.srt``,
+        ``Movie.nfo``, ``Movie-poster.jpg``). Cache-only: array/unknown items
+        are never probed. Returns ``[{filename, size}]`` sorted by name.
+        """
+        if not video_cache_path:
+            return []
+        directory = os.path.dirname(video_cache_path)
+        video_name = os.path.basename(video_cache_path)
+        stem = os.path.splitext(video_name)[0]
+        if not directory or not stem:
+            return []
+        found: List[Dict[str, str]] = []
+        try:
+            with os.scandir(directory) as it:
+                for entry in it:
+                    if entry.name == video_name:
+                        continue
+                    try:
+                        if not entry.is_file():
+                            continue
+                    except OSError:
+                        continue
+                    entry_stem = os.path.splitext(entry.name)[0]
+                    if (entry_stem == stem
+                            or entry_stem.startswith(stem + ".")
+                            or entry_stem.startswith(stem + "-")):
+                        try:
+                            size = entry.stat().st_size
+                        except OSError:
+                            size = 0
+                        found.append({
+                            "filename": entry.name,
+                            "size": format_bytes(size) if size else "",
+                        })
+        except OSError:
+            return []
+        return sorted(found, key=lambda f: f["filename"])
 
     @staticmethod
     def _summary(rows: List[RecentlyAddedRow]) -> Dict[str, Any]:

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from web.config import DATA_DIR, SETTINGS_FILE
+from core.file_operations import is_sidecar_candidate, name_matches_video_stem
 from core.system_utils import get_array_direct_path, format_bytes, format_cache_age
 from core.media_grouping import format_season_range, group_ordered, stable_group_id
 from web.outcome_vocabulary import OUTCOMES, Outcome, outcome_tooltip
@@ -503,10 +504,15 @@ class RecentlyAddedService:
     def _scan_associated_files(self, video_cache_path: Optional[str]) -> List[Dict[str, str]]:
         """Find subtitle/sidecar files sharing a cache-resident video's basename.
 
-        Scans the video's directory for siblings whose stem matches the video's
-        stem (exact, or with a ``.``/``-`` suffix — catches ``Movie.en.srt``,
-        ``Movie.nfo``, ``Movie-poster.jpg``). Cache-only: array/unknown items
-        are never probed. Returns ``[{filename, size}]`` sorted by name.
+        Two shared rules, in order: :func:`is_sidecar_candidate` decides what
+        can be a sidecar at all (excludes other videos — Plex local extras land
+        beside the feature as ``<stem>-trailer.mkv`` — plus ``.plexcached``
+        array backups and dotfiles), then :func:`name_matches_video_stem`
+        decides whether it belongs to *this* video, boundary-aware so
+        ``Movie 10.en.srt`` is not claimed by ``Movie 1``.
+
+        Cache-only: array/unknown items are never probed. Returns
+        ``[{filename, size}]`` sorted by name, for display only.
         """
         if not video_cache_path:
             return []
@@ -521,15 +527,16 @@ class RecentlyAddedService:
                 for entry in it:
                     if entry.name == video_name:
                         continue
+                    # Name-only checks first: neither needs a stat, so an
+                    # excluded entry costs no syscall.
+                    if not is_sidecar_candidate(entry.name):
+                        continue
                     try:
                         if not entry.is_file():
                             continue
                     except OSError:
                         continue
-                    entry_stem = os.path.splitext(entry.name)[0]
-                    if (entry_stem == stem
-                            or entry_stem.startswith(stem + ".")
-                            or entry_stem.startswith(stem + "-")):
+                    if name_matches_video_stem(entry.name, stem):
                         try:
                             size = entry.stat().st_size
                         except OSError:

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional
 
 from web.config import DATA_DIR, SETTINGS_FILE
 from core.system_utils import get_array_direct_path, format_bytes, format_cache_age
+from core.media_grouping import format_season_range, group_ordered, stable_group_id
 
 logger = logging.getLogger(__name__)
 
@@ -214,59 +215,76 @@ class RecentlyAddedService:
     def group_rows_for_display(rows: List[RecentlyAddedRow]) -> List[Dict[str, Any]]:
         """Collapse multi-episode TV runs into expandable show groups.
 
+        Uses the app-wide bucketing rule from ``core.media_grouping`` — the same
+        one behind Recent Activity and the completion banner — so a burst of
+        episodes collapses identically everywhere. Only the *key* differs: here
+        it comes from Plex metadata (library + show) rather than a filename.
+
+        A show groups across seasons. A mid-season rollover would otherwise
+        split one show into two adjacent rows, which is exactly the fragmenting
+        the grouping exists to remove; ``season_display`` names the span.
+
         Returns an ordered list of display items, each either:
 
         * ``{"kind": "row", "row": RecentlyAddedRow}`` — a movie or a standalone
-          episode (a show+season with only one episode in the window), or
-        * ``{"kind": "show", "group_id", "show", "season", "library_title",
-          "episodes": [...], "episode_count", "total_size", "total_size_display",
-          "locations": [...], "not_pinned_count", "pinned_count"}``.
+          episode (a show with only one episode in the window), or
+        * ``{"kind": "show", "group_id", "show", "season", "seasons",
+          "season_display", "library_title", "episodes": [...], "episode_count",
+          "total_size", "total_size_display", "added_display", "locations": [...],
+          "not_pinned_count", "pinned_count"}``.
 
         Order follows first-seen position (rows arrive newest-first), so a show
         group anchors where its first episode appeared.
         """
-        groups: Dict[Any, List[RecentlyAddedRow]] = {}
-        order: List[Any] = []
-        for idx, row in enumerate(rows):
+        def key_fn(row: RecentlyAddedRow):
             info = row.episode_info or {}
             if row.media_type == "episode" and info.get("show"):
-                key = ("show", row.library_title, info.get("show"), info.get("season"))
-            else:
-                key = ("single", idx)
-            if key not in groups:
-                groups[key] = []
-                order.append(key)
-            groups[key].append(row)
+                return ("show", row.library_title, info.get("show"))
+            return None
 
         display: List[Dict[str, Any]] = []
-        gid = 0
-        for key in order:
-            members = groups[key]
-            if key[0] == "show" and len(members) > 1:
-                eps = sorted(members, key=lambda r: ((r.episode_info or {}).get("episode") or 0))
-                total_size = sum(r.size for r in eps)
-                locations: List[str] = []
-                for r in eps:
-                    if r.location not in locations:
-                        locations.append(r.location)
-                display.append({
-                    "kind": "show",
-                    "group_id": f"rag{gid}",
-                    "show": key[2],
-                    "season": key[3],
-                    "library_title": key[1],
-                    "episodes": eps,
-                    "episode_count": len(eps),
-                    "total_size": total_size,
-                    "total_size_display": format_bytes(total_size) if total_size else "",
-                    "locations": locations,
-                    "not_pinned_count": sum(1 for r in eps if r.state == "on_cache_not_pinned"),
-                    "pinned_count": sum(1 for r in eps if r.is_pinned),
-                })
-                gid += 1
-            else:
-                for r in members:
-                    display.append({"kind": "row", "row": r})
+        for key, members in group_ordered(rows, key_fn):
+            if key is None or len(members) == 1:
+                display.extend({"kind": "row", "row": r} for r in members)
+                continue
+
+            eps = sorted(members, key=lambda r: (
+                (r.episode_info or {}).get("season") or 0,
+                (r.episode_info or {}).get("episode") or 0,
+            ))
+            seasons = sorted({
+                s for s in ((r.episode_info or {}).get("season") for r in eps)
+                if s is not None
+            })
+            total_size = sum(r.size for r in eps)
+            locations: List[str] = []
+            for r in eps:
+                if r.location not in locations:
+                    locations.append(r.location)
+            display.append({
+                "kind": "show",
+                # Same minting as the activity/banner groups — derived from the
+                # key, not from list position, and free of user content that
+                # could break the data-* attribute it lands in.
+                "group_id": stable_group_id("ra", key[1], key[2]),
+                "show": key[2],
+                # Kept for callers that want a plain season number; None once a
+                # group spans more than one season. Prefer season_display.
+                "season": seasons[0] if len(seasons) == 1 else None,
+                "seasons": seasons,
+                "season_display": format_season_range(seasons),
+                "library_title": key[1],
+                "episodes": eps,
+                "episode_count": len(eps),
+                "total_size": total_size,
+                "total_size_display": format_bytes(total_size) if total_size else "",
+                # Rows arrive newest-first, so the first member is the newest
+                # episode — the group's "added" age.
+                "added_display": members[0].added_display,
+                "locations": locations,
+                "not_pinned_count": sum(1 for r in eps if r.state == "on_cache_not_pinned"),
+                "pinned_count": sum(1 for r in eps if r.is_pinned),
+            })
         return display
 
     def _scan_associated_files(self, video_cache_path: Optional[str]) -> List[Dict[str, str]]:

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -6,15 +6,20 @@ on cache. This view does NOT cache anything itself — caching happens through
 the existing Watchlist/OnDeck pipeline or an explicit Pin. See issue #174 and
 FUTURE_ENHANCEMENTS.md #7.
 
-Enrichment per item cross-references the existing trackers/exclude list to
-derive a display state:
+Enrichment per item cross-references the existing trackers and the mover
+exclude list to derive an **outcome** — what happens to the file next — rather
+than a state noun. See ``web/outcome_vocabulary.py`` for the enum and why:
+briefly, a noun like "Protected" can assert protection the code does not
+provide (OnDeck only adds +15 to the priority score; only a pin exempts), while
+an outcome cannot.
 
-* ``pinned``               — rating_key is in the pin tracker (always cached)
-* ``protected``            — currently OnDeck or Watchlist (transient)
-* ``on_cache_not_pinned``  — physically on cache but not pinned (the actionable
-                             case; the mover may move it on its next run)
-* ``on_array``             — on the array, not cached
-* ``unknown``              — location could not be resolved (unmapped path)
+Each row carries exactly one ``outcome``, which makes per-group counts a
+partition and lets the group header lead with its *weakest* member instead of
+falling through to a reassuring default.
+
+The legacy ``state`` field (``pinned`` / ``protected`` / ``on_cache_not_pinned``
+/ ``on_array`` / ``unknown``) is still populated for one release so existing
+callers and tests keep working; ``outcome`` is the field to render.
 """
 
 import logging
@@ -27,6 +32,7 @@ from typing import Any, Dict, List, Optional
 from web.config import DATA_DIR, SETTINGS_FILE
 from core.system_utils import get_array_direct_path, format_bytes, format_cache_age
 from core.media_grouping import format_season_range, group_ordered, stable_group_id
+from web.outcome_vocabulary import OUTCOMES, Outcome, outcome_tooltip
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +60,22 @@ class RecentlyAddedRow:
     episode_info: Optional[Dict[str, Any]] = None
     associated_files: List[Dict[str, str]] = field(default_factory=list)  # [{filename, size}]
     filename: str = ""            # basename of file_path (shown in the expand detail)
+    # Non-preferred versions of the same Plex item ([{filename, size_display,
+    # label}]). PlexCache only caches/pins the preferred one, so these are
+    # disclosed in the expand detail rather than given rows of their own.
+    other_versions: List[Dict[str, str]] = field(default_factory=list)
+    # --- outcome vocabulary (see OUTCOMES below) ---
+    outcome: str = "stays_on_array"
+    # The pin that actually holds this file, which may be a show or season pin
+    # rather than a pin on this episode. The Pin button must unpin the holder;
+    # writing a redundant episode pin under a show pin double-counts the same
+    # bytes in budget_check and strands an invisible pin when the show is
+    # unpinned later.
+    pin_scope: str = ""           # "movie" | "show" | "season" | "episode"
+    pin_holder_key: str = ""      # rating_key of the holding pin
+    pin_holder_title: str = ""
+    is_mover_protected: bool = False  # in the Unraid mover exclude list
+    is_released: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -76,6 +98,14 @@ class RecentlyAddedRow:
             "episode_info": self.episode_info,
             "associated_files": self.associated_files,
             "filename": self.filename,
+            "other_versions": self.other_versions,
+            "outcome": self.outcome,
+            "outcome_label": OUTCOMES[self.outcome].label if self.outcome in OUTCOMES else "",
+            "pin_scope": self.pin_scope,
+            "pin_holder_key": self.pin_holder_key,
+            "pin_holder_title": self.pin_holder_title,
+            "is_mover_protected": self.is_mover_protected,
+            "is_released": self.is_released,
         }
 
 
@@ -103,7 +133,11 @@ class RecentlyAddedService:
         try:
             from core.config import ConfigManager
             config = ConfigManager(str(self.settings_file))
-            config.load_config()
+            # persist_updates=False: this runs on a GET, and the dashboard widget
+            # fires one on every dashboard visit. The default path ends in a
+            # truncating rewrite of plexcache_settings.json, which would race any
+            # concurrent reader of that file.
+            config.load_config(persist_updates=False)
         except Exception as e:
             logger.warning(f"RecentlyAddedService: settings not loadable: {e}")
             return self._empty_result("PlexCache is not configured yet.")
@@ -116,8 +150,13 @@ class RecentlyAddedService:
             return self._empty_result("Could not connect to the Plex server.")
 
         valid_sections = config.plex.valid_sections or []
+        # Same version preference the pin and caching paths use, so the row
+        # describes the file PlexCache would actually manage.
+        version_preference = getattr(config.plex, "pinned_preferred_resolution", "highest") or "highest"
         try:
-            items = plex_manager.get_recently_added_media(valid_sections, days, max_items)
+            items = plex_manager.get_recently_added_media(
+                valid_sections, days, max_items, version_preference=version_preference
+            )
         except Exception as e:
             logger.warning(f"RecentlyAddedService: fetch failed: {e}")
             return self._empty_result(f"Could not fetch recently added media: {e}")
@@ -133,6 +172,12 @@ class RecentlyAddedService:
                 ondeck_keys=self._json_keys(self.ondeck_file),
                 watchlist_keys=self._json_keys(self.watchlist_file),
                 timestamps_keys=self._json_keys(self.timestamps_file),
+                # Reuse the live PlexServer this request already opened rather
+                # than paying a second handshake.
+                pin_path_map=self._pin_path_map(plex_manager),
+                exclude_paths=self._exclude_paths(),
+                released_paths=self._released_paths(),
+                watched_move=bool(getattr(config.cache, "watched_move", True)),
             )
         except Exception as e:
             logger.warning(f"RecentlyAddedService: enrichment failed: {e}")
@@ -149,8 +194,59 @@ class RecentlyAddedService:
     # Enrichment (pure — unit-testable without Plex/filesystem)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _classify_outcome(*, pin_index_available: bool, is_pinned: bool, location: str,
+                          is_mover_protected: bool, watched_move: bool,
+                          is_ondeck: bool, is_watchlist: bool) -> str:
+        """Name what happens to this file next. Exactly one outcome per row.
+
+        Order matters. ``pin_unknown`` sorts first because a row whose pin state
+        is unverified cannot honestly claim any of the outcomes below it.
+        """
+        if not pin_index_available:
+            return "pin_unknown"
+        if location == "unknown":
+            return "unmapped"
+        if is_pinned and location != "cache":
+            return "arriving"
+        if is_pinned:
+            return "held"
+        if location == "array":
+            return "stays_on_array"
+        # On cache, not pinned. Exclude-file membership is the mechanically
+        # correct discriminator: get_files_to_move_back_to_array() iterates the
+        # exclude file directly, so a file absent from it is one PlexCache has
+        # stopped holding — whether deliberately released or never tracked.
+        if not is_mover_protected:
+            return "mover_decides"
+        if not watched_move:
+            return "held_by_setting"
+        if is_ondeck or is_watchlist:
+            return "returns_when_done"
+        return "moves_back"
+
     def _enrich(self, items, path_modifier, pinned_keys, ondeck_keys,
-                watchlist_keys, timestamps_keys) -> List[RecentlyAddedRow]:
+                watchlist_keys, timestamps_keys,
+                pin_path_map=None, exclude_paths=None, released_paths=None,
+                watched_move=True) -> List[RecentlyAddedRow]:
+        """Enrich fetched items into display rows.
+
+        Args:
+            pin_path_map: ``{plex_path: (rating_key, pin_type, title)}`` from
+                ``PinnedService.resolve_all_to_plex_path_map``. ``{}`` means
+                nothing is pinned; ``None`` means pins exist but could not be
+                resolved, which renders as ``pin_unknown`` with the Pin button
+                disabled rather than silently as "not pinned".
+            exclude_paths: Cache paths in the Unraid mover exclude list.
+            released_paths: Cache paths deliberately handed to the mover.
+            watched_move: The ``watched_move`` setting; when off, PlexCache
+                never moves anything back and every cached row says so.
+        """
+        pin_index_available = pin_path_map is not None
+        pin_map = pin_path_map or {}
+        exclude_paths = exclude_paths if exclude_paths is not None else set()
+        released_paths = released_paths if released_paths is not None else set()
+
         rows: List[RecentlyAddedRow] = []
         for item in items:
             real_path, _ = path_modifier.convert_plex_to_real(item.file_path)
@@ -160,13 +256,51 @@ class RecentlyAddedService:
 
             on_cache = bool(cache_path) and self._file_exists(cache_path)
             array_direct = get_array_direct_path(real_path) if real_path else None
-            on_array = bool(array_direct) and self._file_exists(array_direct)
+            # Short-circuit on on_cache: the array probe touches /mnt/user0/ —
+            # the spinning array — and its result is unused once the file is
+            # known to be on cache. Caching exists to avoid exactly this.
+            on_array = (
+                (not on_cache)
+                and bool(array_direct)
+                and self._file_exists(array_direct)
+            )
             location = "cache" if on_cache else ("array" if on_array else "unknown")
 
-            is_pinned = item.rating_key in pinned_keys if item.rating_key else False
+            # Pin state comes from the resolved pin map, keyed on the Plex path,
+            # so a file held by a SHOW or SEASON pin is correctly pinned even
+            # though its own rating_key never appears in pinned_media.json.
+            # Falls back to raw key membership only when resolution is
+            # unavailable, which catches direct item pins but not inherited ones.
+            holder = pin_map.get(item.file_path)
+            if holder:
+                is_pinned = True
+                pin_holder_key, pin_scope, pin_holder_title = holder
+            else:
+                is_pinned = (
+                    bool(item.rating_key) and item.rating_key in pinned_keys
+                )
+                pin_holder_key = item.rating_key if is_pinned else ""
+                pin_scope = (
+                    ("episode" if item.media_type == "episode" else "movie")
+                    if is_pinned else ""
+                )
+                pin_holder_title = item.title if is_pinned else ""
+
             is_ondeck = bool(real_path) and real_path in ondeck_keys
             is_watchlist = item.file_path in watchlist_keys
             is_cache_tracked = bool(cache_path) and cache_path in timestamps_keys
+            is_mover_protected = bool(cache_path) and cache_path in exclude_paths
+            is_released = bool(cache_path) and cache_path in released_paths
+
+            outcome = self._classify_outcome(
+                pin_index_available=pin_index_available,
+                is_pinned=is_pinned,
+                location=location,
+                is_mover_protected=is_mover_protected,
+                watched_move=watched_move,
+                is_ondeck=is_ondeck,
+                is_watchlist=is_watchlist,
+            )
 
             protected_by: List[str] = []
             if is_pinned:
@@ -208,8 +342,73 @@ class RecentlyAddedService:
                 episode_info=item.episode_info,
                 associated_files=self._scan_associated_files(cache_path) if on_cache else [],
                 filename=os.path.basename(item.file_path) if item.file_path else "",
+                other_versions=self._other_versions(item),
+                outcome=outcome,
+                pin_scope=pin_scope,
+                pin_holder_key=pin_holder_key,
+                pin_holder_title=pin_holder_title,
+                is_mover_protected=is_mover_protected,
+                is_released=is_released,
             ))
         return rows
+
+    @staticmethod
+    def _group_outcome(rows: List[RecentlyAddedRow]) -> Dict[str, Any]:
+        """Reduce a show group's rows to one headline outcome.
+
+        Weakest tier wins, so a group can never look safer than its worst
+        episode — a 7-pinned/1-leaving show must not read like a healthy one.
+
+        ``stays_on_array`` sits outside the ranking (tier 99) and only leads
+        when it is unanimous: a file that never arrived on cache cannot leave.
+        """
+        counts: Dict[str, int] = {}
+        for r in rows:
+            counts[r.outcome] = counts.get(r.outcome, 0) + 1
+        # Partition invariant: every row carries exactly one outcome.
+        assert sum(counts.values()) == len(rows)
+
+        present = sorted(counts, key=lambda k: OUTCOMES[k].tier if k in OUTCOMES else 98)
+        lead = present[0] if present else "stays_on_array"
+        mixed = len(present) > 1
+
+        label = OUTCOMES[lead].label if lead in OUTCOMES else ""
+        if mixed and label:
+            label = f"{counts[lead]} of {len(rows)} {label}"
+        return {
+            "outcome_lead": lead,
+            "outcome_label": label,
+            "outcome_counts": counts,
+            "outcome_mixed": mixed,
+            "outcome_badge": OUTCOMES[lead].badge if lead in OUTCOMES else "badge-muted",
+            "outcome_icon": OUTCOMES[lead].icon if lead in OUTCOMES else "",
+            "outcome_tooltip": "; ".join(
+                f"{n} {OUTCOMES[k].label}" for k, n in
+                sorted(counts.items(), key=lambda kv: OUTCOMES[kv[0]].tier if kv[0] in OUTCOMES else 98)
+                if k in OUTCOMES
+            ),
+        }
+
+    @staticmethod
+    def _other_versions(item) -> List[Dict[str, str]]:
+        """Files belonging to versions of this item that PlexCache does not manage.
+
+        The preferred version's files are already described by the row itself
+        (``filename``/``size_display``); these are disclosed in the expand detail
+        so a multi-version item is visible without earning a second row and a
+        second pin control.
+        """
+        out: List[Dict[str, str]] = []
+        for f in getattr(item, "version_files", None) or []:
+            if f.get("is_preferred"):
+                continue
+            size = int(f.get("size") or 0)
+            out.append({
+                "filename": os.path.basename(f.get("file_path") or ""),
+                "size": format_bytes(size) if size else "",
+                "label": f.get("label") or "",
+            })
+        return out
 
     @staticmethod
     def group_rows_for_display(rows: List[RecentlyAddedRow]) -> List[Dict[str, Any]]:
@@ -284,6 +483,7 @@ class RecentlyAddedService:
                 "locations": locations,
                 "not_pinned_count": sum(1 for r in eps if r.state == "on_cache_not_pinned"),
                 "pinned_count": sum(1 for r in eps if r.is_pinned),
+                **RecentlyAddedService._group_outcome(eps),
             })
         return display
 
@@ -362,6 +562,43 @@ class RecentlyAddedService:
         except Exception as e:
             logger.warning(f"RecentlyAddedService: Plex connection failed: {e}")
             return None
+
+    @staticmethod
+    def _pin_path_map(plex_manager):
+        """Resolved pins keyed on Plex path, or None if they can't be checked.
+
+        None is not the same as "nothing pinned": rendering an unresolvable pin
+        state as "not pinned" gives a genuinely pinned row a live Pin button,
+        and one click unpins the item and starts a background eviction of it.
+        """
+        try:
+            from web.services import get_pinned_service
+            return get_pinned_service().resolve_all_to_plex_path_map(
+                plex=getattr(plex_manager, "plex", None)
+            )
+        except Exception as e:
+            logger.warning(f"RecentlyAddedService: pin resolve failed: {e}")
+            return None
+
+    @staticmethod
+    def _exclude_paths() -> set:
+        """Cache paths held back from the Unraid mover (reuses the audit reader)."""
+        try:
+            from web.services import get_maintenance_service
+            return get_maintenance_service().get_exclude_files()
+        except Exception as e:
+            logger.debug(f"RecentlyAddedService: exclude list unavailable: {e}")
+            return set()
+
+    @staticmethod
+    def _released_paths() -> set:
+        """Cache paths deliberately handed to the mover (reuses the audit reader)."""
+        try:
+            from web.services import get_maintenance_service
+            return get_maintenance_service().get_released_files()
+        except Exception as e:
+            logger.debug(f"RecentlyAddedService: released set unavailable: {e}")
+            return set()
 
     @staticmethod
     def _file_exists(path: str) -> bool:

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -261,3 +261,15 @@ class RecentlyAddedService:
             "summary": self._summary([]),
             "error": error,
         }
+
+
+# Module-level singleton (mirrors the other web services).
+_recently_added_service: Optional[RecentlyAddedService] = None
+
+
+def get_recently_added_service() -> RecentlyAddedService:
+    """Return the shared RecentlyAddedService instance."""
+    global _recently_added_service
+    if _recently_added_service is None:
+        _recently_added_service = RecentlyAddedService()
+    return _recently_added_service

--- a/web/services/recently_added_service.py
+++ b/web/services/recently_added_service.py
@@ -52,6 +52,7 @@ class RecentlyAddedRow:
     pin_type: str = "movie"       # scope passed to /api/pinned/toggle
     episode_info: Optional[Dict[str, Any]] = None
     associated_files: List[Dict[str, str]] = field(default_factory=list)  # [{filename, size}]
+    filename: str = ""            # basename of file_path (shown in the expand detail)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -73,6 +74,7 @@ class RecentlyAddedRow:
             "pin_type": self.pin_type,
             "episode_info": self.episode_info,
             "associated_files": self.associated_files,
+            "filename": self.filename,
         }
 
 
@@ -204,6 +206,7 @@ class RecentlyAddedService:
                 pin_type="episode" if item.media_type == "episode" else "movie",
                 episode_info=item.episode_info,
                 associated_files=self._scan_associated_files(cache_path) if on_cache else [],
+                filename=os.path.basename(item.file_path) if item.file_path else "",
             ))
         return rows
 

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -630,6 +630,9 @@ class SettingsService:
             # Content discovery (moved from Plex tab)
             "number_episodes": ("number_episodes", safe_int),
             "days_to_monitor": ("days_to_monitor", safe_int),
+            # Recently Added view (display-only; see issue #174)
+            "recently_added_days": ("recently_added_days", safe_int),
+            "recently_added_max_items": ("recently_added_max_items", safe_int),
             "watchlist_toggle": ("watchlist_toggle", lambda x: x == "on" or x is True),
             "watchlist_episodes": ("watchlist_episodes", safe_int),
             "prefetch_minimum_minutes": ("prefetch_minimum_minutes", safe_int),

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -584,6 +584,12 @@ class SettingsService:
             # Content discovery (moved from Plex tab)
             "number_episodes": raw.get("number_episodes", 5),
             "days_to_monitor": raw.get("days_to_monitor", 183),
+            # Recently Added view (display-only; see issue #174). Defaults must
+            # match web/routers/recently_added.py DEFAULT_DAYS / DEFAULT_MAX_ITEMS —
+            # the Cache tab renders these, so omitting them here made the form show
+            # a default and write it back over the stored value on the next save.
+            "recently_added_days": raw.get("recently_added_days", 7),
+            "recently_added_max_items": raw.get("recently_added_max_items", 250),
             "watchlist_toggle": raw.get("watchlist_toggle", True),
             "watchlist_episodes": raw.get("watchlist_episodes", 3),
             "prefetch_minimum_minutes": raw.get("prefetch_minimum_minutes", 0),

--- a/web/services/web_cache.py
+++ b/web/services/web_cache.py
@@ -423,7 +423,7 @@ def _audit_results_to_dict(results) -> dict:
         'exclude_entry_count': results.exclude_entry_count,
         'timestamp_entry_count': results.timestamp_entry_count,
         'health_status': results.health_status,
-        'unprotected_count': len(results.unprotected_files),
+        'untracked_count': len(results.untracked_files),
         'orphaned_count': len(results.orphaned_plexcached),
         'stale_exclude_count': len(results.stale_exclude_entries),
         'stale_timestamp_count': len(results.stale_timestamp_entries),

--- a/web/settings_search_index.py
+++ b/web/settings_search_index.py
@@ -166,6 +166,22 @@ _INDEX: List[Dict[str, Any]] = [
         "icon": "clock", "tone": "tone-ok",
         "keywords": ["minimum", "runtime", "minutes", "prefetch", "duration", "episodes"],
     },
+    {
+        "tab": "cache", "setting_id": "recently_added_days",
+        "label": "Recently Added — Default Window",
+        "hint": "Default time window for the Recently Added page.",
+        "section": "Cache", "subsection": "Content Discovery",
+        "icon": "sparkles", "tone": "tone-ok",
+        "keywords": ["recently", "added", "new", "window", "days", "default", "recent"],
+    },
+    {
+        "tab": "cache", "setting_id": "recently_added_max_items",
+        "label": "Recently Added — Max Items",
+        "hint": "Most recent items to load on the Recently Added page (1–500).",
+        "section": "Cache", "subsection": "Content Discovery",
+        "icon": "sparkles", "tone": "tone-ok",
+        "keywords": ["recently", "added", "new", "max", "items", "limit", "count"],
+    },
 
     # --- Cache: Watchlist --------------------------------------------------
     {

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1775,8 +1775,11 @@ footer {
 
 /* File-detail sub-row: full-width colspan cell. The filename wraps inline
    (overflow-wrap:anywhere) so long release names never widen the table, and the
-   size sits as a muted chip right after the name — not floated to the far edge. */
+   size sits as a muted chip right after the name — not floated to the far edge.
+   padding-left aligns the name under the title text above it (past the
+   chevron + media icon); child rows have no icon so they're overridden inline. */
 .ra-detail-cell {
+    padding-left: 4rem;
     font-size: 0.8rem;
     color: var(--plex-text-muted, #8e8e93);
 }
@@ -1784,12 +1787,83 @@ footer {
     overflow-wrap: anywhere;
     word-break: break-word;
 }
-.ra-detail-size {
+
+/* Shared muted size chip (file-detail rows + dashboard widget). */
+.ra-size-chip {
+    display: inline-block;
     margin-left: 0.5rem;
     padding: 0.05rem 0.4rem;
     border-radius: var(--plex-radius-sm, 8px);
     background: var(--plex-bg-hover, rgba(255, 255, 255, 0.06));
     white-space: nowrap;
     font-size: 0.72rem;
-    opacity: 0.85;
+    color: var(--plex-text-muted, #8e8e93);
+}
+
+/* ── Dashboard "Recently Added" widget: header + aligned columns ── */
+.ra-w-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.3rem 0;
+    border-bottom: 1px solid var(--plex-border);
+    font-size: 0.66rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--plex-text-muted);
+}
+.ra-w-head .ra-w-lead { width: 2.2rem; flex-shrink: 0; }
+.ra-w-row {
+    cursor: pointer;
+    border-top: 1px solid var(--plex-border);
+}
+.ra-w-row:first-of-type { border-top: none; }
+.ra-w-line {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0;
+    font-size: 0.85rem;
+}
+.ra-w-chevron {
+    display: inline-flex;
+    color: var(--plex-text-muted);
+    flex-shrink: 0;
+    transition: transform 0.15s ease;
+}
+.ra-w-title {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.ra-w-size {
+    width: 5rem;
+    flex-shrink: 0;
+    text-align: right;
+}
+.ra-w-size .ra-size-chip { margin-left: 0; }
+.ra-w-age {
+    width: 4.5rem;
+    flex-shrink: 0;
+    text-align: right;
+    white-space: nowrap;
+    color: var(--plex-text-muted);
+}
+.ra-w-detail { padding: 0 0 0.4rem 2.2rem; }
+.ra-w-detail-line {
+    display: flex;
+    align-items: baseline;
+    padding: 0.1rem 0;
+    font-size: 0.78rem;
+    color: var(--plex-text-muted);
+}
+.ra-w-detail-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1751,3 +1751,14 @@ footer {
     color: var(--plex-text-muted);
     margin-top: 0.2rem;
 }
+
+/* Expandable show-group header (TV runs collapsed under one row) */
+.ra-group-header { cursor: pointer; }
+.ra-group-header:hover td { background: var(--plex-bg-hover); }
+.ra-chevron {
+    display: inline-flex;
+    color: var(--plex-text-muted);
+    transition: transform 0.15s ease;
+}
+.ra-group-header.is-open .ra-chevron { transform: rotate(90deg); }
+.ra-group-child { background: rgba(0, 0, 0, 0.12); }

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1861,7 +1861,9 @@ footer {
 }
 .ra-w-size .ra-size-chip { margin-left: 0; }
 .ra-w-age {
-    width: 4.5rem;
+    /* 5rem, matching .ra-w-size above: "30 days ago" overflows 4.5rem (72px)
+       at this font size now that format_cache_age has a day tier. */
+    width: 5rem;
     flex-shrink: 0;
     text-align: right;
     white-space: nowrap;

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1839,6 +1839,13 @@ footer {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+/* Season/episode-count qualifier on a grouped show line. Inline (not a second
+   line) so grouped and ungrouped rows keep the same row height. */
+.ra-w-sub {
+    color: var(--plex-text-muted);
+    font-size: 0.76rem;
+    margin-left: 0.35rem;
+}
 .ra-w-size {
     width: 5rem;
     flex-shrink: 0;

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1762,3 +1762,13 @@ footer {
 }
 .ra-group-header.is-open .ra-chevron { transform: rotate(90deg); }
 .ra-group-child { background: rgba(0, 0, 0, 0.12); }
+
+/* Per-row file-detail expander (chevron on the title cell) */
+.ra-detail-chevron {
+    display: inline-flex;
+    color: var(--plex-text-muted);
+    flex-shrink: 0;
+    transition: transform 0.15s ease;
+}
+.ra-detail-chevron i { width: 14px; height: 14px; }
+.ra-detail-chevron.open { transform: rotate(90deg); }

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1839,6 +1839,14 @@ footer {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+/* Indeterminate outcome (pin state unknown / unmapped path). A dashed outline
+   reads as "not established" rather than as a settled state, without inventing
+   a new colour outside the token set. */
+.ra-badge-dashed {
+    border: 1px dashed var(--plex-border);
+    background: transparent;
+}
+
 /* Season/episode-count qualifier on a grouped show line. Inline (not a second
    line) so grouped and ungrouped rows keep the same row height. */
 .ra-w-sub {

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1742,3 +1742,12 @@ footer {
 .ss-flash-pinned-card.is-dismissing {
     border-color: rgba(229, 160, 13, 0) !important;
 }
+
+/* ─────────────────────────────────────────────────────────────────────
+   Recently Added — small caption under a row's Pin action
+   ───────────────────────────────────────────────────────────────────── */
+.ra-status-note {
+    font-size: 0.72rem;
+    color: var(--plex-text-muted);
+    margin-top: 0.2rem;
+}

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1761,7 +1761,13 @@ footer {
     transition: transform 0.15s ease;
 }
 .ra-group-header.is-open .ra-chevron { transform: rotate(90deg); }
-.ra-group-child { background: rgba(0, 0, 0, 0.12); }
+/* Inset surface token, so the nesting tint follows the theme. A hardcoded
+   rgba(0,0,0,0.12) composited to #E0E0E0 in light, all but identical to the
+   #DDDDE2 that tbody tr:hover paints — 1.03 contrast, i.e. no hover feedback
+   on a row that is clickable. Keep the specificity at (0,1,0): a
+   [data-theme="light"] companion would outrank tbody tr:hover and kill the
+   hover outright. */
+.ra-group-child { background: var(--plex-bg-input); }
 
 /* Per-row file-detail expander (chevron on the title cell) */
 .ra-detail-chevron {

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1772,3 +1772,25 @@ footer {
 }
 .ra-detail-chevron i { width: 14px; height: 14px; }
 .ra-detail-chevron.open { transform: rotate(90deg); }
+
+/* File-detail sub-row: full-width colspan cell with a wrapping name + fixed
+   size, so long release filenames never widen the Title column / table. */
+.ra-detail-line {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+}
+.ra-detail-name {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    font-size: 0.8rem;
+    color: var(--plex-text-muted, #8e8e93);
+}
+.ra-detail-size {
+    flex-shrink: 0;
+    white-space: nowrap;
+    font-size: 0.8rem;
+    color: var(--plex-text-muted, #8e8e93);
+}

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1860,8 +1860,10 @@ footer {
     font-size: 0.78rem;
     color: var(--plex-text-muted);
 }
+/* Name shrinks (ellipsis) only as needed so the size chip hugs it, rather than
+   being pushed to the far right edge. */
 .ra-w-detail-name {
-    flex: 1;
+    flex: 0 1 auto;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1773,24 +1773,23 @@ footer {
 .ra-detail-chevron i { width: 14px; height: 14px; }
 .ra-detail-chevron.open { transform: rotate(90deg); }
 
-/* File-detail sub-row: full-width colspan cell with a wrapping name + fixed
-   size, so long release filenames never widen the Title column / table. */
-.ra-detail-line {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 1rem;
+/* File-detail sub-row: full-width colspan cell. The filename wraps inline
+   (overflow-wrap:anywhere) so long release names never widen the table, and the
+   size sits as a muted chip right after the name — not floated to the far edge. */
+.ra-detail-cell {
+    font-size: 0.8rem;
+    color: var(--plex-text-muted, #8e8e93);
 }
 .ra-detail-name {
-    min-width: 0;
     overflow-wrap: anywhere;
     word-break: break-word;
-    font-size: 0.8rem;
-    color: var(--plex-text-muted, #8e8e93);
 }
 .ra-detail-size {
-    flex-shrink: 0;
+    margin-left: 0.5rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: var(--plex-radius-sm, 8px);
+    background: var(--plex-bg-hover, rgba(255, 255, 255, 0.06));
     white-space: nowrap;
-    font-size: 0.8rem;
-    color: var(--plex-text-muted, #8e8e93);
+    font-size: 0.72rem;
+    opacity: 0.85;
 }

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1869,3 +1869,44 @@ footer {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+/* ==========================================================================
+   Share Alignment Warning (Libraries tab)
+   Flags a path mapping whose cache destination isn't the same Unraid share as
+   its media — the misconfiguration behind files appearing missing in Plex.
+   ========================================================================== */
+
+.share-mismatch-warning {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem 0.65rem;
+    background: color-mix(in srgb, var(--plex-warning) 12%, transparent);
+    border-left: 3px solid var(--plex-warning);
+    border-radius: var(--plex-radius-sm);
+    font-size: 0.8rem;
+    color: var(--plex-warning);
+}
+
+.share-mismatch-warning__icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+}
+
+.share-mismatch-warning__body {
+    margin-top: 0.2rem;
+    color: var(--plex-text);
+    opacity: 0.85;
+    line-height: 1.45;
+}
+
+.share-mismatch-warning code {
+    padding: 0.05rem 0.3rem;
+    background: color-mix(in srgb, var(--plex-warning) 18%, transparent);
+    border-radius: 3px;
+    color: var(--plex-warning);
+    font-size: 0.95em;
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -80,6 +80,12 @@
                     </a>
                 </li>
                 <li>
+                    <a href="/recently-added" data-tooltip="Recently Added" {% if page_title == 'Recently Added' %}class="active"{% endif %}>
+                        <i data-lucide="sparkles"></i>
+                        <span>Recently Added</span>
+                    </a>
+                </li>
+                <li>
                     <a href="/cache/drive" data-tooltip="Storage" {% if page_title == 'Storage' %}class="active"{% endif %}>
                         <i data-lucide="hard-drive"></i>
                         <span>Storage</span>

--- a/web/templates/cache/partials/file_table.html
+++ b/web/templates/cache/partials/file_table.html
@@ -1,6 +1,7 @@
 <!-- Cache files table body - HTMX partial -->
 {% from "macros/associated_files.html" import af_popup, af_popup_init %}
 {% from "macros/user_badge.html" import user_badge %}
+{% from "macros/source_badge.html" import ondeck_badge, watchlist_badge, lapsed_badge %}
 {% if files %}
     {% for file in files %}
     {% set assoc_count = file.subtitle_count + file.sidecar_count %}
@@ -38,20 +39,10 @@
                 Released
             </span>
             {% else %}
-            {% if file.is_ondeck %}
-            <span class="badge badge-info">OnDeck</span>
-            {% endif %}
-            {% if file.is_watchlist %}
-            <span class="badge badge-muted">Watchlist</span>
-            {% endif %}
+            {% if file.is_ondeck %}{{ ondeck_badge() }}{% endif %}
+            {% if file.is_watchlist %}{{ watchlist_badge() }}{% endif %}
             {% if not file.is_ondeck and not file.is_watchlist and not file.is_pinned %}
-                {% if file.source == 'ondeck' %}
-                <span class="badge badge-warning">Stale OnDeck</span>
-                {% elif file.source == 'watchlist' %}
-                <span class="badge badge-warning">Stale Watchlist</span>
-                {% else %}
-                <span class="badge badge-warning">Other</span>
-                {% endif %}
+                {{ lapsed_badge(file.source) }}
             {% endif %}
             {% endif %}
         </td>

--- a/web/templates/cache/partials/file_table.html
+++ b/web/templates/cache/partials/file_table.html
@@ -25,16 +25,16 @@
         {% endif %}
         <td class="source-badges">
             {% if file.is_pinned %}
-            <span class="badge badge-pinned" title="Pinned — protected from eviction">
+            <span class="badge badge-pinned" title="{{ protected_sentence }} PlexCache won't move it back to the array either, until you unpin.">
                 <i data-lucide="pin" style="width: 10px; height: 10px; vertical-align: middle;"></i>
                 Pinned
             </span>
             {% endif %}
             {% if file.is_released %}
-            {# Released takes precedence: it is unprotected on purpose, so the
+            {# Released takes precedence: it is released on purpose, so the
                "Stale OnDeck" / "Other" wording below would misread as a problem. #}
             <span class="badge badge-released"
-                  title="Handed back to the Unraid mover. Still on cache and no longer protected, so the mover will relocate it on its own schedule.">
+                  title="Handed back to the Unraid mover. Still on cache but no longer held back, so the mover relocates it on its own schedule.">
                 <i data-lucide="send" style="width: 10px; height: 10px; vertical-align: middle;"></i>
                 Released
             </span>

--- a/web/templates/cache/partials/storage_stats.html
+++ b/web/templates/cache/partials/storage_stats.html
@@ -276,7 +276,7 @@
             </a>
             {% if data.breakdown.released.count > 0 %}
             <a href="/cache?source=released" class="breakdown-card breakdown-released"
-               title="Handed back to the Unraid mover. Still on cache and no longer protected, so the mover will relocate these on its own schedule. PlexCache keeps tracking them and will move them itself if the cache runs out of room first.">
+               title="Handed back to the Unraid mover. Still on cache but no longer held back, so the mover relocates these on its own schedule. PlexCache keeps tracking them and will move them itself if the cache runs out of room first.">
                 <div class="breakdown-header">
                     <i data-lucide="send"></i>
                     <span>Released</span>
@@ -546,7 +546,7 @@
                 <i data-lucide="timer"></i>
                 <h2>Watchlist Expiring Soon</h2>
                 {% if not data.config.eviction_enabled %}
-                <span class="badge badge-muted badge-sm" title="Smart eviction is disabled. These items will lose watchlist protection but won't be auto-removed.">Eviction Off</span>
+                <span class="badge badge-muted badge-sm" title="Smart eviction is disabled, so these won't be evicted for space. They still stop counting as watchlisted, and a run moves them back to the array unless Move Watched to Array is off.">Eviction Off</span>
                 {% endif %}
             </div>
             <select class="form-select" style="width: auto; padding: 0.25rem 0.5rem; font-size: 0.85rem;"

--- a/web/templates/components/global_operation_banner.html
+++ b/web/templates/components/global_operation_banner.html
@@ -264,18 +264,22 @@ function diPillClick() {
 // Toggle a grouped show row in the completed-state detail view.
 // Hides/shows the adjacent .di-file-row--ep sub-rows without re-rendering
 // (which would require replaying the IIFE that built detailHtml).
+// `data-show` carries the group id minted by core.media_grouping — not the show
+// name — so two groups for the same show (cached vs restored in one run) toggle
+// independently. The id is stable across the 2s poll re-renders, which is what
+// lets the expanded state below survive.
 function bannerToggleShow(evt, el) {
     if (evt && evt.stopPropagation) evt.stopPropagation();
-    var show = el.getAttribute('data-show');
+    var groupId = el.getAttribute('data-show');
     var chev = el.querySelector('.di-expand-chev');
     var expand = !chev.classList.contains('open');
     chev.classList.toggle('open');
 
-    var subs = document.querySelectorAll('.di-file-row--ep[data-parent-show="' + (show || '').replace(/"/g, '\\"') + '"]');
+    var subs = document.querySelectorAll('.di-file-row--ep[data-parent-show="' + (groupId || '') + '"]');
     subs.forEach(function(s) { s.style.display = expand ? 'flex' : 'none'; });
 
     if (!window.__bannerExpandedShows) window.__bannerExpandedShows = {};
-    window.__bannerExpandedShows[show] = expand;
+    window.__bannerExpandedShows[groupId] = expand;
 }
 
 // Preserve window scroll position across banner swaps.
@@ -1002,7 +1006,7 @@ function dismissMaintCompletionBanner() {
     var recentFiles = [
         {% for f in status.recent_files|default([]) %}
         {%- if f.is_group is defined and f.is_group %}
-        { action: '{{ f.action }}', isGroup: true, showName: {{ f.show_name|tojson }}, episodeCount: {{ f.episode_count }}, size: '{{ f.size }}', episodes: [
+        { action: '{{ f.action }}', isGroup: true, groupId: '{{ f.group_id }}', showName: {{ f.show_name|tojson }}, episodeCount: {{ f.episode_count }}, size: '{{ f.size }}', episodes: [
             {%- for ep in f.episodes %}
             { filename: '{{ ep.filename|truncate_filename(45)|e }}', fullFilename: '{{ ep.filename|e }}', size: '{{ ep.size }}', associatedFiles: [
                 {%- if ep.associated_files %}{% for af in ep.associated_files %}{ filename: '{{ af.filename|truncate_filename(45)|e }}', fullFilename: '{{ af.filename|e }}', size: '{{ af.size }}' },{% endfor %}{% endif -%}
@@ -1041,10 +1045,14 @@ function dismissMaintCompletionBanner() {
             var tagClass = f.action === 'Cached' ? 'di-action-tag--cached' : 'di-action-tag--restored';
 
             if (f.isGroup) {
-                var isExpanded = expandedShows[f.showName] === true;
+                // Keyed on groupId, not showName: one run can both cache and
+                // restore episodes of the same show, which the grouper emits as
+                // two rows sharing a name. The id also keeps user-supplied
+                // titles (which can contain quotes) out of the attribute.
+                var isExpanded = expandedShows[f.groupId] === true;
                 var chevClass = isExpanded ? 'di-expand-chev open' : 'di-expand-chev';
                 var epLabel = f.episodeCount + ' ep' + (f.episodeCount !== 1 ? 's' : '');
-                detailHtml += '<div class="di-file-row di-file-row--group" data-show="' + f.showName + '" onclick="bannerToggleShow(event, this)" style="cursor:pointer">' +
+                detailHtml += '<div class="di-file-row di-file-row--group" data-show="' + f.groupId + '" onclick="bannerToggleShow(event, this)" style="cursor:pointer">' +
                     '<span class="di-action-tag ' + tagClass + '">' + f.action.toUpperCase() + '</span>' +
                     '<span class="di-file-row__name">' + f.showName + '</span>' +
                     '<span class="di-file-row__assoc-badge">' + epLabel + '</span>' +
@@ -1053,7 +1061,7 @@ function dismissMaintCompletionBanner() {
                     '</div>';
                 f.episodes.forEach(function(ep) {
                     var epAssoc = ep.associatedFiles.length > 0 ? '<span class="di-file-row__assoc-badge">+' + ep.associatedFiles.length + '</span>' : '';
-                    detailHtml += '<div class="di-file-row di-file-row--sub di-file-row--ep" data-parent-show="' + f.showName + '" style="display:' + (isExpanded ? 'flex' : 'none') + '">' +
+                    detailHtml += '<div class="di-file-row di-file-row--sub di-file-row--ep" data-parent-show="' + f.groupId + '" style="display:' + (isExpanded ? 'flex' : 'none') + '">' +
                         '<span class="di-sub-arrow">&#8627;</span>' +
                         '<span class="di-file-row__name" title="' + ep.fullFilename + '">' + ep.filename + '</span>' +
                         epAssoc +

--- a/web/templates/components/recent_activity.html
+++ b/web/templates/components/recent_activity.html
@@ -2,15 +2,49 @@
 {% from "macros/associated_files.html" import af_expand_badge, af_expand_rows, af_expand_onclick %}
 {% from "macros/user_badge.html" import user_badge %}
 
+{#
+  Activity action badge.
+
+  These describe HISTORY — what already happened to a file — so the tooltips say
+  what was done and why, unlike the Recently Added outcome badges which predict
+  what happens next.
+
+  Every action written to the feed gets an explicit arm. The writers are
+  FileMover (Cached/Restored/Moved), PlexCacheApp._release_files (Released),
+  MaintenanceRunner.ACTION_ACTIVITY_LABELS, and the pin router. `Moved` and
+  `Released` previously fell through to the muted default, which made them
+  indistinguishable from an unrecognised action.
+
+  ACTION_LABELS re-labels at RENDER time only. The action string is persisted in
+  data/recent_activity.json, so rewriting it on disk would need a migration and
+  would rewrite history; mapping here keeps old and new entries reading the same.
+#}
+{% set ACTION_LABELS = {'Protected': 'Kept on Cache'} %}
+{% set ACTION_TOOLTIPS = {
+    'Cached':          'Copied from the array to the cache pool.',
+    'Restored':        'Moved back to the array by renaming its .plexcached backup — no bytes copied.',
+    'Moved':           'Copied back to the array. No .plexcached backup existed to rename, so the file was copied and then removed from cache.',
+    'Released':        'Handed to the Unraid mover. No bytes were moved — PlexCache dropped its exclude entry and left relocation to the mover.',
+    'Protected':       'Added to the mover exclude list and tracked, so the Unraid mover leaves it on cache. A one-time keep, not a pin — it will not be re-cached automatically.',
+    'Moved to Array':  'Copied from cache to the array by a maintenance action, then removed from cache.',
+    'Fixed':           'Had a .plexcached backup on the array, so the cache copy was removed and the backup restored to its original name.',
+    'Restored Backup': 'A .plexcached backup on the array was restored to its original filename.',
+    'Deleted Backup':  'An orphaned .plexcached backup was deleted from the array.'
+} %}
+
 {% macro action_badge(action) -%}
+{%- set label = ACTION_LABELS.get(action, action) -%}
+{%- set tip = ACTION_TOOLTIPS.get(action, '') -%}
 {%- if action in ('Cached', 'Protected', 'Fixed') -%}
-<span class="badge badge-success">{{ action }}</span>
-{%- elif action in ('Restored', 'Moved to Array', 'Restored Backup') -%}
-<span class="badge badge-info">{{ action }}</span>
+<span class="badge badge-success" title="{{ tip }}">{{ label }}</span>
+{%- elif action in ('Restored', 'Moved', 'Moved to Array', 'Restored Backup') -%}
+<span class="badge badge-info" title="{{ tip }}">{{ label }}</span>
+{%- elif action == 'Released' -%}
+<span class="badge badge-released" title="{{ tip }}">{{ label }}</span>
 {%- elif action == 'Deleted Backup' -%}
-<span class="badge badge-warning">{{ action }}</span>
+<span class="badge badge-warning" title="{{ tip }}">{{ label }}</span>
 {%- else -%}
-<span class="badge badge-muted">{{ action }}</span>
+<span class="badge badge-muted" title="{{ tip }}">{{ label }}</span>
 {%- endif -%}
 {%- endmacro %}
 

--- a/web/templates/components/recent_activity.html
+++ b/web/templates/components/recent_activity.html
@@ -19,17 +19,23 @@
   data/recent_activity.json, so rewriting it on disk would need a migration and
   would rewrite history; mapping here keeps old and new entries reading the same.
 #}
+{#
+  Tooltip rule: say the thing that changes the reader's understanding, then
+  stop. Mechanism earns a place only when it explains a difference they can
+  actually see — Restored vs Moved is the case that does, since both appear in
+  one run and otherwise look arbitrary.
+#}
 {% set ACTION_LABELS = {'Protected': 'Kept on Cache'} %}
 {% set ACTION_TOOLTIPS = {
-    'Cached':          'Copied from the array to the cache pool.',
-    'Restored':        'Moved back to the array by renaming its .plexcached backup — no bytes copied.',
-    'Moved':           'Copied back to the array. No .plexcached backup existed to rename, so the file was copied and then removed from cache.',
-    'Released':        'Handed to the Unraid mover. No bytes were moved — PlexCache dropped its exclude entry and left relocation to the mover.',
-    'Protected':       'Added to the mover exclude list and tracked, so the Unraid mover leaves it on cache. A one-time keep, not a pin — it will not be re-cached automatically.',
-    'Moved to Array':  'Copied from cache to the array by a maintenance action, then removed from cache.',
-    'Fixed':           'Had a .plexcached backup on the array, so the cache copy was removed and the backup restored to its original name.',
-    'Restored Backup': 'A .plexcached backup on the array was restored to its original filename.',
-    'Deleted Backup':  'An orphaned .plexcached backup was deleted from the array.'
+    'Cached':          'Copied to the cache pool.',
+    'Restored':        'Moved back to the array using its .plexcached backup.',
+    'Moved':           'Copied back to the array. No .plexcached backup existed.',
+    'Released':        'Handed to the Unraid mover, which relocates it on its own schedule.',
+    'Protected':       'Kept on cache so the Unraid mover leaves it alone. One-time — not a pin.',
+    'Moved to Array':  'Copied to the array by a maintenance action.',
+    'Fixed':           'Cache copy removed and its .plexcached backup restored.',
+    'Restored Backup': 'A .plexcached backup was restored to its original name.',
+    'Deleted Backup':  'An orphaned .plexcached backup was deleted.'
 } %}
 
 {% macro action_badge(action) -%}

--- a/web/templates/components/recent_activity.html
+++ b/web/templates/components/recent_activity.html
@@ -31,7 +31,7 @@
     'Restored':        'Moved back to the array using its .plexcached backup.',
     'Moved':           'Copied back to the array. No .plexcached backup existed.',
     'Released':        'Handed to the Unraid mover, which relocates it on its own schedule.',
-    'Protected':       'Kept on cache so the Unraid mover leaves it alone. One-time — not a pin.',
+    'Protected':       'Kept on cache so the Unraid mover leaves it alone.',
     'Moved to Array':  'Copied to the array by a maintenance action.',
     'Fixed':           'Cache copy removed and its .plexcached backup restored.',
     'Restored Backup': 'A .plexcached backup was restored to its original name.',

--- a/web/templates/components/recent_activity.html
+++ b/web/templates/components/recent_activity.html
@@ -74,7 +74,10 @@
 
 {% for entry in run.entries %}
 {% if entry.is_group %}
-{% set show_id = run.run_id ~ '-show-' ~ loop.index %}
+{# Group id from core.media_grouping, namespaced by run: the id is unique per
+   (action, show) within one run, but the page renders many runs and the same
+   show can appear in several of them. #}
+{% set show_id = run.run_id ~ '-' ~ entry.group_id %}
 <tr class="run-row run-show-parent{% if is_newest %} is-visible{% endif %}"
     data-run-member="{{ run.run_id }}"
     data-show-id="{{ show_id }}"

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -89,6 +89,7 @@
            Both mean "copied back to the array", so one pill matches both — it
            previously sent only "Moved to Array" and missed every run entry. #}
         <button class="activity-filter-pill" data-filter="Moved|Moved to Array">Moved</button>
+        <button class="activity-filter-pill" data-filter="Released">Released</button>
         <button class="activity-filter-pill" data-filter="other">Other</button>
     </div>
     <div class="card-body" style="padding: 0;">

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -53,6 +53,27 @@
     {% include "partials/dashboard_skeleton.html" %}
 </div>
 
+<!-- Recently Added (visibility into new media + where it lives) -->
+<div class="card">
+    <div class="card-header">
+        <i data-lucide="sparkles"></i>
+        <h2>Recently Added</h2>
+        <a href="/recently-added" class="btn btn-sm btn-secondary" style="margin-left: auto;">
+            View all <i data-lucide="arrow-right"></i>
+        </a>
+    </div>
+    <div class="card-body" style="padding: 0;">
+        <div id="recently-added-widget"
+             hx-get="/recently-added/widget"
+             hx-trigger="load"
+             hx-swap="innerHTML">
+            <div class="text-muted" style="text-align: center; padding: 1.5rem; font-size: 0.85rem;">
+                <span class="spinner" style="width: 18px; height: 18px;"></span>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Recent Activity (Last 24 Hours) -->
 <div class="card">
     <div class="card-header">

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -81,11 +81,14 @@
         <h2>Recent Activity</h2>
         <span class="text-muted" style="font-size: 0.75rem; margin-left: auto;">Last {{ retention_label }}</span>
     </div>
-    <div class="activity-filter-bar" style="padding: 0.75rem 1.25rem;">
+    <div class="activity-filter-bar" id="activity-filter-bar" style="padding: 0.75rem 1.25rem;">
         <button class="activity-filter-pill active" data-filter="all">All</button>
         <button class="activity-filter-pill" data-filter="Cached">Cached</button>
         <button class="activity-filter-pill" data-filter="Restored">Restored</button>
-        <button class="activity-filter-pill" data-filter="Moved to Array">Moved</button>
+        {# Runs write "Moved"; maintenance sync-to-array writes "Moved to Array".
+           Both mean "copied back to the array", so one pill matches both — it
+           previously sent only "Moved to Array" and missed every run entry. #}
+        <button class="activity-filter-pill" data-filter="Moved|Moved to Array">Moved</button>
         <button class="activity-filter-pill" data-filter="other">Other</button>
     </div>
     <div class="card-body" style="padding: 0;">
@@ -147,7 +150,22 @@ document.getElementById('verbose-toggle').addEventListener('change', saveVerbose
 // throw on `const` redeclaration (the partial includes its own <script>).
 var ActivityRuns = window.ActivityRuns || {
     EXPANDED_RUNS_KEY: 'plexcache_dashboard_expanded_runs',
-    KNOWN_ACTIONS: ['Cached', 'Restored', 'Moved to Array', 'Protected'],
+    // Actions covered by a specific pill, derived from the pills themselves so
+    // the two can't drift. The hardcoded list previously named 'Protected',
+    // which has no pill — so those rows matched neither their own filter nor
+    // "Other" and were reachable only under "All".
+    knownActions: function() {
+        var acts = [];
+        document.querySelectorAll('#activity-filter-bar .activity-filter-pill[data-filter]')
+            .forEach(function(pill) {
+                var f = pill.getAttribute('data-filter');
+                if (f === 'all' || f === 'other') return;
+                f.split('|').forEach(function(a) {
+                    if (a && acts.indexOf(a) === -1) acts.push(a);
+                });
+            });
+        return acts;
+    },
 
     loadExpandedRuns: function() {
         try {
@@ -226,12 +244,15 @@ var ActivityRuns = window.ActivityRuns || {
         var self = this;
 
         // Per-row filter decision
+        var known = self.knownActions();
         tbody.querySelectorAll('.run-row[data-action]').forEach(function(row) {
             var action = row.getAttribute('data-action');
+            // A pill may name several actions ("Moved|Moved to Array") when one
+            // user-facing outcome has more than one internal label.
             var pass = (
                 filter === 'all' ||
-                (filter === 'other' && self.KNOWN_ACTIONS.indexOf(action) === -1) ||
-                action === filter
+                (filter === 'other' && known.indexOf(action) === -1) ||
+                filter.split('|').indexOf(action) !== -1
             );
             row.dataset.filterPass = pass ? '1' : '0';
             // When filtered out, force-hide via inline style (overrides .is-visible)

--- a/web/templates/macros/pin_button.html
+++ b/web/templates/macros/pin_button.html
@@ -29,7 +29,7 @@
     <input type="hidden" name="pin_type" value="{{ pin_type }}">
     <input type="hidden" name="title" value="{{ title }}">
     <button type="submit" class="btn btn-sm {% if is_pinned %}btn-secondary{% else %}btn-primary{% endif %}"
-            title="{% if is_pinned %}Unpin this item{% else %}Pin this item{% endif %}">
+            title="{% if is_pinned %}Unpin — allow this item to be evicted or moved back to the array{% else %}Pin — always keep this item on cache (never evicted){% endif %}">
         <i data-lucide="{% if is_pinned %}pin-off{% else %}pin{% endif %}" style="width: 14px; height: 14px; vertical-align: middle;"></i>
         {% if is_pinned %}Unpin{% else %}Pin{% endif %}
     </button>

--- a/web/templates/macros/pin_button.html
+++ b/web/templates/macros/pin_button.html
@@ -17,10 +17,26 @@
 
   See PINNED_MEDIA_PLAN.md → Phase 4 discovery #6 for the rationale behind this shape.
 #}
-{% macro pin_button(rating_key, pin_type, title, is_pinned) %}
+{% macro pin_button(rating_key, pin_type, title, is_pinned, label='', confirm='', disabled=False, disabled_reason='') %}
+{#
+  Optional params (all default to reproducing the original output byte-for-byte):
+    label           — override the button text, e.g. "Unpin show"
+    confirm         — hx-confirm text; use when the click affects more than this row
+    disabled        — render a non-submitting button (pin state indeterminate)
+    disabled_reason — tooltip explaining why
+#}
+{% if disabled %}
+<button type="button" class="btn btn-sm btn-secondary" disabled
+        title="{{ disabled_reason or 'Pin state could not be checked.' }}"
+        style="margin: 0; opacity: 0.55; cursor: not-allowed;">
+    <i data-lucide="pin" style="width: 14px; height: 14px; vertical-align: middle;"></i>
+    Pin
+</button>
+{% else %}
 <form hx-post="/api/pinned/toggle"
       hx-target="this"
       hx-swap="outerHTML"
+      {% if confirm %}hx-confirm="{{ confirm }}"{% endif %}
       class="pinned-toggle-form"
       data-rating-key="{{ rating_key }}"
       data-is-pinned="{{ 'true' if is_pinned else 'false' }}"
@@ -31,7 +47,8 @@
     <button type="submit" class="btn btn-sm {% if is_pinned %}btn-secondary{% else %}btn-primary{% endif %}"
             title="{% if is_pinned %}Unpin — allow this item to be evicted or moved back to the array{% else %}Pin — always keep this item on cache (never evicted){% endif %}">
         <i data-lucide="{% if is_pinned %}pin-off{% else %}pin{% endif %}" style="width: 14px; height: 14px; vertical-align: middle;"></i>
-        {% if is_pinned %}Unpin{% else %}Pin{% endif %}
+        {% if label %}{{ label }}{% elif is_pinned %}Unpin{% else %}Pin{% endif %}
     </button>
 </form>
+{% endif %}
 {% endmacro %}

--- a/web/templates/macros/source_badge.html
+++ b/web/templates/macros/source_badge.html
@@ -16,8 +16,8 @@
 #}
 
 {% set SOURCE_TOOLTIPS = {
-    'ondeck':          'On a Plex user\'s OnDeck, so PlexCache keeps it on cache for now. Not eviction protection — pin it for that.',
-    'watchlist':       'On a Plex user\'s Watchlist, so PlexCache keeps it on cache for now. Not eviction protection — pin it for that.',
+    'ondeck':          'On a Plex user\'s OnDeck, so PlexCache keeps it on cache for now.',
+    'watchlist':       'On a Plex user\'s Watchlist, so PlexCache keeps it on cache for now.',
     'stale_ondeck':    'Cached for OnDeck, but it has since dropped off. The next run moves it back to the array.',
     'stale_watchlist': 'Cached for a Watchlist, but it has since dropped off. The next run moves it back to the array.',
     'other':           'On cache, but PlexCache no longer has a reason to keep it. The next run moves it back to the array.'

--- a/web/templates/macros/source_badge.html
+++ b/web/templates/macros/source_badge.html
@@ -1,0 +1,46 @@
+{#
+  Shared "why is this on cache" badges.
+
+  Both the Cached Files table and the Recently Added rows answer the same
+  question — what put this file on the cache pool, and does that still hold —
+  so the wording lives here rather than being hand-copied. Hand-copied copy is
+  how "Protected" ended up meaning three different things across the app.
+
+  Tooltip rule (same as the outcome badges): say the thing that changes the
+  reader's understanding, then stop.
+
+  The load-bearing claim in these is that OnDeck and Watchlist are NOT eviction
+  protection. They add +15 to the priority score (core/file_operations.py) and
+  defer the move back to the array; only a pin exempts a file from eviction.
+  Keep that distinction in any rewording.
+#}
+
+{% set SOURCE_TOOLTIPS = {
+    'ondeck':          'On a Plex user\'s OnDeck, so PlexCache keeps it on cache for now. Not eviction protection — pin it for that.',
+    'watchlist':       'On a Plex user\'s Watchlist, so PlexCache keeps it on cache for now. Not eviction protection — pin it for that.',
+    'stale_ondeck':    'Cached for OnDeck, but it has since dropped off. The next run moves it back to the array.',
+    'stale_watchlist': 'Cached for a Watchlist, but it has since dropped off. The next run moves it back to the array.',
+    'other':           'On cache, but PlexCache no longer has a reason to keep it. The next run moves it back to the array.'
+} %}
+
+{% macro ondeck_badge() -%}
+<span class="badge badge-info" title="{{ SOURCE_TOOLTIPS['ondeck'] }}">OnDeck</span>
+{%- endmacro %}
+
+{% macro watchlist_badge() -%}
+<span class="badge badge-muted" title="{{ SOURCE_TOOLTIPS['watchlist'] }}">Watchlist</span>
+{%- endmacro %}
+
+{#
+  A file on cache that nothing currently justifies. `source` is the tracker that
+  originally cached it, used only to say which reason lapsed.
+#}
+{% macro lapsed_badge(source) -%}
+{%- if source == 'ondeck' -%}
+<span class="badge badge-warning" title="{{ SOURCE_TOOLTIPS['stale_ondeck'] }}">Stale OnDeck</span>
+{%- elif source == 'watchlist' -%}
+<span class="badge badge-warning" title="{{ SOURCE_TOOLTIPS['stale_watchlist'] }}">Stale Watchlist</span>
+{%- else -%}
+<span class="badge badge-warning" title="{{ SOURCE_TOOLTIPS['other'] }}">Other</span>
+{%- endif -%}
+{%- endmacro %}

--- a/web/templates/maintenance/index.html
+++ b/web/templates/maintenance/index.html
@@ -9,7 +9,7 @@
         </div>
         <div>
             <h1>Maintenance</h1>
-            <p>Verify files are properly protected and tracked</p>
+            <p>Verify every cached file is tracked and managed</p>
         </div>
     </div>
 </header>

--- a/web/templates/maintenance/partials/audit_results.html
+++ b/web/templates/maintenance/partials/audit_results.html
@@ -116,10 +116,11 @@
         <div id="untracked-bulk-actions" class="flex gap-1 mb-1" style="display: none;">
             <span class="text-muted">Selected: <strong id="untracked-selected-count">0</strong></span>
             <button class="btn btn-sm btn-success" onclick="keepOnCacheSelected()"
-                    title="Keep these files on cache once — creates an array backup and excludes them from the mover. This is a one-time action, not a pin: they won't be re-cached automatically. To always keep an item cached, pin it in Settings → Cache.">
+                    title="Keep on cache once — backs up to the array and excludes from the mover. Not a pin: won't re-cache automatically.">
                 <i data-lucide="hard-drive"></i> Keep on Cache
             </button>
-            <button class="btn btn-sm btn-secondary" onclick="moveToArraySelected()">
+            <button class="btn btn-sm btn-secondary" onclick="moveToArraySelected()"
+                    title="Move these files off the cache drive to the array, freeing cache space.">
                 <i data-lucide="database"></i> Move to Array
             </button>
         </div>

--- a/web/templates/maintenance/partials/audit_results.html
+++ b/web/templates/maintenance/partials/audit_results.html
@@ -110,12 +110,13 @@
     </div>
     <div class="card-body" style="padding: 0.75rem;">
         <p class="text-muted" style="margin: 0 0 0.75rem 0;">
-            These files are on cache but not managed by PlexCache. {% if is_unraid %}The Unraid mover will handle them normally.{% else %}They will not be automatically moved.{% endif %} Use the actions below if you want PlexCache to manage them:
+            These files are on cache but not managed by PlexCache. {% if is_unraid %}The Unraid mover will handle them normally.{% else %}They will not be automatically moved.{% endif %} Use the actions below to decide what happens to them:
         </p>
         <!-- Bulk Actions -->
         <div id="untracked-bulk-actions" class="flex gap-1 mb-1" style="display: none;">
             <span class="text-muted">Selected: <strong id="untracked-selected-count">0</strong></span>
-            <button class="btn btn-sm btn-success" onclick="keepOnCacheSelected()">
+            <button class="btn btn-sm btn-success" onclick="keepOnCacheSelected()"
+                    title="Keep these files on cache once — creates an array backup and excludes them from the mover. This is a one-time action, not a pin: they won't be re-cached automatically. To always keep an item cached, pin it in Settings → Cache.">
                 <i data-lucide="hard-drive"></i> Keep on Cache
             </button>
             <button class="btn btn-sm btn-secondary" onclick="moveToArraySelected()">
@@ -851,7 +852,7 @@ function keepOnCacheSelected() {
                 <i data-lucide="hard-drive" style="width: 18px; height: 18px; vertical-align: middle;"></i>
                 Keep ${count} file(s) on Cache
             </h4>
-            <p style="margin: 0 0 1rem 0;">These files will remain on your fast cache drive with full protection.</p>
+            <p style="margin: 0 0 1rem 0;">These files will stay on your cache drive with a backup on the array. This is a <strong>one-time keep</strong> — it does not pin them, so they won't be re-cached automatically on future runs. To always keep an item cached, pin it in Settings → Cache.</p>
         </div>
 
         <div class="confirm-section" style="background: var(--plex-surface); padding: 1rem; border-radius: var(--plex-radius-sm); margin-bottom: 1rem;">
@@ -859,7 +860,7 @@ function keepOnCacheSelected() {
             <ol style="margin: 0.5rem 0 0 1.5rem; padding: 0;">
                 <li>Copy each file to the array as a <code>.plexcached</code> backup</li>
                 <li>Add to the {% if is_unraid %}Unraid mover exclude list{% else %}cache tracking list{% endif %}</li>
-                <li>Register in PlexCache tracking</li>
+                <li>Add to PlexCache's cache tracking (one-time — not a pin)</li>
             </ol>
         </div>
 

--- a/web/templates/maintenance/partials/audit_results.html
+++ b/web/templates/maintenance/partials/audit_results.html
@@ -45,17 +45,17 @@
         {% endif %}
     </div>
 
-    <div class="stat-card {% if results.unprotected_files|length == 0 %}stat-card-success{% endif %}">
+    <div class="stat-card {% if results.untracked_files|length == 0 %}stat-card-success{% endif %}">
         <div class="stat-card-header">
-            {% if results.unprotected_files|length == 0 %}
+            {% if results.untracked_files|length == 0 %}
             <i data-lucide="shield-check"></i>
             {% else %}
             <i data-lucide="eye"></i>
             {% endif %}
             Untracked
         </div>
-        <div class="stat-value">{{ results.unprotected_files|length }}</div>
-        <div class="stat-label">{% if results.unprotected_files|length == 0 %}all tracked{% else %}not managed{% endif %}</div>
+        <div class="stat-value">{{ results.untracked_files|length }}</div>
+        <div class="stat-label">{% if results.untracked_files|length == 0 %}all tracked{% else %}not managed{% endif %}</div>
     </div>
 
     <div class="stat-card {% if results.orphaned_plexcached|length > 20 %}stat-card-danger{% elif results.orphaned_plexcached|length > 0 %}stat-card-warning{% else %}stat-card-success{% endif %}">
@@ -71,12 +71,17 @@
         <div class="stat-label">{% if results.orphaned_plexcached|length == 0 %}none found{% else %}need attention{% endif %}</div>
     </div>
 
+    {# "Mover-excluded", not "Protected": this counts exclude-list membership,
+       which holds the Unraid mover back. It is not eviction protection — only a
+       pin is that. The value is the intersection with what's actually on cache;
+       exclude_entry_count includes stale lines, so it could exceed the "of M"
+       denominator and render "3 of 1 on cache". #}
     <div class="stat-card">
         <div class="stat-card-header">
             <i data-lucide="shield-check"></i>
-            Protected
+            Mover-excluded
         </div>
-        <div class="stat-value">{{ results.exclude_entry_count }}</div>
+        <div class="stat-value">{{ results.excluded_on_cache_count }}</div>
         <div class="stat-label">of {{ results.cache_file_count }} on cache</div>
     </div>
 </div>
@@ -102,11 +107,11 @@
 {% endif %}
 
 <!-- Untracked Files Section -->
-{% if results.unprotected_files %}
+{% if results.untracked_files %}
 <div class="card mb-2">
     <div class="card-header">
         <i data-lucide="eye"></i>
-        <h2>Untracked Files ({{ results.unprotected_files|length }}{% if results.grouped_unprotected|length != results.unprotected_files|length %} in {{ results.grouped_unprotected|length }} groups{% endif %})</h2>
+        <h2>Untracked Files ({{ results.untracked_files|length }}{% if results.grouped_untracked|length != results.untracked_files|length %} in {{ results.grouped_untracked|length }} groups{% endif %})</h2>
     </div>
     <div class="card-body" style="padding: 0.75rem;">
         <p class="text-muted" style="margin: 0 0 0.75rem 0;">
@@ -146,7 +151,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for group in results.grouped_unprotected %}
+                    {% for group in results.grouped_untracked %}
                     {% set file = group.primary %}
                     {% set children = group.children %}
                     {% set group_size = file.size + children|sum(attribute='size') if children else file.size %}
@@ -396,7 +401,7 @@
                 <button class="btn btn-sm btn-primary"
                         hx-post="/operations/run"
                         hx-swap="none"
-                        title="Start a run to re-protect pinned files">
+                        title="Start a run to re-add pinned files to the mover exclude list">
                     <i data-lucide="play"></i> Run Now
                 </button>
             </div>
@@ -581,12 +586,12 @@
 {% endif %}
 
 <!-- No Issues Message -->
-{% if not results.unprotected_files and not results.orphaned_plexcached and not results.extensionless_files and not results.stale_exclude_entries and not results.stale_timestamp_entries %}
+{% if not results.untracked_files and not results.orphaned_plexcached and not results.extensionless_files and not results.stale_exclude_entries and not results.stale_timestamp_entries %}
 <div class="card">
     <div class="card-body" style="text-align: center; padding: 3rem;">
         <i data-lucide="check-circle" style="width: 64px; height: 64px; color: var(--success); margin-bottom: 1rem;"></i>
         <h3 style="margin-bottom: 0.5rem;">Cache is Healthy</h3>
-        <p class="text-muted">No issues found. All files are properly tracked and protected.</p>
+        <p class="text-muted">No issues found. Every cached file is tracked.</p>
     </div>
 </div>
 {% endif %}

--- a/web/templates/maintenance/partials/audit_skeleton.html
+++ b/web/templates/maintenance/partials/audit_skeleton.html
@@ -44,5 +44,5 @@
 <!-- Loading indicator -->
 <div class="loading-container">
     <div class="spinner"></div>
-    <p>Checking protection status...</p>
+    <p>Checking tracking status...</p>
 </div>

--- a/web/templates/maintenance/partials/health_widget.html
+++ b/web/templates/maintenance/partials/health_widget.html
@@ -12,7 +12,7 @@
         <span class="stat-label">Tracking Health</span>
         <span class="stat-value">
             {% if health.status == 'critical' %}
-            {{ health.unprotected_count + health.orphaned_count }} issues
+            {{ health.untracked_count + health.orphaned_count }} issues
             {% elif health.status == 'warnings' %}
             {{ health.stale_exclude_count + health.stale_timestamp_count }} warnings
             {% else %}

--- a/web/templates/recently_added/index.html
+++ b/web/templates/recently_added/index.html
@@ -157,7 +157,17 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
     // which is what makes restoring expansion by id work.
     function restore() {
         var lib = document.getElementById('ra-lib-filter');
-        if (lib && _state.lib) lib.value = _state.lib;
+        if (lib && _state.lib) {
+            lib.value = _state.lib;
+            // The Library options are built from whatever rows the server
+            // returned, so a narrower window — or an item ageing out between
+            // refetches — can drop the selected library entirely. Assigning a
+            // value no <option> carries leaves the select at selectedIndex -1
+            // with value "", which matches no row: every row would hide behind
+            // "No items match" under a blank dropdown, with nothing on screen
+            // explaining why. Fall back to showing everything.
+            if (lib.selectedIndex === -1) { lib.value = 'all'; _state.lib = 'all'; }
+        }
         var search = document.getElementById('ra-search');
         if (search && _state.term) search.value = _state.term;
 

--- a/web/templates/recently_added/index.html
+++ b/web/templates/recently_added/index.html
@@ -36,9 +36,16 @@
 </div>
 
 <!-- Lazy-loaded content (stat cards + filters + table) -->
+{# Refetches on pin/unpin: the pin button swaps only its own <form>, so without
+   this the row's outcome badge, status note and group header keep asserting the
+   pre-click state — and after an *unpin* the badge still promises the file stays
+   on cache while a background eviction of it has already started. The small
+   delay lets the toggle's own swap land first. RecentlyAdded._state restores the
+   user's filters and expanded groups after the swap. #}
 <div id="ra-content"
-     hx-get="/recently-added/list?days={{ default_days }}"
-     hx-trigger="load"
+     hx-get="/recently-added/list"
+     hx-include="#ra-days-input"
+     hx-trigger="load, pinned-updated from:body delay:400ms"
      hx-swap="innerHTML">
     <div class="card">
         <div class="card-body" style="text-align: center; padding: 3rem;">
@@ -61,6 +68,11 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
             activePill: document.querySelector('.ra-loc-pill.active'),
         };
     }
+
+    // The user's current view, kept in memory so it survives an HTMX swap of
+    // #ra-content (the pin/unpin refetch). Deliberately not persisted: a stale
+    // search term restored on a fresh page load would look like a bug.
+    var _state = { lib: '', term: '', loc: 'all', expanded: {} };
 
     // Does a single media row match the active library/search/location filters?
     function rowMatches(row, lib, term, loc) {
@@ -129,7 +141,35 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
 
     function toggleGroup(header) {
         header.classList.toggle('is-open');
+        var gid = header.getAttribute('data-group-id');
+        if (gid) {
+            if (header.classList.contains('is-open')) _state.expanded[gid] = true;
+            else delete _state.expanded[gid];
+        }
         apply();
+    }
+
+    // Re-apply the remembered view to freshly-swapped markup. Without this a
+    // pin/unpin refetch silently resets the library filter, the search term,
+    // the location pill and every expanded group — trading one wrong-state bug
+    // for another. Group ids are stable across renders (core.media_grouping's
+    // stable_group_id derives them from the grouping key, not list position),
+    // which is what makes restoring expansion by id work.
+    function restore() {
+        var lib = document.getElementById('ra-lib-filter');
+        if (lib && _state.lib) lib.value = _state.lib;
+        var search = document.getElementById('ra-search');
+        if (search && _state.term) search.value = _state.term;
+
+        if (_state.loc && _state.loc !== 'all') {
+            document.querySelectorAll('.ra-loc-pill').forEach(function (p) {
+                p.classList.toggle('active', p.getAttribute('data-loc') === _state.loc);
+            });
+        }
+
+        document.querySelectorAll('#ra-table-body .ra-group-header').forEach(function (h) {
+            if (_state.expanded[h.getAttribute('data-group-id')]) h.classList.add('is-open');
+        });
     }
 
     // Expand/collapse a leaf row's file-detail sub-rows.
@@ -150,12 +190,15 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
             p.classList.remove('active');
         });
         pill.classList.add('active');
+        _state.loc = pill.getAttribute('data-loc') || 'all';
         apply();
     }
 
     // Event delegation survives HTMX swaps of #ra-content.
     document.addEventListener('input', function (e) {
         if (e.target && (e.target.id === 'ra-lib-filter' || e.target.id === 'ra-search')) {
+            if (e.target.id === 'ra-lib-filter') _state.lib = e.target.value;
+            else _state.term = e.target.value;
             apply();
         }
     });
@@ -164,10 +207,14 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
         if (pill) setPill(pill);
     });
     document.body.addEventListener('htmx:afterSwap', function (e) {
-        if (e.detail.target && e.detail.target.id === 'ra-content') apply();
+        if (e.detail.target && e.detail.target.id === 'ra-content') {
+            restore();
+            apply();
+        }
     });
 
-    return { apply: apply, setPill: setPill, toggleGroup: toggleGroup, toggleDetail: toggleDetail };
+    return { apply: apply, setPill: setPill, toggleGroup: toggleGroup,
+             toggleDetail: toggleDetail, restore: restore };
 })();
 </script>
 {% endblock %}

--- a/web/templates/recently_added/index.html
+++ b/web/templates/recently_added/index.html
@@ -72,7 +72,11 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
     // The user's current view, kept in memory so it survives an HTMX swap of
     // #ra-content (the pin/unpin refetch). Deliberately not persisted: a stale
     // search term restored on a fresh page load would look like a bug.
-    var _state = { lib: '', term: '', loc: 'all', expanded: {} };
+    // `expanded` holds show groups by data-group-id; `details` holds leaf rows
+    // by data-row-id. Both are view state and both must survive the pin/unpin
+    // refetch — inspecting a row's files and then pinning it is the page's main
+    // sequence, and the pin swaps #ra-content out from under the expansion.
+    var _state = { lib: '', term: '', loc: 'all', expanded: {}, details: {} };
 
     // Does a single media row match the active library/search/location filters?
     function rowMatches(row, lib, term, loc) {
@@ -83,17 +87,29 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
     }
 
     // A leaf row's detail sub-rows (.associated-sub-row) follow it directly.
-    // Reset them (collapse) when the leaf row itself is hidden/collapsed.
-    function resetDetailRows(leafRow, visible) {
+    // Open or close all of them together, chevron included. Takes the target
+    // state rather than toggling each sub-row, so a row can be restored to a
+    // known state instead of only flipped from whatever it currently shows.
+    function setDetail(leafRow, open) {
+        var chev = leafRow.querySelector('.ra-detail-chevron');
+        if (chev) chev.classList.toggle('open', open);
         var s = leafRow.nextElementSibling;
         while (s && s.classList.contains('associated-sub-row')) {
-            if (!visible) s.classList.remove('af-visible');
+            s.classList.toggle('af-visible', open);
             s = s.nextElementSibling;
         }
-        if (!visible) {
-            var chev = leafRow.querySelector('.ra-detail-chevron');
-            if (chev) chev.classList.remove('open');
-        }
+    }
+
+    // Collapse a leaf row's details when the row itself is hidden, so a row
+    // filtered out of view cannot leave its sub-rows on screen. Forgetting the
+    // row here as well keeps what is remembered in step with what is shown:
+    // filtering discards detail state deliberately, so clearing the filter must
+    // not spring rows back open on its own.
+    function resetDetailRows(leafRow, visible) {
+        if (visible) return;
+        setDetail(leafRow, false);
+        var id = leafRow.getAttribute('data-row-id');
+        if (id) delete _state.details[id];
     }
 
     function apply() {
@@ -180,6 +196,13 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
         document.querySelectorAll('#ra-table-body .ra-group-header').forEach(function (h) {
             if (_state.expanded[h.getAttribute('data-group-id')]) h.classList.add('is-open');
         });
+
+        // Re-open the rows whose file details were showing. Safe to run before
+        // apply(): apply() only ever collapses details for rows it hides, so a
+        // row restored here and then filtered out still ends up closed.
+        document.querySelectorAll('#ra-table-body .ra-row').forEach(function (r) {
+            if (_state.details[r.getAttribute('data-row-id')]) setDetail(r, true);
+        });
     }
 
     // Expand/collapse a leaf row's file-detail sub-rows.
@@ -187,11 +210,12 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
         var row = td.closest ? td.closest('tr') : null;
         if (!row) return;
         var chev = row.querySelector('.ra-detail-chevron');
-        if (chev) chev.classList.toggle('open');
-        var s = row.nextElementSibling;
-        while (s && s.classList.contains('associated-sub-row')) {
-            s.classList.toggle('af-visible');
-            s = s.nextElementSibling;
+        var open = !(chev && chev.classList.contains('open'));
+        setDetail(row, open);
+        var id = row.getAttribute('data-row-id');
+        if (id) {
+            if (open) _state.details[id] = true;
+            else delete _state.details[id];
         }
     }
 

--- a/web/templates/recently_added/index.html
+++ b/web/templates/recently_added/index.html
@@ -70,6 +70,20 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
         return matchLib && matchLoc && matchTerm;
     }
 
+    // A leaf row's detail sub-rows (.associated-sub-row) follow it directly.
+    // Reset them (collapse) when the leaf row itself is hidden/collapsed.
+    function resetDetailRows(leafRow, visible) {
+        var s = leafRow.nextElementSibling;
+        while (s && s.classList.contains('associated-sub-row')) {
+            if (!visible) s.classList.remove('af-visible');
+            s = s.nextElementSibling;
+        }
+        if (!visible) {
+            var chev = leafRow.querySelector('.ra-detail-chevron');
+            if (chev) chev.classList.remove('open');
+        }
+    }
+
     function apply() {
         var c = getControls();
         if (!c.lib && !c.search && !c.activePill) return;
@@ -85,6 +99,7 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
             anyRows = true;
             var visible = rowMatches(row, lib, term, loc);
             row.style.display = visible ? '' : 'none';
+            resetDetailRows(row, visible);
             if (visible) shown++;
         });
 
@@ -100,7 +115,9 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
             children.forEach(function (child) {
                 var m = rowMatches(child, lib, term, loc);
                 if (m) anyMatch = true;
-                child.style.display = (m && expanded) ? '' : 'none';
+                var visible = m && expanded;
+                child.style.display = visible ? '' : 'none';
+                resetDetailRows(child, visible);
             });
             header.style.display = anyMatch ? '' : 'none';
             if (anyMatch) shown++;
@@ -113,6 +130,19 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
     function toggleGroup(header) {
         header.classList.toggle('is-open');
         apply();
+    }
+
+    // Expand/collapse a leaf row's file-detail sub-rows.
+    function toggleDetail(td) {
+        var row = td.closest ? td.closest('tr') : null;
+        if (!row) return;
+        var chev = row.querySelector('.ra-detail-chevron');
+        if (chev) chev.classList.toggle('open');
+        var s = row.nextElementSibling;
+        while (s && s.classList.contains('associated-sub-row')) {
+            s.classList.toggle('af-visible');
+            s = s.nextElementSibling;
+        }
     }
 
     function setPill(pill) {
@@ -137,7 +167,7 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
         if (e.detail.target && e.detail.target.id === 'ra-content') apply();
     });
 
-    return { apply: apply, setPill: setPill, toggleGroup: toggleGroup };
+    return { apply: apply, setPill: setPill, toggleGroup: toggleGroup, toggleDetail: toggleDetail };
 })();
 </script>
 {% endblock %}

--- a/web/templates/recently_added/index.html
+++ b/web/templates/recently_added/index.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+
+{% block content %}
+<!-- Page Header -->
+<header class="page-header">
+    <div class="page-title">
+        <div class="page-title-icon">
+            <i data-lucide="sparkles"></i>
+        </div>
+        <div>
+            <h1>Recently Added</h1>
+            <p>New media in your libraries and where it physically lives</p>
+        </div>
+    </div>
+    <div class="action-buttons">
+        <button class="btn btn-secondary"
+                hx-get="/recently-added/list"
+                hx-target="#ra-content"
+                hx-swap="innerHTML"
+                hx-include="#ra-days-input">
+            <i data-lucide="refresh-cw"></i>
+            Refresh
+        </button>
+    </div>
+</header>
+
+<!-- Concept explainer -->
+<div class="alert alert-info" style="margin-bottom: 1.5rem;">
+    <i data-lucide="info"></i>
+    <span>
+        New media is cached automatically once it hits your Watchlist or On&nbsp;Deck.
+        To hold something on the cache yourself, <strong>Pin</strong> it: items already on
+        the cache drive are pinned instantly (no copy); items on the array are copied over on
+        the next run. Pins stay until you unpin them.
+    </span>
+</div>
+
+<!-- Lazy-loaded content (stat cards + filters + table) -->
+<div id="ra-content"
+     hx-get="/recently-added/list?days={{ default_days }}"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+    <div class="card">
+        <div class="card-body" style="text-align: center; padding: 3rem;">
+            <span class="spinner" style="width: 28px; height: 28px;"></span>
+            <div class="text-muted" style="margin-top: 0.75rem;">Loading recently added media...</div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+// Client-side filtering over the loaded rows (library + search + location).
+// The "Added Within" (days) dropdown re-fetches from the server via HTMX.
+var RecentlyAdded = window.RecentlyAdded || (function () {
+    function getControls() {
+        return {
+            lib: document.getElementById('ra-lib-filter'),
+            search: document.getElementById('ra-search'),
+            activePill: document.querySelector('.ra-loc-pill.active'),
+        };
+    }
+
+    function apply() {
+        var c = getControls();
+        if (!c.lib && !c.search && !c.activePill) return;
+        var lib = c.lib ? c.lib.value : 'all';
+        var term = c.search ? c.search.value.trim().toLowerCase() : '';
+        var loc = c.activePill ? c.activePill.getAttribute('data-loc') : 'all';
+
+        var rows = document.querySelectorAll('#ra-table-body .ra-row');
+        var shown = 0;
+        rows.forEach(function (row) {
+            var matchLib = lib === 'all' || row.getAttribute('data-library') === lib;
+            var matchLoc = loc === 'all' || row.getAttribute('data-loc') === loc;
+            var matchTerm = !term || (row.getAttribute('data-title') || '').indexOf(term) !== -1;
+            var visible = matchLib && matchLoc && matchTerm;
+            row.style.display = visible ? '' : 'none';
+            if (visible) shown++;
+        });
+
+        var empty = document.getElementById('ra-no-match');
+        if (empty) empty.style.display = shown === 0 && rows.length > 0 ? '' : 'none';
+    }
+
+    function setPill(pill) {
+        document.querySelectorAll('.ra-loc-pill').forEach(function (p) {
+            p.classList.remove('active');
+        });
+        pill.classList.add('active');
+        apply();
+    }
+
+    // Event delegation survives HTMX swaps of #ra-content.
+    document.addEventListener('input', function (e) {
+        if (e.target && (e.target.id === 'ra-lib-filter' || e.target.id === 'ra-search')) {
+            apply();
+        }
+    });
+    document.addEventListener('click', function (e) {
+        var pill = e.target.closest ? e.target.closest('.ra-loc-pill') : null;
+        if (pill) setPill(pill);
+    });
+    document.body.addEventListener('htmx:afterSwap', function (e) {
+        if (e.detail.target && e.detail.target.id === 'ra-content') apply();
+    });
+
+    return { apply: apply, setPill: setPill };
+})();
+</script>
+{% endblock %}

--- a/web/templates/recently_added/index.html
+++ b/web/templates/recently_added/index.html
@@ -62,6 +62,14 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
         };
     }
 
+    // Does a single media row match the active library/search/location filters?
+    function rowMatches(row, lib, term, loc) {
+        var matchLib = lib === 'all' || row.getAttribute('data-library') === lib;
+        var matchLoc = loc === 'all' || row.getAttribute('data-loc') === loc;
+        var matchTerm = !term || (row.getAttribute('data-title') || '').indexOf(term) !== -1;
+        return matchLib && matchLoc && matchTerm;
+    }
+
     function apply() {
         var c = getControls();
         if (!c.lib && !c.search && !c.activePill) return;
@@ -69,19 +77,42 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
         var term = c.search ? c.search.value.trim().toLowerCase() : '';
         var loc = c.activePill ? c.activePill.getAttribute('data-loc') : 'all';
 
-        var rows = document.querySelectorAll('#ra-table-body .ra-row');
+        var anyRows = false;
         var shown = 0;
-        rows.forEach(function (row) {
-            var matchLib = lib === 'all' || row.getAttribute('data-library') === lib;
-            var matchLoc = loc === 'all' || row.getAttribute('data-loc') === loc;
-            var matchTerm = !term || (row.getAttribute('data-title') || '').indexOf(term) !== -1;
-            var visible = matchLib && matchLoc && matchTerm;
+
+        // Standalone rows (movies + single episodes).
+        document.querySelectorAll('#ra-table-body .ra-item').forEach(function (row) {
+            anyRows = true;
+            var visible = rowMatches(row, lib, term, loc);
             row.style.display = visible ? '' : 'none';
             if (visible) shown++;
         });
 
+        // Show groups: header shows when any child matches; children show only
+        // when the group is expanded AND they match.
+        document.querySelectorAll('#ra-table-body .ra-group-header').forEach(function (header) {
+            anyRows = true;
+            var gid = header.getAttribute('data-group-id');
+            var expanded = header.classList.contains('is-open');
+            var children = document.querySelectorAll(
+                '#ra-table-body .ra-group-child[data-group="' + gid + '"]');
+            var anyMatch = false;
+            children.forEach(function (child) {
+                var m = rowMatches(child, lib, term, loc);
+                if (m) anyMatch = true;
+                child.style.display = (m && expanded) ? '' : 'none';
+            });
+            header.style.display = anyMatch ? '' : 'none';
+            if (anyMatch) shown++;
+        });
+
         var empty = document.getElementById('ra-no-match');
-        if (empty) empty.style.display = shown === 0 && rows.length > 0 ? '' : 'none';
+        if (empty) empty.style.display = (shown === 0 && anyRows) ? '' : 'none';
+    }
+
+    function toggleGroup(header) {
+        header.classList.toggle('is-open');
+        apply();
     }
 
     function setPill(pill) {
@@ -106,7 +137,7 @@ var RecentlyAdded = window.RecentlyAdded || (function () {
         if (e.detail.target && e.detail.target.id === 'ra-content') apply();
     });
 
-    return { apply: apply, setPill: setPill };
+    return { apply: apply, setPill: setPill, toggleGroup: toggleGroup };
 })();
 </script>
 {% endblock %}

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -37,18 +37,23 @@
 {% endif %}
 {% endmacro %}
 
+{# Outcome badge — names what happens to the file next rather than a state noun.
+   Every arm is explicit: the terminal branch renders a neutral em-dash, which is
+   true of any input, rather than letting an unrecognised outcome silently borrow
+   another state's badge (the defect the old {% else %} → "Protected" produced).
+   tests/test_outcome_vocabulary.py asserts every enum member appears here. #}
 {% macro ra_status_badge(row) %}
-{% if row.state == 'pinned' %}
-<span class="badge badge-pinned"><i data-lucide="pin"></i> Pinned</span>
-{% elif row.state == 'protected' %}
-<span class="badge badge-info"><i data-lucide="check"></i> Protected</span>
-{% for p in row.protected_by %}<span class="badge badge-info badge-sm">{{ p }}</span>{% endfor %}
-{% elif row.state == 'on_cache_not_pinned' %}
-<span class="badge badge-muted" title="On cache now, but not held — it'll return to the array naturally once it's no longer OnDeck/Watchlist. Pin to keep it.">Not pinned</span>
-{% elif row.state == 'on_array' %}
-<span class="badge badge-muted">Not cached</span>
-{% else %}
-<span class="badge badge-muted">Unknown</span>
+{% if   row.outcome == 'held'              %}<span class="badge badge-pinned" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="pin"></i> Stays on cache</span>
+{% elif row.outcome == 'arriving'          %}<span class="badge badge-pinned" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="arrow-down-to-line"></i> Pinned, not on cache yet</span>
+{% elif row.outcome == 'held_by_setting'   %}<span class="badge badge-info" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="sliders-horizontal"></i> Stays on cache</span>
+{% elif row.outcome == 'returns_when_done' %}<span class="badge badge-info" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="clock"></i> Returns when watched</span>
+    {% for p in row.protected_by %}{% if p != 'Pinned' %}<span class="badge badge-info badge-sm">{{ p }}</span>{% endif %}{% endfor %}
+{% elif row.outcome == 'moves_back'        %}<span class="badge badge-muted" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="arrow-down"></i> Moves to array</span>
+{% elif row.outcome == 'mover_decides'     %}<span class="badge badge-released" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="send"></i> Mover's call</span>
+{% elif row.outcome == 'stays_on_array'    %}<span class="badge badge-muted" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="server"></i> Not on cache</span>
+{% elif row.outcome == 'unmapped'          %}<span class="badge badge-muted ra-badge-dashed" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="help-circle"></i> Unmapped</span>
+{% elif row.outcome == 'pin_unknown'       %}<span class="badge badge-muted ra-badge-dashed" title="{{ outcome_tooltip(row.outcome) }}">Pin state unknown</span>
+{% else %}<span class="badge badge-muted" title="Unrecognised outcome — please report">&mdash;</span>
 {% endif %}
 {% endmacro %}
 
@@ -93,25 +98,41 @@
     <td>{{ ra_status_badge(row) }}</td>
     <td>
         {% if row.rating_key %}
+        {# The pin that actually holds this file may be a show/season pin, so the
+           button must unpin the HOLDER — writing a redundant episode pin under a
+           show pin double-counts its bytes in budget_check and strands an
+           invisible pin when the show is later unpinned. #}
+        {% if row.outcome == 'pin_unknown' %}
+        {{ pin_button(row.rating_key, row.pin_type, row.title, False,
+                      disabled=True,
+                      disabled_reason='Plex did not answer, so PlexCache cannot tell whether this is pinned. Refresh to retry.') }}
+        {% elif row.is_pinned and row.pin_scope in ('show', 'season') %}
+        {{ pin_button(row.pin_holder_key, row.pin_scope, row.pin_holder_title, True,
+                      label='Unpin ' ~ row.pin_scope,
+                      confirm='This episode is held by a ' ~ row.pin_scope ~ ' pin on "' ~ row.pin_holder_title ~ '". Unpinning releases every episode it covers. Continue?') }}
+        {% else %}
         {{ pin_button(row.rating_key, row.pin_type, row.title, row.is_pinned) }}
-        {% if row.state == 'on_cache_not_pinned' %}
-        <div class="ra-status-note">stays on cache, backs up to array</div>
-        {% elif row.state == 'on_array' %}
+        {% endif %}
+        {% if row.outcome == 'stays_on_array' %}
         <div class="ra-status-note">copies ~{{ row.size_display }} to cache</div>
-        {% elif row.state == 'protected' %}
-        <div class="ra-status-note">{{ row.protected_by|join(' / ') }} is temporary</div>
-        {% elif row.state == 'pinned' %}
-        <div class="ra-status-note">stays on cache until unpinned</div>
+        {% elif row.outcome == 'arriving' %}
+        <div class="ra-status-note">next run copies ~{{ row.size_display }} across</div>
+        {% elif row.is_pinned and row.pin_scope in ('show', 'season') %}
+        <div class="ra-status-note">held by a {{ row.pin_scope }} pin</div>
         {% endif %}
         {% else %}
         <span class="text-muted">—</span>
         {% endif %}
     </td>
 </tr>
-{# Expand detail: the primary media file, then any associated files. #}
+{# Expand detail: the primary media file, then any associated files, then any
+   other Plex versions of the same item (which PlexCache does not manage). #}
 {{ ra_detail_file(row.filename or row.title, row.size_display, group_id if is_child else '') }}
 {% for af in row.associated_files %}
 {{ ra_detail_file(af.filename, af.size, group_id if is_child else '') }}
+{% endfor %}
+{% for ov in row.other_versions %}
+{{ ra_detail_file(ov.filename ~ (' — other version' if not ov.label else ' — ' ~ ov.label ~ ' version, not managed'), ov.size, group_id if is_child else '') }}
 {% endfor %}
 {% endmacro %}
 
@@ -223,13 +244,20 @@
                             {% if item.locations|length == 1 %}{{ ra_location_badge(item.locations[0]) }}
                             {% else %}<span class="badge badge-muted">Mixed</span>{% endif %}
                         </td>
+                        {# Weakest-outcome-wins, computed in Python (_group_outcome).
+                           The old chain lived here in Jinja and fell through to
+                           "Protected" for groups where nothing was protected. #}
                         <td>
-                            {% if item.not_pinned_count %}
-                            <span class="badge badge-muted">{{ item.not_pinned_count }} not pinned</span>
-                            {% elif item.pinned_count == item.episode_count %}
-                            <span class="badge badge-pinned"><i data-lucide="pin"></i> Pinned</span>
-                            {% else %}
-                            <span class="badge badge-info"><i data-lucide="check"></i> Protected</span>
+                            {% if   item.outcome_lead == 'held'              %}<span class="badge badge-pinned" title="{{ item.outcome_tooltip }}"><i data-lucide="pin"></i> {{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'arriving'          %}<span class="badge badge-pinned" title="{{ item.outcome_tooltip }}"><i data-lucide="arrow-down-to-line"></i> {{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'held_by_setting'   %}<span class="badge badge-info" title="{{ item.outcome_tooltip }}"><i data-lucide="sliders-horizontal"></i> {{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'returns_when_done' %}<span class="badge badge-info" title="{{ item.outcome_tooltip }}"><i data-lucide="clock"></i> {{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'moves_back'        %}<span class="badge badge-muted" title="{{ item.outcome_tooltip }}"><i data-lucide="arrow-down"></i> {{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'mover_decides'     %}<span class="badge badge-released" title="{{ item.outcome_tooltip }}"><i data-lucide="send"></i> {{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'stays_on_array'    %}<span class="badge badge-muted" title="{{ item.outcome_tooltip }}"><i data-lucide="server"></i> {{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'unmapped'          %}<span class="badge badge-muted ra-badge-dashed" title="{{ item.outcome_tooltip }}">{{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'pin_unknown'       %}<span class="badge badge-muted ra-badge-dashed" title="{{ item.outcome_tooltip }}">{{ item.outcome_label }}</span>
+                            {% else %}<span class="badge badge-muted" title="Unrecognised outcome — please report">&mdash;</span>
                             {% endif %}
                         </td>
                         <td><span class="text-muted" style="font-size: 0.72rem;">expand to pin</span></td>

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -152,6 +152,23 @@
 </div>
 {% else %}
 
+{# A library Plex refused to list is missing from the table, the counts and the
+   Library filter alike. Same register as the pin_unknown outcome: an
+   unverifiable fetch becomes a named state, never a reassuring default. Markup
+   copied from cache/partials/storage_stats.html rather than including
+   partials/alert.html, which appends its own lucide.createIcons() call that
+   this template already makes. #}
+{% if unreadable_libraries %}
+<div class="alert alert-warning mb-2" style="display: flex; align-items: flex-start; gap: 0.75rem; padding: 0.75rem 1rem;">
+    <i data-lucide="alert-triangle" style="flex-shrink: 0; margin-top: 2px;"></i>
+    <div>
+        <strong>Couldn't read {{ unreadable_libraries|length }} librar{{ 'ies' if unreadable_libraries|length != 1 else 'y' }}:</strong>
+        {{ unreadable_libraries|join(', ') }}. Plex didn't answer, so anything
+        added there is missing from the counts and the table below. Refresh to retry.
+    </div>
+</div>
+{% endif %}
+
 <!-- Stat cards -->
 <div class="stats-row">
     <div class="stat-card">
@@ -277,7 +294,13 @@
                 {% if not groups %}
                 <tr id="ra-empty-row">
                     <td colspan="7" class="text-muted" style="text-align: center; padding: 2.5rem;">
+                        {# Only claim there is nothing new if every library answered.
+                           Otherwise the sentence would be about media never read. #}
+                        {% if unreadable_libraries %}
+                        No results from the libraries that answered.
+                        {% else %}
                         Nothing added in the last {{ days }} day{{ 's' if days != 1 else '' }}.
+                        {% endif %}
                     </td>
                 </tr>
                 {% endif %}

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -1,4 +1,5 @@
 {% from "macros/pin_button.html" import pin_button %}
+{% from "macros/source_badge.html" import ondeck_badge, watchlist_badge %}
 {#
   Recently Added — stat cards + filter bar + table.
 
@@ -48,7 +49,9 @@
 {% elif row.outcome == 'arriving'          %}<span class="badge badge-pinned" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="arrow-down-to-line"></i> Pinned, not on cache yet</span>
 {% elif row.outcome == 'held_by_setting'   %}<span class="badge badge-info" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="sliders-horizontal"></i> Not moved back</span>
 {% elif row.outcome == 'returns_when_done' %}<span class="badge badge-info" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="clock"></i> Returns when watched</span>
-    {% for p in row.protected_by %}{% if p != 'Pinned' %}<span class="badge badge-info badge-sm">{{ p }}</span>{% endif %}{% endfor %}
+    {# Which list is holding it. Same badges and wording as Cached Files. #}
+    {% if row.is_ondeck %}{{ ondeck_badge() }}{% endif %}
+    {% if row.is_watchlist %}{{ watchlist_badge() }}{% endif %}
 {% elif row.outcome == 'moves_back'        %}<span class="badge badge-muted" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="arrow-down"></i> Moves to array</span>
 {% elif row.outcome == 'mover_decides'     %}<span class="badge badge-released" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="send"></i> Mover's call</span>
 {% elif row.outcome == 'stays_on_array'    %}<span class="badge badge-muted" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="server"></i> Not on cache</span>

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -21,10 +21,7 @@
 {% macro ra_detail_file(name, size, group_id='') %}
 <tr class="associated-sub-row ra-detail-row"{% if group_id %} data-group="{{ group_id }}"{% endif %}>
     <td colspan="7" class="ra-detail-cell"{% if group_id %} style="padding-left: 3.6rem !important;"{% endif %}>
-        <div class="ra-detail-line">
-            <span class="ra-detail-name"><span class="associated-sub-arrow">&#8627;</span> {{ name }}</span>
-            <span class="ra-detail-size">{{ size or '—' }}</span>
-        </div>
+        <span class="associated-sub-arrow">&#8627;</span><span class="ra-detail-name">{{ name }}</span>{% if size %}<span class="ra-detail-size">{{ size }}</span>{% endif %}
     </td>
 </tr>
 {% endmacro %}
@@ -267,6 +264,12 @@
                 <tr>
                     <td colspan="7" style="padding: 0.75rem 0.85rem; background: rgba(0,0,0,0.15); border-top: 1px solid var(--plex-border);">
                         <span class="text-muted"><strong>{{ summary.total }}</strong> items · <strong>{{ summary.total_size_display }}</strong> total{% if summary.on_cache_not_pinned %} · <span style="color: var(--plex-warning);"><strong>{{ summary.on_cache_not_pinned }}</strong> on cache, not pinned</span>{% endif %}</span>
+                        {% if capped %}
+                        <span class="text-muted" style="display: block; margin-top: 0.35rem; font-size: 0.78rem;">
+                            <i data-lucide="info" style="width: 13px; height: 13px; vertical-align: -2px;"></i>
+                            Showing the {{ max_items }} most recently added files. Raise <strong>Max Items</strong> in Settings → Cache to include older media.
+                        </span>
+                        {% endif %}
                     </td>
                 </tr>
             </tfoot>

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -15,18 +15,17 @@
   the shared .associated-sub-row / .af-visible markup.
 #}
 
-{# ── detail sub-row: a single file (name + size) under a leaf row ── #}
+{# ── detail sub-row: a single file (name + size) under a leaf row ──
+   Full-width colspan cell so long release names wrap instead of forcing the
+   Title column wide (which would blow out the whole table). #}
 {% macro ra_detail_file(name, size, group_id='') %}
 <tr class="associated-sub-row ra-detail-row"{% if group_id %} data-group="{{ group_id }}"{% endif %}>
-    <td class="associated-sub-file"{% if group_id %} style="padding-left: 3.6rem !important;"{% endif %}>
-        <span class="associated-sub-arrow">&#8627;</span> {{ name }}
+    <td colspan="7" class="ra-detail-cell"{% if group_id %} style="padding-left: 3.6rem !important;"{% endif %}>
+        <div class="ra-detail-line">
+            <span class="ra-detail-name"><span class="associated-sub-arrow">&#8627;</span> {{ name }}</span>
+            <span class="ra-detail-size">{{ size or '—' }}</span>
+        </div>
     </td>
-    <td></td>
-    <td></td>
-    <td class="associated-sub-size">{{ size or '—' }}</td>
-    <td></td>
-    <td></td>
-    <td></td>
 </tr>
 {% endmacro %}
 

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -20,8 +20,8 @@
    Title column wide (which would blow out the whole table). #}
 {% macro ra_detail_file(name, size, group_id='') %}
 <tr class="associated-sub-row ra-detail-row"{% if group_id %} data-group="{{ group_id }}"{% endif %}>
-    <td colspan="7" class="ra-detail-cell"{% if group_id %} style="padding-left: 3.6rem !important;"{% endif %}>
-        <span class="associated-sub-arrow">&#8627;</span><span class="ra-detail-name">{{ name }}</span>{% if size %}<span class="ra-detail-size">{{ size }}</span>{% endif %}
+    <td colspan="7" class="ra-detail-cell"{% if group_id %} style="padding-left: 3rem !important;"{% endif %}>
+        <span class="associated-sub-arrow">&#8627;</span><span class="ra-detail-name">{{ name }}</span>{% if size %}<span class="ra-size-chip">{{ size }}</span>{% endif %}
     </td>
 </tr>
 {% endmacro %}

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -44,8 +44,9 @@
    tests/test_outcome_vocabulary.py asserts every enum member appears here. #}
 {% macro ra_status_badge(row) %}
 {% if   row.outcome == 'held'              %}<span class="badge badge-pinned" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="pin"></i> Stays on cache</span>
+{% elif row.outcome == 'held_mover_gap'    %}<span class="badge badge-pinned" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="pin"></i> Stays on cache</span>
 {% elif row.outcome == 'arriving'          %}<span class="badge badge-pinned" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="arrow-down-to-line"></i> Pinned, not on cache yet</span>
-{% elif row.outcome == 'held_by_setting'   %}<span class="badge badge-info" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="sliders-horizontal"></i> Stays on cache</span>
+{% elif row.outcome == 'held_by_setting'   %}<span class="badge badge-info" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="sliders-horizontal"></i> Not moved back</span>
 {% elif row.outcome == 'returns_when_done' %}<span class="badge badge-info" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="clock"></i> Returns when watched</span>
     {% for p in row.protected_by %}{% if p != 'Pinned' %}<span class="badge badge-info badge-sm">{{ p }}</span>{% endif %}{% endfor %}
 {% elif row.outcome == 'moves_back'        %}<span class="badge badge-muted" title="{{ outcome_tooltip(row.outcome) }}"><i data-lucide="arrow-down"></i> Moves to array</span>
@@ -249,6 +250,7 @@
                            "Protected" for groups where nothing was protected. #}
                         <td>
                             {% if   item.outcome_lead == 'held'              %}<span class="badge badge-pinned" title="{{ item.outcome_tooltip }}"><i data-lucide="pin"></i> {{ item.outcome_label }}</span>
+                            {% elif item.outcome_lead == 'held_mover_gap'    %}<span class="badge badge-pinned" title="{{ item.outcome_tooltip }}"><i data-lucide="pin"></i> {{ item.outcome_label }}</span>
                             {% elif item.outcome_lead == 'arriving'          %}<span class="badge badge-pinned" title="{{ item.outcome_tooltip }}"><i data-lucide="arrow-down-to-line"></i> {{ item.outcome_label }}</span>
                             {% elif item.outcome_lead == 'held_by_setting'   %}<span class="badge badge-info" title="{{ item.outcome_tooltip }}"><i data-lucide="sliders-horizontal"></i> {{ item.outcome_label }}</span>
                             {% elif item.outcome_lead == 'returns_when_done' %}<span class="badge badge-info" title="{{ item.outcome_tooltip }}"><i data-lucide="clock"></i> {{ item.outcome_label }}</span>

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -148,7 +148,7 @@
         <p class="text-muted" style="margin: 0;">{{ error or "Could not load recently added media." }}</p>
     </div>
     {# Keep the days input present so Refresh still works in the error state. #}
-    <input type="hidden" id="ra-days-input" value="{{ days }}">
+    <input type="hidden" id="ra-days-input" name="days" value="{{ days }}">
 </div>
 {% else %}
 

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -1,11 +1,96 @@
 {% from "macros/pin_button.html" import pin_button %}
+{% from "macros/associated_files.html" import af_popup, af_popup_init %}
 {#
   Recently Added — stat cards + filter bar + table.
 
   Swapped into #ra-content. The "Added Within" (days) <select> re-fetches this
   whole partial from the server; the Library/Search/location controls filter the
   loaded rows client-side (RecentlyAdded JS in index.html).
+
+  Rows arrive pre-grouped from the router (service.group_rows_for_display):
+  movies + standalone episodes render as individual rows; multi-episode TV runs
+  render as an expandable show-group header + episode child rows.
 #}
+
+{# ── one media row (movie, standalone episode, or group child) ── #}
+{% macro ra_location_badge(location) %}
+{% if location == 'cache' %}
+<span class="badge badge-success"><i data-lucide="zap"></i> On Cache</span>
+{% elif location == 'array' %}
+<span class="badge badge-muted"><i data-lucide="server"></i> On Array</span>
+{% else %}
+<span class="badge badge-muted">Unknown</span>
+{% endif %}
+{% endmacro %}
+
+{% macro ra_status_badge(row) %}
+{% if row.state == 'pinned' %}
+<span class="badge badge-pinned"><i data-lucide="pin"></i> Pinned</span>
+{% elif row.state == 'protected' %}
+<span class="badge badge-info"><i data-lucide="check"></i> Protected</span>
+{% for p in row.protected_by %}<span class="badge badge-info badge-sm">{{ p }}</span>{% endfor %}
+{% elif row.state == 'on_cache_not_pinned' %}
+<span class="badge badge-warning" title="The Unraid mover may move this to the array on its next run">Not pinned</span>
+{% elif row.state == 'on_array' %}
+<span class="badge badge-muted">Not cached</span>
+{% else %}
+<span class="badge badge-muted">Unknown</span>
+{% endif %}
+{% endmacro %}
+
+{% macro ra_row(row, is_child=False, group_id='') %}
+<tr class="ra-row {% if is_child %}ra-group-child{% else %}ra-item{% endif %}"
+    {% if is_child %}data-group="{{ group_id }}" style="display: none;"{% endif %}
+    data-library="{{ row.library_title }}"
+    data-loc="{{ row.location }}"
+    data-title="{{ row.title|lower }}{% if row.episode_info %} {{ row.episode_info.show|lower }}{% endif %}">
+    <td{% if is_child %} style="padding-left: 2.4rem;"{% endif %}>
+        <div class="title-cell" style="display: flex; align-items: center; gap: 0.55rem;">
+            {% if not is_child %}
+            <span class="media-ic" style="width: 30px; height: 30px; border-radius: 7px; background: var(--plex-bg-hover); display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;">
+                <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 15px; height: 15px; color: var(--plex-text-muted);"></i>
+            </span>
+            {% endif %}
+            <div>
+                {% if row.media_type == 'episode' and row.episode_info %}
+                    {% if is_child %}
+                    <div style="font-weight: 500;">S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %} {{ af_popup(row.associated_files) }}</div>
+                    {% else %}
+                    <div style="font-weight: 500;">{{ row.episode_info.show }} {{ af_popup(row.associated_files) }}</div>
+                    <div class="text-muted" style="font-size: 0.76rem;">
+                        S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %}
+                    </div>
+                    {% endif %}
+                {% else %}
+                <div style="font-weight: 500;">{{ row.title }} {{ af_popup(row.associated_files) }}</div>
+                <div class="text-muted" style="font-size: 0.76rem;">Movie</div>
+                {% endif %}
+            </div>
+        </div>
+    </td>
+    <td class="text-muted">{{ row.library_title }}</td>
+    <td class="text-muted" style="white-space: nowrap;">{{ row.added_display or '—' }}</td>
+    <td style="white-space: nowrap;">{{ row.size_display or '—' }}</td>
+    <td>{{ ra_location_badge(row.location) }}</td>
+    <td>{{ ra_status_badge(row) }}</td>
+    <td>
+        {% if row.rating_key %}
+        {{ pin_button(row.rating_key, row.pin_type, row.title, row.is_pinned) }}
+        {% if row.state == 'on_cache_not_pinned' %}
+        <div class="ra-status-note">stays on cache, backs up to array</div>
+        {% elif row.state == 'on_array' %}
+        <div class="ra-status-note">copies ~{{ row.size_display }} to cache</div>
+        {% elif row.state == 'protected' %}
+        <div class="ra-status-note">{{ row.protected_by|join(' / ') }} is temporary</div>
+        {% elif row.state == 'pinned' %}
+        <div class="ra-status-note">stays on cache until unpinned</div>
+        {% endif %}
+        {% else %}
+        <span class="text-muted">—</span>
+        {% endif %}
+    </td>
+</tr>
+{% endmacro %}
 
 {% if not available %}
 <div class="card">
@@ -96,74 +181,49 @@
                 </tr>
             </thead>
             <tbody id="ra-table-body">
-                {% for row in rows %}
-                <tr class="ra-row"
-                    data-library="{{ row.library_title }}"
-                    data-loc="{{ row.location }}"
-                    data-title="{{ row.title|lower }}{% if row.episode_info %} {{ row.episode_info.show|lower }}{% endif %}">
-                    <td>
-                        <div class="title-cell" style="display: flex; align-items: center; gap: 0.55rem;">
-                            <span class="media-ic" style="width: 30px; height: 30px; border-radius: 7px; background: var(--plex-bg-hover); display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;">
-                                <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 15px; height: 15px; color: var(--plex-text-muted);"></i>
-                            </span>
-                            <div>
-                                {% if row.media_type == 'episode' and row.episode_info %}
-                                <div style="font-weight: 500;">{{ row.episode_info.show }}</div>
-                                <div class="text-muted" style="font-size: 0.76rem;">
-                                    S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %}
+                {% for item in groups %}
+                    {% if item.kind == 'show' %}
+                    <tr class="ra-group-header" data-group-id="{{ item.group_id }}"
+                        data-library="{{ item.library_title }}"
+                        onclick="RecentlyAdded.toggleGroup(this)">
+                        <td>
+                            <div class="title-cell" style="display: flex; align-items: center; gap: 0.55rem;">
+                                <span class="ra-chevron"><i data-lucide="chevron-right"></i></span>
+                                <span class="media-ic" style="width: 30px; height: 30px; border-radius: 7px; background: var(--plex-bg-hover); display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;">
+                                    <i data-lucide="tv" style="width: 15px; height: 15px; color: var(--plex-text-muted);"></i>
+                                </span>
+                                <div>
+                                    <div style="font-weight: 500;">{{ item.show }}{% if item.season is not none %} — Season {{ item.season }}{% endif %}</div>
+                                    <div class="text-muted" style="font-size: 0.76rem;">{{ item.episode_count }} new episode{{ 's' if item.episode_count != 1 else '' }}</div>
                                 </div>
-                                {% else %}
-                                <div style="font-weight: 500;">{{ row.title }}</div>
-                                <div class="text-muted" style="font-size: 0.76rem;">Movie</div>
-                                {% endif %}
                             </div>
-                        </div>
-                    </td>
-                    <td class="text-muted">{{ row.library_title }}</td>
-                    <td class="text-muted" style="white-space: nowrap;">{{ row.added_display or '—' }}</td>
-                    <td style="white-space: nowrap;">{{ row.size_display or '—' }}</td>
-                    <td>
-                        {% if row.location == 'cache' %}
-                        <span class="badge badge-success"><i data-lucide="zap"></i> On Cache</span>
-                        {% elif row.location == 'array' %}
-                        <span class="badge badge-muted"><i data-lucide="server"></i> On Array</span>
-                        {% else %}
-                        <span class="badge badge-muted">Unknown</span>
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if row.state == 'pinned' %}
-                        <span class="badge badge-pinned"><i data-lucide="pin"></i> Pinned</span>
-                        {% elif row.state == 'protected' %}
-                        <span class="badge badge-info"><i data-lucide="check"></i> Protected</span>
-                        {% for p in row.protected_by %}<span class="badge badge-info badge-sm">{{ p }}</span>{% endfor %}
-                        {% elif row.state == 'on_cache_not_pinned' %}
-                        <span class="badge badge-warning" title="The Unraid mover may move this to the array on its next run">Not pinned</span>
-                        {% elif row.state == 'on_array' %}
-                        <span class="badge badge-muted">Not cached</span>
-                        {% else %}
-                        <span class="badge badge-muted">Unknown</span>
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if row.rating_key %}
-                        {{ pin_button(row.rating_key, row.pin_type, row.title, row.is_pinned) }}
-                        {% if row.state == 'on_cache_not_pinned' %}
-                        <div class="ra-status-note">stays on cache, backs up to array</div>
-                        {% elif row.state == 'on_array' %}
-                        <div class="ra-status-note">copies ~{{ row.size_display }} to cache</div>
-                        {% elif row.state == 'protected' %}
-                        <div class="ra-status-note">{{ row.protected_by|join(' / ') }} is temporary</div>
-                        {% elif row.state == 'pinned' %}
-                        <div class="ra-status-note">stays on cache until unpinned</div>
-                        {% endif %}
-                        {% else %}
-                        <span class="text-muted">—</span>
-                        {% endif %}
-                    </td>
-                </tr>
+                        </td>
+                        <td class="text-muted">{{ item.library_title }}</td>
+                        <td class="text-muted">—</td>
+                        <td style="white-space: nowrap;">{{ item.total_size_display or '—' }}</td>
+                        <td>
+                            {% if item.locations|length == 1 %}{{ ra_location_badge(item.locations[0]) }}
+                            {% else %}<span class="badge badge-muted">Mixed</span>{% endif %}
+                        </td>
+                        <td>
+                            {% if item.not_pinned_count %}
+                            <span class="badge badge-warning">{{ item.not_pinned_count }} not pinned</span>
+                            {% elif item.pinned_count == item.episode_count %}
+                            <span class="badge badge-pinned"><i data-lucide="pin"></i> Pinned</span>
+                            {% else %}
+                            <span class="badge badge-info"><i data-lucide="check"></i> Protected</span>
+                            {% endif %}
+                        </td>
+                        <td><span class="text-muted" style="font-size: 0.72rem;">expand to pin</span></td>
+                    </tr>
+                        {% for ep in item.episodes %}
+                        {{ ra_row(ep, is_child=True, group_id=item.group_id) }}
+                        {% endfor %}
+                    {% else %}
+                    {{ ra_row(item.row) }}
+                    {% endif %}
                 {% endfor %}
-                {% if not rows %}
+                {% if not groups %}
                 <tr id="ra-empty-row">
                     <td colspan="7" class="text-muted" style="text-align: center; padding: 2.5rem;">
                         Nothing added in the last {{ days }} day{{ 's' if days != 1 else '' }}.
@@ -176,7 +236,7 @@
                     </td>
                 </tr>
             </tbody>
-            {% if rows %}
+            {% if groups %}
             <tfoot>
                 <tr>
                     <td colspan="7" style="padding: 0.75rem 0.85rem; background: rgba(0,0,0,0.15); border-top: 1px solid var(--plex-border);">
@@ -188,5 +248,6 @@
         </table>
     </div>
 </div>
-<script>lucide.createIcons();</script>
+{{ af_popup_init('ra-table-body') }}
+<script>lucide.createIcons(); if (window.RecentlyAdded) RecentlyAdded.apply();</script>
 {% endif %}

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -1,5 +1,4 @@
 {% from "macros/pin_button.html" import pin_button %}
-{% from "macros/associated_files.html" import af_popup, af_popup_init %}
 {#
   Recently Added — stat cards + filter bar + table.
 
@@ -10,7 +9,26 @@
   Rows arrive pre-grouped from the router (service.group_rows_for_display):
   movies + standalone episodes render as individual rows; multi-episode TV runs
   render as an expandable show-group header + episode child rows.
+
+  Each leaf row's title cell is click-to-expand: it reveals detail sub-rows
+  (the primary media filename + size, then any subtitle/sidecar files), reusing
+  the shared .associated-sub-row / .af-visible markup.
 #}
+
+{# ── detail sub-row: a single file (name + size) under a leaf row ── #}
+{% macro ra_detail_file(name, size, group_id='') %}
+<tr class="associated-sub-row ra-detail-row"{% if group_id %} data-group="{{ group_id }}"{% endif %}>
+    <td class="associated-sub-file"{% if group_id %} style="padding-left: 3.6rem !important;"{% endif %}>
+        <span class="associated-sub-arrow">&#8627;</span> {{ name }}
+    </td>
+    <td></td>
+    <td></td>
+    <td class="associated-sub-size">{{ size or '—' }}</td>
+    <td></td>
+    <td></td>
+    <td></td>
+</tr>
+{% endmacro %}
 
 {# ── one media row (movie, standalone episode, or group child) ── #}
 {% macro ra_location_badge(location) %}
@@ -43,9 +61,12 @@
     {% if is_child %}data-group="{{ group_id }}" style="display: none;"{% endif %}
     data-library="{{ row.library_title }}"
     data-loc="{{ row.location }}"
-    data-title="{{ row.title|lower }}{% if row.episode_info %} {{ row.episode_info.show|lower }}{% endif %}">
-    <td{% if is_child %} style="padding-left: 2.4rem;"{% endif %}>
-        <div class="title-cell" style="display: flex; align-items: center; gap: 0.55rem;">
+    data-title="{{ row.title|lower }}{% if row.episode_info %} {{ row.episode_info.show|lower }}{% endif %} {{ row.filename|lower }}">
+    <td class="ra-title-cell" onclick="RecentlyAdded.toggleDetail(this)"
+        style="cursor: pointer;{% if is_child %} padding-left: 2.4rem;{% endif %}"
+        title="Show file details">
+        <div class="title-cell" style="display: flex; align-items: center; gap: 0.5rem;">
+            <span class="ra-detail-chevron"><i data-lucide="chevron-right"></i></span>
             {% if not is_child %}
             <span class="media-ic" style="width: 30px; height: 30px; border-radius: 7px; background: var(--plex-bg-hover); display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;">
                 <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 15px; height: 15px; color: var(--plex-text-muted);"></i>
@@ -54,18 +75,19 @@
             <div>
                 {% if row.media_type == 'episode' and row.episode_info %}
                     {% if is_child %}
-                    <div style="font-weight: 500;">S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %} {{ af_popup(row.associated_files) }}</div>
+                    <div style="font-weight: 500;">S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %}</div>
                     {% else %}
-                    <div style="font-weight: 500;">{{ row.episode_info.show }} {{ af_popup(row.associated_files) }}</div>
+                    <div style="font-weight: 500;">{{ row.episode_info.show }}</div>
                     <div class="text-muted" style="font-size: 0.76rem;">
                         S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %}
                     </div>
                     {% endif %}
                 {% else %}
-                <div style="font-weight: 500;">{{ row.title }} {{ af_popup(row.associated_files) }}</div>
+                <div style="font-weight: 500;">{{ row.title }}</div>
                 <div class="text-muted" style="font-size: 0.76rem;">Movie</div>
                 {% endif %}
             </div>
+            {% if row.associated_files %}<span class="badge badge-muted badge-sm" title="{{ row.associated_files|length }} associated file(s)">+{{ row.associated_files|length }}</span>{% endif %}
         </div>
     </td>
     <td class="text-muted">{{ row.library_title }}</td>
@@ -90,6 +112,11 @@
         {% endif %}
     </td>
 </tr>
+{# Expand detail: the primary media file, then any associated files. #}
+{{ ra_detail_file(row.filename or row.title, row.size_display, group_id if is_child else '') }}
+{% for af in row.associated_files %}
+{{ ra_detail_file(af.filename, af.size, group_id if is_child else '') }}
+{% endfor %}
 {% endmacro %}
 
 {% if not available %}
@@ -248,6 +275,5 @@
         </table>
     </div>
 </div>
-{{ af_popup_init('ra-table-body') }}
 <script>lucide.createIcons(); if (window.RecentlyAdded) RecentlyAdded.apply();</script>
 {% endif %}

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -62,7 +62,11 @@
 {% endmacro %}
 
 {% macro ra_row(row, is_child=False, group_id='') %}
+{# data-row-id is identity, not search: RecentlyAdded._state.details keys on it
+   to re-open a row's file details after an HTMX swap. rating_key is stable
+   across Sonarr/Radarr upgrades; filename covers the rows Plex gave no key. #}
 <tr class="ra-row {% if is_child %}ra-group-child{% else %}ra-item{% endif %}"
+    data-row-id="{{ row.rating_key or row.filename }}"
     {% if is_child %}data-group="{{ group_id }}" style="display: none;"{% endif %}
     data-library="{{ row.library_title }}"
     data-loc="{{ row.location }}"

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -44,7 +44,7 @@
 <span class="badge badge-info"><i data-lucide="check"></i> Protected</span>
 {% for p in row.protected_by %}<span class="badge badge-info badge-sm">{{ p }}</span>{% endfor %}
 {% elif row.state == 'on_cache_not_pinned' %}
-<span class="badge badge-warning" title="The Unraid mover may move this to the array on its next run">Not pinned</span>
+<span class="badge badge-muted" title="On cache now, but not held — it'll return to the array naturally once it's no longer OnDeck/Watchlist. Pin to keep it.">Not pinned</span>
 {% elif row.state == 'on_array' %}
 <span class="badge badge-muted">Not cached</span>
 {% else %}
@@ -139,11 +139,6 @@
         <div class="stat-value success">{{ summary.on_cache }}</div>
         <div class="stat-label">on fast storage now</div>
     </div>
-    <div class="stat-card {% if summary.on_cache_not_pinned %}stat-card-warning{% endif %}">
-        <div class="stat-card-header"><i data-lucide="pin-off"></i> On Cache, Not Pinned</div>
-        <div class="stat-value {% if summary.on_cache_not_pinned %}warning{% endif %}">{{ summary.on_cache_not_pinned }}</div>
-        <div class="stat-label">mover may move these to array</div>
-    </div>
     <div class="stat-card">
         <div class="stat-card-header"><i data-lucide="server"></i> On Array</div>
         <div class="stat-value">{{ summary.on_array }}</div>
@@ -230,7 +225,7 @@
                         </td>
                         <td>
                             {% if item.not_pinned_count %}
-                            <span class="badge badge-warning">{{ item.not_pinned_count }} not pinned</span>
+                            <span class="badge badge-muted">{{ item.not_pinned_count }} not pinned</span>
                             {% elif item.pinned_count == item.episode_count %}
                             <span class="badge badge-pinned"><i data-lucide="pin"></i> Pinned</span>
                             {% else %}
@@ -263,7 +258,7 @@
             <tfoot>
                 <tr>
                     <td colspan="7" style="padding: 0.75rem 0.85rem; background: rgba(0,0,0,0.15); border-top: 1px solid var(--plex-border);">
-                        <span class="text-muted"><strong>{{ summary.total }}</strong> items · <strong>{{ summary.total_size_display }}</strong> total{% if summary.on_cache_not_pinned %} · <span style="color: var(--plex-warning);"><strong>{{ summary.on_cache_not_pinned }}</strong> on cache, not pinned</span>{% endif %}</span>
+                        <span class="text-muted"><strong>{{ summary.total }}</strong> items · <strong>{{ summary.total_size_display }}</strong> total · <strong>{{ summary.on_cache }}</strong> on cache · <strong>{{ summary.on_array }}</strong> on array</span>
                         {% if capped %}
                         <span class="text-muted" style="display: block; margin-top: 0.35rem; font-size: 0.78rem;">
                             <i data-lucide="info" style="width: 13px; height: 13px; vertical-align: -2px;"></i>

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -1,0 +1,192 @@
+{% from "macros/pin_button.html" import pin_button %}
+{#
+  Recently Added — stat cards + filter bar + table.
+
+  Swapped into #ra-content. The "Added Within" (days) <select> re-fetches this
+  whole partial from the server; the Library/Search/location controls filter the
+  loaded rows client-side (RecentlyAdded JS in index.html).
+#}
+
+{% if not available %}
+<div class="card">
+    <div class="card-body" style="text-align: center; padding: 3rem;">
+        <i data-lucide="cloud-off" style="width: 36px; height: 36px; color: var(--plex-text-muted);"></i>
+        <h3 style="margin: 0.75rem 0 0.25rem;">Recently added is unavailable</h3>
+        <p class="text-muted" style="margin: 0;">{{ error or "Could not load recently added media." }}</p>
+    </div>
+    {# Keep the days input present so Refresh still works in the error state. #}
+    <input type="hidden" id="ra-days-input" value="{{ days }}">
+</div>
+{% else %}
+
+<!-- Stat cards -->
+<div class="stats-row">
+    <div class="stat-card">
+        <div class="stat-card-header"><i data-lucide="sparkles"></i> Recently Added</div>
+        <div class="stat-value">{{ summary.total }}</div>
+        <div class="stat-label">last {{ days }} day{{ 's' if days != 1 else '' }}</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-card-header"><i data-lucide="zap"></i> Already on Cache</div>
+        <div class="stat-value success">{{ summary.on_cache }}</div>
+        <div class="stat-label">on fast storage now</div>
+    </div>
+    <div class="stat-card {% if summary.on_cache_not_pinned %}stat-card-warning{% endif %}">
+        <div class="stat-card-header"><i data-lucide="pin-off"></i> On Cache, Not Pinned</div>
+        <div class="stat-value {% if summary.on_cache_not_pinned %}warning{% endif %}">{{ summary.on_cache_not_pinned }}</div>
+        <div class="stat-label">mover may move these to array</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-card-header"><i data-lucide="server"></i> On Array</div>
+        <div class="stat-value">{{ summary.on_array }}</div>
+        <div class="stat-label">not currently cached</div>
+    </div>
+</div>
+
+<!-- Filters -->
+<div class="card mb-2">
+    <div class="card-body">
+        <div class="grid grid-3">
+            <div class="form-group mb-0">
+                <label for="ra-lib-filter">Library</label>
+                <select id="ra-lib-filter">
+                    <option value="all">All Libraries</option>
+                    {% for lib in libraries %}
+                    <option value="{{ lib }}">{{ lib }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group mb-0">
+                <label for="ra-days-input">Added Within</label>
+                <select id="ra-days-input" name="days"
+                        hx-get="/recently-added/list"
+                        hx-target="#ra-content"
+                        hx-swap="innerHTML">
+                    <option value="1" {% if days == 1 %}selected{% endif %}>Last 24 hours</option>
+                    <option value="7" {% if days == 7 %}selected{% endif %}>Last 7 days</option>
+                    <option value="30" {% if days == 30 %}selected{% endif %}>Last 30 days</option>
+                </select>
+            </div>
+            <div class="form-group mb-0">
+                <label for="ra-search">Search</label>
+                <input type="search" id="ra-search" placeholder="Search titles...">
+            </div>
+        </div>
+        <div class="activity-filter-bar" style="padding: 0.75rem 0 0;">
+            <button type="button" class="activity-filter-pill ra-loc-pill active" data-loc="all">All</button>
+            <button type="button" class="activity-filter-pill ra-loc-pill" data-loc="cache">On Cache</button>
+            <button type="button" class="activity-filter-pill ra-loc-pill" data-loc="array">On Array</button>
+        </div>
+    </div>
+</div>
+
+<!-- Table -->
+<div class="card">
+    <div class="card-body" style="padding: 0; overflow-x: auto;">
+        <table>
+            <thead>
+                <tr>
+                    <th>Title</th>
+                    <th>Library</th>
+                    <th>Added</th>
+                    <th>Size</th>
+                    <th>Location</th>
+                    <th>Status</th>
+                    <th>Action</th>
+                </tr>
+            </thead>
+            <tbody id="ra-table-body">
+                {% for row in rows %}
+                <tr class="ra-row"
+                    data-library="{{ row.library_title }}"
+                    data-loc="{{ row.location }}"
+                    data-title="{{ row.title|lower }}{% if row.episode_info %} {{ row.episode_info.show|lower }}{% endif %}">
+                    <td>
+                        <div class="title-cell" style="display: flex; align-items: center; gap: 0.55rem;">
+                            <span class="media-ic" style="width: 30px; height: 30px; border-radius: 7px; background: var(--plex-bg-hover); display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;">
+                                <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 15px; height: 15px; color: var(--plex-text-muted);"></i>
+                            </span>
+                            <div>
+                                {% if row.media_type == 'episode' and row.episode_info %}
+                                <div style="font-weight: 500;">{{ row.episode_info.show }}</div>
+                                <div class="text-muted" style="font-size: 0.76rem;">
+                                    S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %}
+                                </div>
+                                {% else %}
+                                <div style="font-weight: 500;">{{ row.title }}</div>
+                                <div class="text-muted" style="font-size: 0.76rem;">Movie</div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </td>
+                    <td class="text-muted">{{ row.library_title }}</td>
+                    <td class="text-muted" style="white-space: nowrap;">{{ row.added_display or '—' }}</td>
+                    <td style="white-space: nowrap;">{{ row.size_display or '—' }}</td>
+                    <td>
+                        {% if row.location == 'cache' %}
+                        <span class="badge badge-success"><i data-lucide="zap"></i> On Cache</span>
+                        {% elif row.location == 'array' %}
+                        <span class="badge badge-muted"><i data-lucide="server"></i> On Array</span>
+                        {% else %}
+                        <span class="badge badge-muted">Unknown</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if row.state == 'pinned' %}
+                        <span class="badge badge-pinned"><i data-lucide="pin"></i> Pinned</span>
+                        {% elif row.state == 'protected' %}
+                        <span class="badge badge-info"><i data-lucide="check"></i> Protected</span>
+                        {% for p in row.protected_by %}<span class="badge badge-info badge-sm">{{ p }}</span>{% endfor %}
+                        {% elif row.state == 'on_cache_not_pinned' %}
+                        <span class="badge badge-warning" title="The Unraid mover may move this to the array on its next run">Not pinned</span>
+                        {% elif row.state == 'on_array' %}
+                        <span class="badge badge-muted">Not cached</span>
+                        {% else %}
+                        <span class="badge badge-muted">Unknown</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if row.rating_key %}
+                        {{ pin_button(row.rating_key, row.pin_type, row.title, row.is_pinned) }}
+                        {% if row.state == 'on_cache_not_pinned' %}
+                        <div class="ra-status-note">stays on cache, backs up to array</div>
+                        {% elif row.state == 'on_array' %}
+                        <div class="ra-status-note">copies ~{{ row.size_display }} to cache</div>
+                        {% elif row.state == 'protected' %}
+                        <div class="ra-status-note">{{ row.protected_by|join(' / ') }} is temporary</div>
+                        {% elif row.state == 'pinned' %}
+                        <div class="ra-status-note">stays on cache until unpinned</div>
+                        {% endif %}
+                        {% else %}
+                        <span class="text-muted">—</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not rows %}
+                <tr id="ra-empty-row">
+                    <td colspan="7" class="text-muted" style="text-align: center; padding: 2.5rem;">
+                        Nothing added in the last {{ days }} day{{ 's' if days != 1 else '' }}.
+                    </td>
+                </tr>
+                {% endif %}
+                <tr id="ra-no-match" style="display: none;">
+                    <td colspan="7" class="text-muted" style="text-align: center; padding: 2.5rem;">
+                        No items match the current filters.
+                    </td>
+                </tr>
+            </tbody>
+            {% if rows %}
+            <tfoot>
+                <tr>
+                    <td colspan="7" style="padding: 0.75rem 0.85rem; background: rgba(0,0,0,0.15); border-top: 1px solid var(--plex-border);">
+                        <span class="text-muted"><strong>{{ summary.total }}</strong> items · <strong>{{ summary.total_size_display }}</strong> total{% if summary.on_cache_not_pinned %} · <span style="color: var(--plex-warning);"><strong>{{ summary.on_cache_not_pinned }}</strong> on cache, not pinned</span>{% endif %}</span>
+                    </td>
+                </tr>
+            </tfoot>
+            {% endif %}
+        </table>
+    </div>
+</div>
+<script>lucide.createIcons();</script>
+{% endif %}

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -289,8 +289,11 @@
             </tbody>
             {% if groups %}
             <tfoot>
-                <tr>
-                    <td colspan="7" style="padding: 0.75rem 0.85rem; background: rgba(0,0,0,0.15); border-top: 1px solid var(--plex-border);">
+                {# Shared totals styling — an inline rgba() here couldn't be
+                   overridden by the light theme, so it rendered darker than
+                   every other table footer in the app. #}
+                <tr class="totals-row">
+                    <td colspan="7" style="padding: 0.75rem 0.85rem;">
                         <span class="text-muted"><strong>{{ summary.total }}</strong> items · <strong>{{ summary.total_size_display }}</strong> total · <strong>{{ summary.on_cache }}</strong> on cache · <strong>{{ summary.on_array }}</strong> on array</span>
                         {% if capped %}
                         <span class="text-muted" style="display: block; margin-top: 0.35rem; font-size: 0.78rem;">

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -66,7 +66,9 @@
     {% if is_child %}data-group="{{ group_id }}" style="display: none;"{% endif %}
     data-library="{{ row.library_title }}"
     data-loc="{{ row.location }}"
-    data-title="{{ row.title|lower }}{% if row.episode_info %} {{ row.episode_info.show|lower }}{% endif %} {{ row.filename|lower }}">
+    {# `or ''` before |lower: a missing show would render the literal "none" into
+       the search index and make every row match a search for "none". #}
+    data-title="{{ row.title|lower }}{% if row.episode_info %} {{ (row.episode_info.show or '')|lower }}{% endif %} {{ row.filename|lower }}">
     <td class="ra-title-cell" onclick="RecentlyAdded.toggleDetail(this)"
         style="cursor: pointer;{% if is_child %} padding-left: 2.4rem;{% endif %}"
         title="Show file details">
@@ -79,17 +81,23 @@
             {% endif %}
             <div>
                 {% if row.media_type == 'episode' and row.episode_info %}
+                    {# "" when Plex gave no usable numbering, so the row falls back
+                       to the episode title rather than inventing S00E00 — which a
+                       genuine Specials episode 0 also renders as. #}
+                    {% set se = format_season_episode(row.episode_info.season, row.episode_info.episode) %}
                     {% if is_child %}
-                    <div style="font-weight: 500;">S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %}</div>
+                    <div style="font-weight: 500;">{% if se %}{{ se }}{% if row.title %} — {{ row.title }}{% endif %}{% else %}{{ row.title or 'Episode' }}{% endif %}</div>
                     {% else %}
-                    <div style="font-weight: 500;">{{ row.episode_info.show }}</div>
+                    <div style="font-weight: 500;">{{ row.episode_info.show or row.title }}</div>
                     <div class="text-muted" style="font-size: 0.76rem;">
-                        S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% if row.title %} — {{ row.title }}{% endif %}
+                        {% if se %}{{ se }}{% if row.title %} — {{ row.title }}{% endif %}{% else %}{{ row.title or 'Episode' }}{% endif %}
                     </div>
                     {% endif %}
                 {% else %}
                 <div style="font-weight: 500;">{{ row.title }}</div>
-                <div class="text-muted" style="font-size: 0.76rem;">Movie</div>
+                {# Terminal arm, so a row built outside plex_api cannot land here
+                   and label an episode "Movie" underneath a tv icon. #}
+                <div class="text-muted" style="font-size: 0.76rem;">{% if row.media_type == 'episode' %}Episode{% else %}Movie{% endif %}</div>
                 {% endif %}
             </div>
             {% if row.associated_files %}<span class="badge badge-muted badge-sm" title="{{ row.associated_files|length }} associated file(s)">+{{ row.associated_files|length }}</span>{% endif %}

--- a/web/templates/recently_added/partials/list.html
+++ b/web/templates/recently_added/partials/list.html
@@ -211,13 +211,13 @@
                                     <i data-lucide="tv" style="width: 15px; height: 15px; color: var(--plex-text-muted);"></i>
                                 </span>
                                 <div>
-                                    <div style="font-weight: 500;">{{ item.show }}{% if item.season is not none %} — Season {{ item.season }}{% endif %}</div>
+                                    <div style="font-weight: 500;">{{ item.show }}{% if item.season_display %} — {{ item.season_display }}{% endif %}</div>
                                     <div class="text-muted" style="font-size: 0.76rem;">{{ item.episode_count }} new episode{{ 's' if item.episode_count != 1 else '' }}</div>
                                 </div>
                             </div>
                         </td>
                         <td class="text-muted">{{ item.library_title }}</td>
-                        <td class="text-muted">—</td>
+                        <td class="text-muted" style="white-space: nowrap;">{{ item.added_display or '—' }}</td>
                         <td style="white-space: nowrap;">{{ item.total_size_display or '—' }}</td>
                         <td>
                             {% if item.locations|length == 1 %}{{ ra_location_badge(item.locations[0]) }}

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -20,6 +20,15 @@
 </div>
 {% endmacro %}
 
+{# The counts below exclude any library Plex refused to list, so say so rather
+   than letting the card read as complete. #}
+{% if unreadable_libraries %}
+<div class="text-muted" style="padding: 0.75rem 1.25rem 0; font-size: 0.78rem; display: flex; align-items: flex-start; gap: 0.4rem;">
+    <i data-lucide="alert-triangle" style="width: 13px; height: 13px; flex-shrink: 0; margin-top: 2px; color: var(--plex-warning);"></i>
+    <span>Couldn't read {{ unreadable_libraries|join(', ') }} — counts are incomplete.</span>
+</div>
+{% endif %}
+
 <div style="display: flex; gap: 1.25rem; flex-wrap: wrap; padding: 1rem 1.25rem; align-items: center;">
     <div>
         <div class="stat-value" style="font-size: 1.5rem;">{{ summary.total }}</div>

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -84,6 +84,9 @@
             {% for af in row.associated_files %}
             {{ ra_w_detail(af.filename, af.size) }}
             {% endfor %}
+            {% for ov in row.other_versions %}
+            {{ ra_w_detail(ov.filename, ov.size) }}
+            {% endfor %}
         </div>
     </div>
     {% endif %}

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -1,0 +1,38 @@
+{#
+  Compact dashboard card for Recently Added. Lazy-loaded into the dashboard;
+  links through to the full /recently-added page.
+#}
+{% if not available %}
+<div class="text-muted" style="padding: 1.25rem; font-size: 0.85rem;">
+    {{ error or "Recently added is unavailable." }}
+</div>
+{% else %}
+<div style="display: flex; gap: 1.25rem; flex-wrap: wrap; padding: 1rem 1.25rem; align-items: center;">
+    <div>
+        <div class="stat-value" style="font-size: 1.5rem;">{{ summary.total }}</div>
+        <div class="stat-label">new in {{ days }}d</div>
+    </div>
+    <div>
+        <div class="stat-value success" style="font-size: 1.5rem;">{{ summary.on_cache }}</div>
+        <div class="stat-label">on cache</div>
+    </div>
+    <div>
+        <div class="stat-value {% if summary.on_cache_not_pinned %}warning{% endif %}" style="font-size: 1.5rem;">{{ summary.on_cache_not_pinned }}</div>
+        <div class="stat-label">not pinned</div>
+    </div>
+</div>
+{% if rows %}
+<div style="padding: 0 1.25rem 0.5rem;">
+    {% for row in rows %}
+    <div style="display: flex; align-items: center; gap: 0.5rem; padding: 0.3rem 0; font-size: 0.85rem; border-top: 1px solid var(--plex-border);">
+        <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 14px; height: 14px; color: var(--plex-text-muted); flex-shrink: 0;"></i>
+        <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+            {% if row.media_type == 'episode' and row.episode_info %}{{ row.episode_info.show }} · S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% else %}{{ row.title }}{% endif %}
+        </span>
+        <span class="text-muted" style="margin-left: auto; white-space: nowrap;">{{ row.added_display }}</span>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+<script>lucide.createIcons();</script>
+{% endif %}

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -29,7 +29,8 @@
         <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
             {% if row.media_type == 'episode' and row.episode_info %}{{ row.episode_info.show }} · S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% else %}{{ row.title }}{% endif %}
         </span>
-        <span class="text-muted" style="margin-left: auto; white-space: nowrap;">{{ row.added_display }}</span>
+        {% if row.size_display %}<span class="text-muted" style="margin-left: auto; white-space: nowrap;">{{ row.size_display }}</span>{% endif %}
+        <span class="text-muted" style="{% if not row.size_display %}margin-left: auto; {% endif %}white-space: nowrap;">{{ row.added_display }}</span>
     </div>
     {% endfor %}
 </div>

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -22,32 +22,36 @@
     </div>
 </div>
 {% if rows %}
-<div style="padding: 0 1.25rem 0.5rem;">
+<div style="padding: 0 1.25rem 0.75rem;">
+    {# Column header — aligns with the per-row columns below. #}
+    <div class="ra-w-head">
+        <span class="ra-w-lead"></span>
+        <span class="ra-w-title">Title</span>
+        <span class="ra-w-size">Size</span>
+        <span class="ra-w-age">Added</span>
+    </div>
     {% for row in rows %}
     {# Click-to-expand: reveals the underlying filename(s) + size. Self-contained
        so it works on the dashboard (the full-page RecentlyAdded JS isn't loaded). #}
-    <div class="ra-w-row" onclick="raWidgetToggle(this)"
-         style="cursor: pointer; border-top: 1px solid var(--plex-border);" title="Show file details">
-        <div style="display: flex; align-items: center; gap: 0.5rem; padding: 0.3rem 0; font-size: 0.85rem;">
-            <span class="ra-w-chevron" style="display: inline-flex; color: var(--plex-text-muted); flex-shrink: 0; transition: transform 0.15s ease;">
-                <i data-lucide="chevron-right" style="width: 13px; height: 13px;"></i>
-            </span>
+    <div class="ra-w-row" onclick="raWidgetToggle(this)" title="Show file details">
+        <div class="ra-w-line">
+            <span class="ra-w-chevron"><i data-lucide="chevron-right" style="width: 13px; height: 13px;"></i></span>
             <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 14px; height: 14px; color: var(--plex-text-muted); flex-shrink: 0;"></i>
-            <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+            <span class="ra-w-title">
                 {% if row.media_type == 'episode' and row.episode_info %}{{ row.episode_info.show }} · S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% else %}{{ row.title }}{% endif %}
             </span>
-            {% if row.size_display %}<span class="text-muted" style="margin-left: auto; white-space: nowrap;">{{ row.size_display }}</span>{% endif %}
-            <span class="text-muted" style="{% if not row.size_display %}margin-left: auto; {% endif %}white-space: nowrap; padding-left: 0.5rem;">{{ row.added_display }}</span>
+            <span class="ra-w-size">{% if row.size_display %}<span class="ra-size-chip">{{ row.size_display }}</span>{% endif %}</span>
+            <span class="ra-w-age">{{ row.added_display }}</span>
         </div>
-        <div class="ra-w-detail" style="display: none; padding: 0 0 0.4rem 1.75rem;">
-            <div style="display: flex; justify-content: space-between; gap: 1rem; padding: 0.1rem 0; font-size: 0.78rem; color: var(--plex-text-muted);">
-                <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">&#8627; {{ row.filename or row.title }}</span>
-                <span style="flex-shrink: 0;">{{ row.size_display or '—' }}</span>
+        <div class="ra-w-detail" style="display: none;">
+            <div class="ra-w-detail-line">
+                <span class="ra-w-detail-name">&#8627; {{ row.filename or row.title }}</span>
+                {% if row.size_display %}<span class="ra-size-chip">{{ row.size_display }}</span>{% endif %}
             </div>
             {% for af in row.associated_files %}
-            <div style="display: flex; justify-content: space-between; gap: 1rem; padding: 0.1rem 0; font-size: 0.78rem; color: var(--plex-text-muted);">
-                <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">&#8627; {{ af.filename }}</span>
-                <span style="flex-shrink: 0;">{{ af.size or '—' }}</span>
+            <div class="ra-w-detail-line">
+                <span class="ra-w-detail-name">&#8627; {{ af.filename }}</span>
+                {% if af.size %}<span class="ra-size-chip">{{ af.size }}</span>{% endif %}
             </div>
             {% endfor %}
         </div>

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -56,7 +56,7 @@
                 <span class="ra-w-sub">{% if item.season_display %}{{ item.season_display }} · {% endif %}{{ item.episode_count }} eps</span>
             </span>
             <span class="ra-w-size">{% if item.total_size_display %}<span class="ra-size-chip">{{ item.total_size_display }}</span>{% endif %}</span>
-            <span class="ra-w-age">{{ item.added_display }}</span>
+            <span class="ra-w-age">{{ item.added_display or "—" }}</span>
         </div>
         <div class="ra-w-detail" style="display: none;">
             {% for ep in item.episodes %}
@@ -77,7 +77,7 @@
                 {% if row.media_type == 'episode' and row.episode_info %}{{ row.episode_info.show }} · S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% else %}{{ row.title }}{% endif %}
             </span>
             <span class="ra-w-size">{% if row.size_display %}<span class="ra-size-chip">{{ row.size_display }}</span>{% endif %}</span>
-            <span class="ra-w-age">{{ row.added_display }}</span>
+            <span class="ra-w-age">{{ row.added_display or "—" }}</span>
         </div>
         <div class="ra-w-detail" style="display: none;">
             {{ ra_w_detail(row.filename or row.title, row.size_display) }}

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -17,8 +17,8 @@
         <div class="stat-label">on cache</div>
     </div>
     <div>
-        <div class="stat-value {% if summary.on_cache_not_pinned %}warning{% endif %}" style="font-size: 1.5rem;">{{ summary.on_cache_not_pinned }}</div>
-        <div class="stat-label">not pinned</div>
+        <div class="stat-value" style="font-size: 1.5rem;">{{ summary.on_array }}</div>
+        <div class="stat-label">on array</div>
     </div>
 </div>
 {% if rows %}

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -83,7 +83,7 @@
             <span class="ra-w-chevron"><i data-lucide="chevron-right" style="width: 13px; height: 13px;"></i></span>
             <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 14px; height: 14px; color: var(--plex-text-muted); flex-shrink: 0;"></i>
             <span class="ra-w-title">
-                {% if row.media_type == 'episode' and row.episode_info %}{{ row.episode_info.show }} · S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% else %}{{ row.title }}{% endif %}
+                {% if row.media_type == 'episode' and row.episode_info %}{% set se = format_season_episode(row.episode_info.season, row.episode_info.episode) %}{{ row.episode_info.show or row.title }}{% if se %} · {{ se }}{% endif %}{% else %}{{ row.title }}{% endif %}
             </span>
             <span class="ra-w-size">{% if row.size_display %}<span class="ra-size-chip">{{ row.size_display }}</span>{% endif %}</span>
             <span class="ra-w-age">{{ row.added_display or "—" }}</span>

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -24,16 +24,46 @@
 {% if rows %}
 <div style="padding: 0 1.25rem 0.5rem;">
     {% for row in rows %}
-    <div style="display: flex; align-items: center; gap: 0.5rem; padding: 0.3rem 0; font-size: 0.85rem; border-top: 1px solid var(--plex-border);">
-        <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 14px; height: 14px; color: var(--plex-text-muted); flex-shrink: 0;"></i>
-        <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-            {% if row.media_type == 'episode' and row.episode_info %}{{ row.episode_info.show }} · S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% else %}{{ row.title }}{% endif %}
-        </span>
-        {% if row.size_display %}<span class="text-muted" style="margin-left: auto; white-space: nowrap;">{{ row.size_display }}</span>{% endif %}
-        <span class="text-muted" style="{% if not row.size_display %}margin-left: auto; {% endif %}white-space: nowrap;">{{ row.added_display }}</span>
+    {# Click-to-expand: reveals the underlying filename(s) + size. Self-contained
+       so it works on the dashboard (the full-page RecentlyAdded JS isn't loaded). #}
+    <div class="ra-w-row" onclick="raWidgetToggle(this)"
+         style="cursor: pointer; border-top: 1px solid var(--plex-border);" title="Show file details">
+        <div style="display: flex; align-items: center; gap: 0.5rem; padding: 0.3rem 0; font-size: 0.85rem;">
+            <span class="ra-w-chevron" style="display: inline-flex; color: var(--plex-text-muted); flex-shrink: 0; transition: transform 0.15s ease;">
+                <i data-lucide="chevron-right" style="width: 13px; height: 13px;"></i>
+            </span>
+            <i data-lucide="{{ 'tv' if row.media_type == 'episode' else 'film' }}" style="width: 14px; height: 14px; color: var(--plex-text-muted); flex-shrink: 0;"></i>
+            <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                {% if row.media_type == 'episode' and row.episode_info %}{{ row.episode_info.show }} · S{{ '%02d'|format(row.episode_info.season or 0) }}E{{ '%02d'|format(row.episode_info.episode or 0) }}{% else %}{{ row.title }}{% endif %}
+            </span>
+            {% if row.size_display %}<span class="text-muted" style="margin-left: auto; white-space: nowrap;">{{ row.size_display }}</span>{% endif %}
+            <span class="text-muted" style="{% if not row.size_display %}margin-left: auto; {% endif %}white-space: nowrap; padding-left: 0.5rem;">{{ row.added_display }}</span>
+        </div>
+        <div class="ra-w-detail" style="display: none; padding: 0 0 0.4rem 1.75rem;">
+            <div style="display: flex; justify-content: space-between; gap: 1rem; padding: 0.1rem 0; font-size: 0.78rem; color: var(--plex-text-muted);">
+                <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">&#8627; {{ row.filename or row.title }}</span>
+                <span style="flex-shrink: 0;">{{ row.size_display or '—' }}</span>
+            </div>
+            {% for af in row.associated_files %}
+            <div style="display: flex; justify-content: space-between; gap: 1rem; padding: 0.1rem 0; font-size: 0.78rem; color: var(--plex-text-muted);">
+                <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">&#8627; {{ af.filename }}</span>
+                <span style="flex-shrink: 0;">{{ af.size or '—' }}</span>
+            </div>
+            {% endfor %}
+        </div>
     </div>
     {% endfor %}
 </div>
 {% endif %}
-<script>lucide.createIcons();</script>
+<script>
+window.raWidgetToggle = window.raWidgetToggle || function (rowEl) {
+    var detail = rowEl.querySelector('.ra-w-detail');
+    var chev = rowEl.querySelector('.ra-w-chevron');
+    if (!detail) return;
+    var open = detail.style.display === 'none';
+    detail.style.display = open ? 'block' : 'none';
+    if (chev) chev.style.transform = open ? 'rotate(90deg)' : '';
+};
+lucide.createIcons();
+</script>
 {% endif %}

--- a/web/templates/recently_added/partials/widget.html
+++ b/web/templates/recently_added/partials/widget.html
@@ -1,12 +1,25 @@
 {#
   Compact dashboard card for Recently Added. Lazy-loaded into the dashboard;
   links through to the full /recently-added page.
+
+  Rows arrive pre-grouped from the router (service.group_rows_for_display) —
+  the same grouping the full page uses — so a multi-episode show shows up as
+  one expandable line here too, instead of filling the card.
 #}
 {% if not available %}
 <div class="text-muted" style="padding: 1.25rem; font-size: 0.85rem;">
     {{ error or "Recently added is unavailable." }}
 </div>
 {% else %}
+
+{# ── one detail sub-line: a file (or episode) name + size ── #}
+{% macro ra_w_detail(name, size) %}
+<div class="ra-w-detail-line">
+    <span class="ra-w-detail-name">&#8627; {{ name }}</span>
+    {% if size %}<span class="ra-size-chip">{{ size }}</span>{% endif %}
+</div>
+{% endmacro %}
+
 <div style="display: flex; gap: 1.25rem; flex-wrap: wrap; padding: 1rem 1.25rem; align-items: center;">
     <div>
         <div class="stat-value" style="font-size: 1.5rem;">{{ summary.total }}</div>
@@ -21,7 +34,7 @@
         <div class="stat-label">on array</div>
     </div>
 </div>
-{% if rows %}
+{% if groups %}
 <div style="padding: 0 1.25rem 0.75rem;">
     {# Column header — aligns with the per-row columns below. #}
     <div class="ra-w-head">
@@ -30,9 +43,32 @@
         <span class="ra-w-size">Size</span>
         <span class="ra-w-age">Added</span>
     </div>
-    {% for row in rows %}
+    {% for item in groups %}
     {# Click-to-expand: reveals the underlying filename(s) + size. Self-contained
        so it works on the dashboard (the full-page RecentlyAdded JS isn't loaded). #}
+    {% if item.kind == 'show' %}
+    <div class="ra-w-row" onclick="raWidgetToggle(this)" title="Show episodes">
+        <div class="ra-w-line">
+            <span class="ra-w-chevron"><i data-lucide="chevron-right" style="width: 13px; height: 13px;"></i></span>
+            <i data-lucide="tv" style="width: 14px; height: 14px; color: var(--plex-text-muted); flex-shrink: 0;"></i>
+            <span class="ra-w-title">
+                {{ item.show }}
+                <span class="ra-w-sub">{% if item.season_display %}{{ item.season_display }} · {% endif %}{{ item.episode_count }} eps</span>
+            </span>
+            <span class="ra-w-size">{% if item.total_size_display %}<span class="ra-size-chip">{{ item.total_size_display }}</span>{% endif %}</span>
+            <span class="ra-w-age">{{ item.added_display }}</span>
+        </div>
+        <div class="ra-w-detail" style="display: none;">
+            {% for ep in item.episodes %}
+            {{ ra_w_detail(ep.filename or ep.title, ep.size_display) }}
+            {% for af in ep.associated_files %}
+            {{ ra_w_detail(af.filename, af.size) }}
+            {% endfor %}
+            {% endfor %}
+        </div>
+    </div>
+    {% else %}
+    {% set row = item.row %}
     <div class="ra-w-row" onclick="raWidgetToggle(this)" title="Show file details">
         <div class="ra-w-line">
             <span class="ra-w-chevron"><i data-lucide="chevron-right" style="width: 13px; height: 13px;"></i></span>
@@ -44,18 +80,13 @@
             <span class="ra-w-age">{{ row.added_display }}</span>
         </div>
         <div class="ra-w-detail" style="display: none;">
-            <div class="ra-w-detail-line">
-                <span class="ra-w-detail-name">&#8627; {{ row.filename or row.title }}</span>
-                {% if row.size_display %}<span class="ra-size-chip">{{ row.size_display }}</span>{% endif %}
-            </div>
+            {{ ra_w_detail(row.filename or row.title, row.size_display) }}
             {% for af in row.associated_files %}
-            <div class="ra-w-detail-line">
-                <span class="ra-w-detail-name">&#8627; {{ af.filename }}</span>
-                {% if af.size %}<span class="ra-size-chip">{{ af.size }}</span>{% endif %}
-            </div>
+            {{ ra_w_detail(af.filename, af.size) }}
             {% endfor %}
         </div>
     </div>
+    {% endif %}
     {% endfor %}
 </div>
 {% endif %}

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -55,8 +55,8 @@
                     <label for="recently_added_max_items">Recently Added — Max Items</label>
                     <input type="number" id="recently_added_max_items" name="recently_added_max_items"
                            class="input-narrow"
-                           value="{{ settings.recently_added_max_items | default(100) }}" min="1" max="500">
-                    <div class="form-hint">Most recent items to load on the Recently Added page (1–500).</div>
+                           value="{{ settings.recently_added_max_items | default(250) }}" min="1" max="500">
+                    <div class="form-hint">Most recent media files to load on the Recently Added page (1–500). Counts individual files — TV episodes group by show for display but still count individually here.</div>
                 </div>
             </div>
 

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -40,6 +40,26 @@
                 <div class="form-hint">Ensures prefetched OnDeck episodes cover at least this many minutes of runtime. Episode count above is treated as a minimum. Set to 0 to disable.</div>
             </div>
 
+            <div class="grid grid-2">
+                <div class="form-group" data-setting-id="recently_added_days">
+                    <label for="recently_added_days">Recently Added — Default Window</label>
+                    <select id="recently_added_days" name="recently_added_days" class="input-narrow">
+                        <option value="1" {% if settings.recently_added_days | default(7) == 1 %}selected{% endif %}>Last 24 hours</option>
+                        <option value="7" {% if settings.recently_added_days | default(7) == 7 %}selected{% endif %}>Last 7 days</option>
+                        <option value="30" {% if settings.recently_added_days | default(7) == 30 %}selected{% endif %}>Last 30 days</option>
+                    </select>
+                    <div class="form-hint">Default time window for the Recently Added page (you can still switch it there).</div>
+                </div>
+
+                <div class="form-group" data-setting-id="recently_added_max_items">
+                    <label for="recently_added_max_items">Recently Added — Max Items</label>
+                    <input type="number" id="recently_added_max_items" name="recently_added_max_items"
+                           class="input-narrow"
+                           value="{{ settings.recently_added_max_items | default(100) }}" min="1" max="500">
+                    <div class="form-hint">Most recent items to load on the Recently Added page (1–500).</div>
+                </div>
+            </div>
+
             <hr style="border-color: var(--plex-border); margin: 1.5rem 0;">
 
             <h3 style="font-size: 1rem; color: var(--plex-orange); margin-bottom: 1rem;">

--- a/web/templates/settings/partials/library_card.html
+++ b/web/templates/settings/partials/library_card.html
@@ -28,13 +28,32 @@
             {% if card.mappings %}
                 {% for mapping in card.mappings %}
                 {% set unrecognized = mapping.auto_fill_recognized is defined and not mapping.auto_fill_recognized %}
+                {% set share_warn = share_warning(mapping) %}
                 <div class="library-mapping-view" id="lib-mapping-view-{{ card.library.id }}-{{ loop.index0 }}"
                      style="font-size: 0.85rem; margin-bottom: 0.75rem; padding: 0.5rem 0.75rem; background: var(--plex-bg-darker); border-radius: var(--plex-radius-sm);
-                     {% if unrecognized %}border: 1px solid var(--plex-warning, #e67e22);{% endif %}">
+                     {% if unrecognized or share_warn %}border: 1px solid var(--plex-warning, #e67e22);{% endif %}">
                     {% if unrecognized %}
                     <div style="margin-bottom: 0.5rem; padding: 0.35rem 0.5rem; background: rgba(230, 126, 34, 0.1); border-radius: var(--plex-radius-sm); font-size: 0.8rem; color: var(--plex-warning, #e67e22);">
                         <i data-lucide="alert-triangle" style="width: 13px; height: 13px; vertical-align: middle;"></i>
                         Plex path prefix <code>{{ mapping.plex_path.split('/')[1] }}/</code> is not a recognized Docker mapping &mdash; Real Path and Cache Path likely need manual correction via Edit Paths.
+                    </div>
+                    {% endif %}
+                    {% if share_warn %}
+                    <div class="share-mismatch-warning">
+                        <i data-lucide="alert-triangle" class="share-mismatch-warning__icon"></i>
+                        <div>
+                            <strong>{% if share_warn.kind == 'share_mismatch' %}Cache path is in a different share{% else %}Cache path is not on an Unraid share{% endif %}</strong>
+                            <div class="share-mismatch-warning__body">
+                                {% if share_warn.kind == 'share_mismatch' %}
+                                Media lives in <code>{{ share_warn.real_share }}</code> but the cache path points into <code>{{ share_warn.cache_share }}</code>.
+                                Unraid merges a share's pool and array tiers under the same <code>/mnt/user/</code> path, so caching only works when both are the
+                                <em>same</em> share. As configured, cached files land where Plex isn't looking and show as missing.
+                                {% else %}
+                                <code>{{ share_warn.real_share }}</code> is an Unraid share, but the cache path isn't under <code>/mnt/</code>.
+                                It should be the pool tier of that share, for example <code>/mnt/&lt;pool&gt;/{{ share_warn.real_share }}/...</code>.
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                     {% endif %}
                     {% if mapping.name != card.library.title %}

--- a/web/templates/settings/partials/pinned_children.html
+++ b/web/templates/settings/partials/pinned_children.html
@@ -51,7 +51,7 @@
                     <input type="hidden" name="pin_type" value="{{ child.type }}">
                     <input type="hidden" name="title" value="{{ child.title }}">
                     <button type="submit" class="btn btn-sm {% if child.already_pinned %}btn-secondary{% else %}btn-primary{% endif %}"
-                            title="{% if child.already_pinned %}Unpin this item{% else %}Pin this item{% endif %}">
+                            title="{% if child.already_pinned %}Unpin — allow this item to be evicted or moved back to the array{% else %}Pin — always keep this item on cache (never evicted){% endif %}">
                         <i data-lucide="{% if child.already_pinned %}pin-off{% else %}pin{% endif %}" style="width: 14px; height: 14px; vertical-align: middle;"></i>
                         {% if child.already_pinned %}Unpin{% else %}Pin{% endif %}
                     </button>

--- a/web/templates/settings/partials/pinned_chip_list.html
+++ b/web/templates/settings/partials/pinned_chip_list.html
@@ -206,7 +206,7 @@
                 var btn = form.querySelector('button[type="submit"]');
                 if (!btn) return;
                 btn.className = 'btn btn-sm btn-primary';
-                btn.title = 'Pin this item';
+                btn.title = 'Pin — always keep this item on cache (never evicted)';
                 btn.innerHTML =
                     '<i data-lucide="pin" style="width: 14px; height: 14px; vertical-align: middle;"></i> Pin';
             });

--- a/web/templates/settings/partials/pinned_result_row.html
+++ b/web/templates/settings/partials/pinned_result_row.html
@@ -45,7 +45,7 @@
         <input type="hidden" name="pin_type" value="{{ item.type }}">
         <input type="hidden" name="title" value="{{ item.title }}">
         <button type="submit" class="btn btn-sm {% if item.already_pinned %}btn-secondary{% else %}btn-primary{% endif %}"
-                title="{% if item.already_pinned %}Unpin this item{% else %}Pin this item{% endif %}">
+                title="{% if item.already_pinned %}Unpin — allow this item to be evicted or moved back to the array{% else %}Pin — always keep this item on cache (never evicted){% endif %}">
             <i data-lucide="{% if item.already_pinned %}pin-off{% else %}pin{% endif %}" style="width: 14px; height: 14px; vertical-align: middle;"></i>
             {% if item.already_pinned %}Unpin{% else %}Pin{% endif %}
         </button>

--- a/web/templates/settings/partials/pinned_toggle_response.html
+++ b/web/templates/settings/partials/pinned_toggle_response.html
@@ -1,3 +1,4 @@
+{% from "macros/pin_button.html" import pin_button %}
 {#
   Response to POST /api/pinned/toggle.
 
@@ -16,20 +17,23 @@
     <strong>Cannot pin:</strong> {{ error }}
 </div>
 {% else %}
-<form hx-post="/api/pinned/toggle"
-      hx-target="this"
-      hx-swap="outerHTML"
-      class="pinned-toggle-form"
-      data-rating-key="{{ rating_key }}"
-      data-is-pinned="{{ 'true' if is_pinned else 'false' }}"
-      style="margin: 0; display: inline-block;">
-    <input type="hidden" name="rating_key" value="{{ rating_key }}">
-    <input type="hidden" name="pin_type" value="{{ pin_type }}">
-    <input type="hidden" name="title" value="{{ title }}">
-    <button type="submit" class="btn btn-sm {% if is_pinned %}btn-secondary{% else %}btn-primary{% endif %}"
-            title="{% if is_pinned %}Unpin — allow this item to be evicted or moved back to the array{% else %}Pin — always keep this item on cache (never evicted){% endif %}">
-        <i data-lucide="{% if is_pinned %}pin-off{% else %}pin{% endif %}" style="width: 14px; height: 14px; vertical-align: middle;"></i>
-        {% if is_pinned %}Unpin{% else %}Pin{% endif %}
-    </button>
-</form>
+{#
+  Rendered through the shared macro rather than a hand-copy of its markup. The
+  copy had drifted: it accepted no label/confirm, so after unpinning a show from
+  a Recently Added episode row the swapped-in control came back as a bare,
+  confirm-less "Pin" still bound to pin_type=show — one stray click re-pinned the
+  whole series.
+
+  A show- or season-scoped control keeps its confirm here for the same reason it
+  has one on the originating row: the click affects every episode the scope
+  covers, not just the row it sits in.
+#}
+{% if pin_type in ('show', 'season') %}
+{{ pin_button(rating_key, pin_type, title, is_pinned,
+              label=('Unpin ' ~ pin_type) if is_pinned else '',
+              confirm=('Unpinning this ' ~ pin_type ~ ' releases every episode it covers. Continue?')
+                      if is_pinned else '') }}
+{% else %}
+{{ pin_button(rating_key, pin_type, title, is_pinned) }}
+{% endif %}
 {% endif %}

--- a/web/templates/settings/partials/pinned_toggle_response.html
+++ b/web/templates/settings/partials/pinned_toggle_response.html
@@ -27,7 +27,7 @@
     <input type="hidden" name="pin_type" value="{{ pin_type }}">
     <input type="hidden" name="title" value="{{ title }}">
     <button type="submit" class="btn btn-sm {% if is_pinned %}btn-secondary{% else %}btn-primary{% endif %}"
-            title="{% if is_pinned %}Unpin this item{% else %}Pin this item{% endif %}">
+            title="{% if is_pinned %}Unpin — allow this item to be evicted or moved back to the array{% else %}Pin — always keep this item on cache (never evicted){% endif %}">
         <i data-lucide="{% if is_pinned %}pin-off{% else %}pin{% endif %}" style="width: 14px; height: 14px; vertical-align: middle;"></i>
         {% if is_pinned %}Unpin{% else %}Pin{% endif %}
     </button>


### PR DESCRIPTION
Adds a Recently Added view, as a page and a dashboard widget. Refs #174.

The idea is visibility first. It answers "Plex just added this, is it on the cache, and what happens to it next" without asking you to pin anything or change a setting.

## What it shows

- Recently added movies and episodes across your libraries, newest first
- Whether each item is on cache, on the array, or not covered by a path mapping
- What PlexCache will do with it next, named as an outcome rather than shown as a raw internal state
- Associated files (subtitles, artwork, NFOs) per item, expandable inline
- Episodes grouped under their show, so importing a season does not bury everything else added that day

There are filters for library and location plus a search box, and the dashboard widget is a compact version of the same data.

## Outcome table

The page names each row by what happens to the file next rather than by an internal state, since that
is the question it exists to answer. There are ten of those outcomes, each with a label, badge class,
icon, tooltip and a severity rank, so they live together in one module (`web/outcome_vocabulary.py`).

The rank is the part that has to be in Python rather than the template: collapsing a show's episodes
into a single group header takes the weakest outcome present, so a group never reads as safer than its
worst episode.

It sits at `web/` top level rather than under `web/services/` because `web/config.py` registers the
tooltip lookup as a template global, and `web/services/__init__.py` imports `cache_service`, which
imports `web.config`. A module under services would close that cycle. `web/settings_search_index.py`
sits at top level for the same reason.

A few existing badges render these same states, so they now read their text from the same table.

## Also included

Two things that are not part of the feature but were written alongside it:

- A warning when a path mapping caches into a different Unraid share than the one its media lives in. That configuration silently defeats the point of the mapping and there was no signal for it.
- A test that parses every Jinja template. A template syntax error is invisible until someone loads the page that uses it, since the CI `py_compile` step only reaches `web/routers/` and `web/services/`.

## Testing

1. Add something to a Plex library, then open Recently Added. It should appear with the correct library, size and outcome.
2. Import a full season. The episodes should group under their show, and anything else added around the same time should still be visible rather than pushed off the list.
3. Expand a row to see its associated files. Pin the item, and the expanded detail should still be open after the list refreshes.
4. Filter by library, then clear the filter. Search for a title, including searching for an episode by its show name.
5. Confirm the dashboard widget lists the same items in compact form.
6. Point a mapping's cache path at a different share than its media path, then start a run. The log should warn about the mismatch.

## Relationship to the other open PR

This can merge before or after #204 (the three run-level fixes), in either order. The two share four files
(`core/app.py`, `core/plex_api.py`, `core/system_utils.py`, `tests/test_resolve_pins_to_paths.py`) but
touch different regions. I tested both merge sequences against `main` and both auto-merge with no
conflicts and produce an identical tree, so there is no ordering requirement.

Together the two PRs bring `main` level with the fork's `dev` branch as it stands today. Further
fixes are in progress on the fork and will follow as separate PRs.
