### PR TITLE
Settings describe and enforce what the engine actually does

### DIFF
--- a/core/app.py
+++ b/core/app.py
@@ -1591,13 +1591,20 @@ class PlexCacheApp:
                         plex_path_to_info[file_path] = episode_info
 
                     if rss_expired_count > 0:
+                        # Stays DEBUG: this is a per-source breakdown that is
+                        # folded into expired_count and reported by the INFO
+                        # summary below. Promoting it would report twice.
                         expired_count += rss_expired_count
                         logging.debug(f"Skipped {rss_expired_count} RSS watchlist items due to retention expiry")
                 except Exception as e:
                     logging.error(f"Failed to fetch remote watchlist via RSS: {str(e)}")
 
             if expired_count > 0:
-                logging.debug(f"Skipped {expired_count} watchlist items due to retention expiry ({retention_days} days)")
+                # INFO, matching the OnDeck twin above: items dropping out of
+                # the watchlist is a user-visible outcome, not operational
+                # detail, and at DEBUG the only sign was media quietly not
+                # being cached.
+                logging.info(f"[FILTER] Skipped {expired_count} watchlist items due to retention expiry ({retention_days} days)")
 
             # Log watchlist summary (show unique item count - raw counts include duplicates across users)
             total_watchlist = len(result_set)

--- a/core/app.py
+++ b/core/app.py
@@ -95,6 +95,9 @@ class PlexCacheApp:
         # Set when _apply_cache_limit() has to skip caching for space reasons.
         # Drives _reclaim_released_if_constrained().
         self._cache_space_constrained = False
+        # Both eviction entry points bail on an empty cache_limit; warn once
+        # per run rather than twice.
+        self._warned_eviction_needs_limit = False
         # Eviction tracking
         self.evicted_count = 0
         self.evicted_bytes = 0
@@ -956,7 +959,43 @@ class PlexCacheApp:
                     self._mount_paths_safe = False
             if self.config_manager.paths.cache_dir:
                 self._ensure_cache_path_exists(self.config_manager.paths.cache_dir)
-    
+
+        self._advise_on_symlinks()
+
+    def _advise_on_symlinks(self) -> None:
+        """Flag the one configuration where caching hides files from Plex.
+
+        Caching renames the original to ``.plexcached``. On Unraid the media
+        path is a FUSE union that still shows the cache copy, so Plex keeps
+        reading the file. Off Unraid that only holds when something else
+        unions the two paths (mergerfs and similar); on plain directories the
+        original path stops resolving and Plex reports the file as missing.
+
+        ``use_symlinks`` exists for exactly that case and defaults to False,
+        so a plain-Linux install hits it by default. This cannot be decided
+        from configuration alone, hence advice rather than an error.
+        """
+        if getattr(self.system_detector, 'is_unraid', False):
+            return
+        if self.config_manager.cache.use_symlinks:
+            return
+
+        cacheable = [
+            m for m in (self.config_manager.paths.path_mappings or [])
+            if m.enabled and m.cacheable and m.cache_path
+        ]
+        if not cacheable and self.config_manager.paths.cache_dir:
+            cacheable = [None]  # legacy single-path config
+        if not cacheable:
+            return
+
+        logging.warning(
+            "Not running on Unraid and 'Create symlinks' is off. Caching renames the "
+            "original file to .plexcached, so unless your media path and cache path are "
+            "a single merged view (mergerfs or similar), Plex will stop finding cached "
+            "files. Turn on 'Create symlinks' in Settings if they are separate directories."
+        )
+
     def _connect_to_plex(self) -> None:
         """Connect to the Plex server and load user tokens."""
         self.plex_manager.connect()
@@ -2633,7 +2672,11 @@ class PlexCacheApp:
         if plexcache_quota_bytes > 0:
             plexcache_tracked, _ = self._get_plexcache_tracked_size()
             quota_available = plexcache_quota_bytes - plexcache_tracked
-            logging.info(f"[QUOTA] PlexCache quota: {plexcache_quota_bytes / (1024**3):.2f}GB (tracked: {plexcache_tracked / (1024**3):.2f}GB, available: {quota_available / (1024**3):.2f}GB)")
+            # The quota's configured value is already logged above; report only
+            # what is measured against it, so one run does not print the same
+            # number twice in two different shapes.
+            logging.info(f"[QUOTA] PlexCache tracked: {plexcache_tracked / (1024**3):.2f}GB "
+                         f"(available: {quota_available / (1024**3):.2f}GB)")
             if available_space is None or quota_available < available_space:
                 available_space = quota_available
                 bottleneck = "plexcache_quota"
@@ -2641,10 +2684,10 @@ class PlexCacheApp:
         if available_space is None:
             return media_files
 
-        # Log which constraint is the bottleneck when multiple are active
-        active_count = sum(1 for v in [cache_limit_bytes, min_free_bytes, plexcache_quota_bytes] if v > 0)
-        if active_count > 1:
-            logging.info(f"[QUOTA] Active constraint: {bottleneck.replace('_', ' ')} (available: {available_space / (1024**3):.2f}GB)")
+        # Always name the constraint that won, even when only one is set.
+        # Gating this on "more than one active" meant the line's absence
+        # carried meaning, and the reader had to work out which limit applied.
+        logging.info(f"[QUOTA] Active constraint: {bottleneck.replace('_', ' ')} (available: {available_space / (1024**3):.2f}GB)")
 
         if available_space <= 0:
             if bottleneck == "min_free_space":
@@ -2803,6 +2846,28 @@ class PlexCacheApp:
         # Clamp to 0-100 range
         return max(0, min(100, score))
 
+    def _warn_eviction_needs_cache_limit(self) -> None:
+        """Say so when eviction is switched on but has nothing to measure.
+
+        Both eviction entry points size themselves as a percentage of
+        ``cache_limit``, so an empty limit leaves a fully configured eviction
+        mode doing nothing at all. Both used to return silently, which reads
+        from the log exactly like a run that had nothing to evict.
+
+        ``plexcache_quota`` does not substitute: it bounds what PlexCache
+        holds, while eviction measures total drive usage.
+        """
+        if self._warned_eviction_needs_limit:
+            return
+        self._warned_eviction_needs_limit = True
+
+        mode = self.config_manager.cache.cache_eviction_mode
+        logging.warning(
+            f"Cache eviction is set to '{mode}' but no Cache Limit is configured, "
+            f"so nothing will ever be evicted. Set a Cache Limit in Settings, or "
+            f"set eviction to 'none' to stop this warning."
+        )
+
     def _filter_low_priority_files(self, media_files: List[str], source_map: dict) -> List[str]:
         """Filter out files that would score below eviction_min_priority.
 
@@ -2840,6 +2905,7 @@ class PlexCacheApp:
         # Check if drive is over eviction threshold
         cache_limit_bytes, _ = self._get_effective_cache_limit(cache_dir)
         if cache_limit_bytes == 0:
+            self._warn_eviction_needs_cache_limit()
             return media_files
 
         threshold_percent = self.config_manager.cache.cache_eviction_threshold_percent
@@ -2916,6 +2982,7 @@ class PlexCacheApp:
         cache_dir = self.config_manager.paths.cache_dir
         cache_limit_bytes, _ = self._get_effective_cache_limit(cache_dir)
         if cache_limit_bytes == 0:
+            self._warn_eviction_needs_cache_limit()
             return (0, 0)
 
         # Get current PlexCache tracked size and file list

--- a/core/app.py
+++ b/core/app.py
@@ -920,7 +920,7 @@ class PlexCacheApp:
                             "CRITICAL: /mnt/user0 is not mounted but .plexcached backups are enabled. "
                             "Without /mnt/user0, file renames will operate through FUSE (/mnt/user/) "
                             "which can corrupt cached files. Add -v /mnt/user0:/mnt/user0 to your "
-                            "Docker configuration, or disable .plexcached backups in settings."
+                            "Docker configuration."
                         )
                     else:
                         logging.warning(
@@ -1813,22 +1813,21 @@ class PlexCacheApp:
         old_plexcached = find_matching_plexcached(old_array_dir, old_identity, old_path)
 
         if old_plexcached and os.path.isfile(old_plexcached):
-            # Delete outdated backup (content has been superseded by upgrade)
-            try:
-                os.remove(old_plexcached)
-                logging.info(f"[UPGRADE] Deleted outdated array backup: {os.path.basename(old_plexcached)} "
-                             f"(superseded by upgrade, rating_key={rating_key})")
-            except OSError as e:
-                logging.warning(f"[UPGRADE] Failed to delete old backup {os.path.basename(old_plexcached)}: "
-                                f"{type(e).__name__}: {e}")
-                return
+            # Create the replacement backup BEFORE removing the outdated one.
+            # Deleting first means an ENOSPC or permission error on the copy
+            # leaves the file with no backup at all, which is the one state
+            # this whole subsystem exists to prevent. Mirrors the ordering in
+            # CacheService._handle_upgrade_plexcached().
+            new_backup_ok = False
 
-            # Create new backup if setting enabled
             if self.config_manager.cache.backup_upgraded_files and new_cache_path:
                 new_array_path = get_array_direct_path(new_path)
                 new_plexcached = new_array_path + '.plexcached'
 
-                if not os.path.isfile(new_plexcached) and os.path.isfile(new_cache_path):
+                if os.path.isfile(new_plexcached):
+                    # Already there from an earlier run.
+                    new_backup_ok = True
+                elif os.path.isfile(new_cache_path):
                     try:
                         new_array_dir = os.path.dirname(new_array_path)
                         create_dir_with_ownership(new_array_dir, new_cache_path)
@@ -1839,12 +1838,28 @@ class PlexCacheApp:
                         if src_size == dst_size:
                             logging.info(f"[UPGRADE] Created new array backup: {os.path.basename(new_plexcached)} "
                                          f"({format_bytes(src_size)}, rating_key={rating_key})")
+                            new_backup_ok = True
                         else:
                             logging.warning(f"[UPGRADE] Backup size mismatch for {os.path.basename(new_plexcached)}: "
                                             f"source={src_size}, dest={dst_size}")
                             os.remove(new_plexcached)
                     except OSError as e:
                         logging.warning(f"[UPGRADE] Failed to create new backup: {type(e).__name__}: {e}")
+            else:
+                # No replacement wanted, so the old backup is merely outdated.
+                new_backup_ok = True
+
+            if new_backup_ok:
+                try:
+                    os.remove(old_plexcached)
+                    logging.info(f"[UPGRADE] Deleted outdated array backup: {os.path.basename(old_plexcached)} "
+                                 f"(superseded by upgrade, rating_key={rating_key})")
+                except OSError as e:
+                    logging.warning(f"[UPGRADE] Failed to delete old backup {os.path.basename(old_plexcached)}: "
+                                    f"{type(e).__name__}: {e}")
+            else:
+                logging.warning(f"[UPGRADE] Keeping old backup, new one could not be created: "
+                                f"{os.path.basename(old_plexcached)} (rating_key={rating_key})")
         else:
             logging.debug(f"[UPGRADE] No existing .plexcached backup found for {os.path.basename(old_path)}, "
                           f"skipping backup handling (rating_key={rating_key})")

--- a/core/config.py
+++ b/core/config.py
@@ -569,15 +569,15 @@ class ConfigManager:
 
         # Load and parse cache limit setting
         self.cache.cache_limit = self.settings_data.get('cache_limit', "")
-        self.cache.cache_limit_bytes = self._parse_cache_limit(self.cache.cache_limit)
+        self.cache.cache_limit_bytes = self._parse_cache_limit(self.cache.cache_limit, 'cache_limit')
 
         # Load and parse min free space setting
         self.cache.min_free_space = self.settings_data.get('min_free_space', "")
-        self.cache.min_free_space_bytes = self._parse_cache_limit(self.cache.min_free_space)
+        self.cache.min_free_space_bytes = self._parse_cache_limit(self.cache.min_free_space, 'min_free_space')
 
         # Load and parse plexcache quota setting
         self.cache.plexcache_quota = self.settings_data.get('plexcache_quota', "")
-        self.cache.plexcache_quota_bytes = self._parse_cache_limit(self.cache.plexcache_quota)
+        self.cache.plexcache_quota_bytes = self._parse_cache_limit(self.cache.plexcache_quota, 'plexcache_quota')
 
         # Load smart eviction settings (default: disabled)
         self.cache.cache_eviction_mode = self.settings_data.get('cache_eviction_mode', "none")
@@ -967,52 +967,44 @@ class ConfigManager:
             logging.error(f"Error saving settings: {type(e).__name__}: {e}")
             raise
     
-    def _parse_cache_limit(self, limit_str: str) -> int:
-        """Parse cache limit string and return bytes.
+    def _parse_cache_limit(self, limit_str: str, key: str = "cache_limit"):
+        """Parse a size-or-percentage setting and return bytes.
 
-        Supports formats:
-        - "250GB" or "250gb" -> 250 * 1024^3 bytes
-        - "500MB" or "500mb" -> 500 * 1024^2 bytes
-        - "50%" -> percentage of total cache drive size (computed at runtime)
-        - "250" -> defaults to GB (250 * 1024^3 bytes)
-        - "" or "0" -> 0 (no limit)
+        Shared by cache_limit, min_free_space and plexcache_quota, so ``key``
+        names the one being parsed — otherwise every warning blamed
+        cache_limit regardless of which value was mistyped.
+
+        Byte quantities delegate to ``parse_size_bytes()``, the parser the rest
+        of the app uses, so the accepted formats are the same everywhere.
+        Short suffixes ("3.7T") used to fall through to "no limit" here while
+        the settings page previewed an enforced cap.
 
         Returns:
-            Bytes as int, or negative value for percentage (e.g., -50 for 50%)
+            Positive bytes, 0 for disabled/unparseable, or a negative number
+            encoding a percentage resolved later against the drive total
+            (-50 for 50%). Percentages may be fractional; _get_effective_limit()
+            takes abs() and multiplies, so -7.5 resolves correctly.
         """
         if not limit_str or limit_str.strip() == "0":
             return 0
 
         limit_str = limit_str.strip().upper()
 
-        try:
-            # Check for percentage
-            if limit_str.endswith('%'):
-                percent = int(limit_str[:-1])
-                if percent <= 0 or percent > 100:
-                    logging.warning(f"Invalid cache_limit percentage '{limit_str}', must be 1-100. Using no limit.")
-                    return 0
-                # Return negative value to indicate percentage (will be computed at runtime)
-                return -percent
+        if limit_str.endswith('%'):
+            try:
+                percent = float(limit_str[:-1])
+            except ValueError:
+                logging.warning(f"Invalid {key} percentage '{limit_str}'. Using no limit.")
+                return 0
+            if percent <= 0 or percent > 100:
+                logging.warning(f"Invalid {key} percentage '{limit_str}', must be 1-100. Using no limit.")
+                return 0
+            return -percent
 
-            # Check for size units
-            if limit_str.endswith('GB'):
-                size = float(limit_str[:-2])
-                return int(size * 1024 * 1024 * 1024)
-            elif limit_str.endswith('MB'):
-                size = float(limit_str[:-2])
-                return int(size * 1024 * 1024)
-            elif limit_str.endswith('TB'):
-                size = float(limit_str[:-2])
-                return int(size * 1024 * 1024 * 1024 * 1024)
-            else:
-                # No unit specified, default to GB
-                size = float(limit_str)
-                return int(size * 1024 * 1024 * 1024)
-
-        except ValueError:
-            logging.warning(f"Invalid cache_limit value '{limit_str}'. Using no limit.")
-            return 0
+        parsed = parse_size_bytes(limit_str)
+        if parsed == 0:
+            logging.warning(f"Invalid {key} value '{limit_str}'. Using no limit.")
+        return parsed
 
 
     @staticmethod

--- a/core/config.py
+++ b/core/config.py
@@ -264,7 +264,8 @@ class LoggingConfig:
     """Configuration for logging settings."""
     # Maximum number of log files to keep (default: 24 for hourly runs = 1 day)
     max_log_files: int = 24
-    # Keep error logs (containing WARNING/ERROR) for this many days (default: 7)
+    # Keep error logs (containing ERROR/CRITICAL) for this many days (default: 7)
+    # Warnings alone do not trigger preservation — see _preserve_error_log()
     # Logs are preserved in logs/errors/ subfolder
     keep_error_logs_days: int = 7
 

--- a/core/config.py
+++ b/core/config.py
@@ -500,6 +500,43 @@ class ConfigManager:
         self.plex.per_user_ondeck_days = per_user_ondeck_days or None
         self.plex.per_user_watchlist_days = per_user_watchlist_days or None
     
+    def _validate_eviction_settings(self) -> None:
+        """Range-check the eviction trio, and flag a threshold that cannot act.
+
+        Out-of-range values fall back to their defaults. The priority threshold
+        gets an extra check that a range test cannot express: scores start at a
+        floor rather than at 0, because ``calculate_priority()`` begins at 50 and
+        its negative factors are bounded. ``get_eviction_candidates()`` keeps
+        anything scoring at or above the threshold, so a threshold below that
+        floor keeps every file and eviction frees nothing while still reporting
+        itself as enabled.
+
+        That case is reported, not corrected. Raising a stored threshold would
+        start deleting cache copies on the next run, which is not a decision to
+        make on the user's behalf while loading their config. The web input and
+        the setup wizard stop new values from landing there.
+        """
+        if self.cache.cache_eviction_mode not in ("smart", "fifo", "none"):
+            logging.warning(f"Invalid cache_eviction_mode '{self.cache.cache_eviction_mode}', using 'none'")
+            self.cache.cache_eviction_mode = "none"
+
+        if not 1 <= self.cache.cache_eviction_threshold_percent <= 100:
+            logging.warning(f"Invalid cache_eviction_threshold_percent '{self.cache.cache_eviction_threshold_percent}', using 90")
+            self.cache.cache_eviction_threshold_percent = 90
+
+        if not 0 <= self.cache.eviction_min_priority <= 100:
+            logging.warning(f"Invalid eviction_min_priority '{self.cache.eviction_min_priority}', using 60")
+            self.cache.eviction_min_priority = 60
+        elif self.cache.cache_eviction_mode == "smart":
+            from core.file_operations import PRIORITY_RANGE_WATCHLIST_MIN
+            if self.cache.eviction_min_priority < PRIORITY_RANGE_WATCHLIST_MIN:
+                logging.warning(
+                    f"eviction_min_priority is {self.cache.eviction_min_priority}, but the lowest "
+                    f"score any file can have is about {PRIORITY_RANGE_WATCHLIST_MIN}, so smart "
+                    f"eviction will never select anything. Raise it (60 is the default) or set "
+                    f"cache_eviction_mode to 'none'."
+                )
+
     def _load_cache_config(self) -> None:
         """Load cache-related configuration."""
         self.cache.watchlist_toggle = self.settings_data['watchlist_toggle']
@@ -547,16 +584,7 @@ class ConfigManager:
         self.cache.cache_eviction_threshold_percent = self.settings_data.get('cache_eviction_threshold_percent', 90)
         self.cache.eviction_min_priority = self.settings_data.get('eviction_min_priority', 60)
 
-        # Validate eviction settings
-        if self.cache.cache_eviction_mode not in ("smart", "fifo", "none"):
-            logging.warning(f"Invalid cache_eviction_mode '{self.cache.cache_eviction_mode}', using 'none'")
-            self.cache.cache_eviction_mode = "none"
-        if not 1 <= self.cache.cache_eviction_threshold_percent <= 100:
-            logging.warning(f"Invalid cache_eviction_threshold_percent '{self.cache.cache_eviction_threshold_percent}', using 90")
-            self.cache.cache_eviction_threshold_percent = 90
-        if not 0 <= self.cache.eviction_min_priority <= 100:
-            logging.warning(f"Invalid eviction_min_priority '{self.cache.eviction_min_priority}', using 60")
-            self.cache.eviction_min_priority = 60
+        self._validate_eviction_settings()
 
         # Load .plexcached backup setting (default True for safety)
         self.cache.create_plexcached_backups = self.settings_data.get('create_plexcached_backups', True)

--- a/core/file_operations.py
+++ b/core/file_operations.py
@@ -2302,25 +2302,10 @@ class CachePriorityManager:
 
         ondeck_season, ondeck_episode = ondeck_pos
 
-        # Calculate how many episodes ahead this file is
-        if season < ondeck_season:
-            # This episode is BEFORE the OnDeck position (shouldn't happen, but handle it)
-            return -1
-        elif season == ondeck_season:
-            if episode <= ondeck_episode:
-                # Same season, same or earlier episode
-                return 0
-            else:
-                # Same season, later episode
-                return episode - ondeck_episode
-        else:
-            # Later season - estimate distance
-            # Assume ~13 episodes per season for estimation
-            episodes_per_season = 13
-            seasons_ahead = season - ondeck_season
-            episodes_remaining_in_ondeck_season = episodes_per_season - ondeck_episode
-            full_seasons_between = max(0, seasons_ahead - 1) * episodes_per_season
-            return episodes_remaining_in_ondeck_season + full_seasons_between + episode
+        # Shared with the Priority Report's scorer so both produce the same
+        # distance — see core/media_grouping.episodes_ahead_of().
+        from core.media_grouping import episodes_ahead_of
+        return episodes_ahead_of(season, episode, ondeck_season, ondeck_episode)
 
     def _is_tv_episode(self, cache_path: str) -> bool:
         """Check if a cached file is a TV episode.

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -673,6 +673,12 @@ class WebhookHandler(logging.Handler):
         return {"content": message, "text": message}
 
 
+# How many 20MB rollovers a single run may leave behind. Separate from
+# max_log_files, which counts whole runs: one pathological run should not be
+# able to occupy the entire log budget.
+ROTATION_BACKUPS_PER_RUN = 2
+
+
 class LoggingManager:
     """Manages logging configuration and setup."""
 
@@ -781,7 +787,11 @@ class LoggingManager:
         file_handler = RotatingFileHandler(
             log_file,
             maxBytes=20*1024*1024,
-            backupCount=self.max_log_files
+            # Not max_log_files: that setting counts *runs* to keep, and each run
+            # writes its own timestamped file. Reusing it here let a single
+            # oversized run keep as many 20MB backups as the user wanted whole
+            # logs. A small constant bounds one run's overflow instead.
+            backupCount=ROTATION_BACKUPS_PER_RUN
         )
         file_handler.setFormatter(log_format)
         file_handler.addFilter(VerboseMessageFilter())  # Apply filter to handler

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -678,6 +678,10 @@ class WebhookHandler(logging.Handler):
 # able to occupy the entire log budget.
 ROTATION_BACKUPS_PER_RUN = 2
 
+# Convenience pointer to the newest run's log. Matches the cleanup glob, so the
+# retention count has to exclude it by name.
+LATEST_LOG_NAME = "plexcache_log_latest.log"
+
 
 class LoggingManager:
     """Manages logging configuration and setup."""
@@ -778,7 +782,7 @@ class LoggingManager:
         current_time = datetime.now().strftime("%Y%m%d_%H%M%S")
         log_file = self.logs_folder / f"plexcache_log_{current_time}.log"
         self.current_log_file = log_file  # Track for error preservation
-        latest_log_file = self.logs_folder / "plexcache_log_latest.log"
+        latest_log_file = self.logs_folder / LATEST_LOG_NAME
 
         datefmt = self._get_log_datefmt()
         log_format = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s', datefmt=datefmt)
@@ -851,7 +855,10 @@ class LoggingManager:
         Tying a backup's lifetime to its base file keeps one rule rather than
         two: when the run's log goes, its overflow goes with it.
         """
-        existing_log_files = list(self.logs_folder.glob(self.log_file_pattern))
+        # plexcache_log_latest.log matches the glob but is a pointer to the
+        # newest run, not a run of its own. Counting it meant "keep 24" kept 23.
+        existing_log_files = [p for p in self.logs_folder.glob(self.log_file_pattern)
+                              if p.name != LATEST_LOG_NAME]
         existing_log_files.sort(key=lambda x: x.stat().st_mtime)
 
         while len(existing_log_files) > self.max_log_files:

--- a/core/logging_config.py
+++ b/core/logging_config.py
@@ -830,12 +830,40 @@ class LoggingManager:
             self.logger.setLevel(logging.INFO)
     
     def _clean_old_log_files(self) -> None:
-        """Clean old log files to maintain the maximum count."""
+        """Clean old log files to maintain the maximum count.
+
+        Also removes rotation backups whose log file has been cleaned up.
+        Each run writes its own timestamped file, so RotatingFileHandler only
+        rolls over when a single run exceeds maxBytes, and the backup it leaves
+        is named ``plexcache_log_<stamp>.log.1``. That does not match the
+        ``*.log`` glob above, so nothing in the product removed them.
+
+        Tying a backup's lifetime to its base file keeps one rule rather than
+        two: when the run's log goes, its overflow goes with it.
+        """
         existing_log_files = list(self.logs_folder.glob(self.log_file_pattern))
         existing_log_files.sort(key=lambda x: x.stat().st_mtime)
-        
+
         while len(existing_log_files) > self.max_log_files:
             os.remove(existing_log_files.pop(0))
+
+        kept = {p.name for p in existing_log_files}
+        orphaned = 0
+        for backup in self.logs_folder.glob(f"{self.log_file_pattern}.*"):
+            # Only numeric rollover suffixes: .log.1, .log.2, ...
+            if not backup.suffix[1:].isdigit():
+                continue
+            if backup.with_suffix("").name in kept:
+                continue
+            try:
+                os.remove(backup)
+                orphaned += 1
+            except OSError:
+                pass
+
+        if orphaned:
+            logging.info(f"[LOGS] Removed {orphaned} rotation backup file(s) "
+                         f"left by oversized runs")
     
     def setup_notification_handlers(self, notification_config, is_unraid: bool, is_docker: bool) -> None:
         """Set up notification handlers based on configuration."""

--- a/core/media_grouping.py
+++ b/core/media_grouping.py
@@ -138,3 +138,40 @@ def format_season_episode(season: Any, episode: Any) -> str:
     if isinstance(season, int) and isinstance(episode, int):
         return f"S{season:02d}E{episode:02d}"
     return ""
+
+
+# Used when a file sits in a later season than the OnDeck position and the real
+# episode count for the intervening seasons is unknown. Only affects the
+# relative ordering of far-ahead episodes, all of which score the same anyway.
+ASSUMED_EPISODES_PER_SEASON = 13
+
+
+def episodes_ahead_of(season: Any, episode: Any,
+                      ondeck_season: Any, ondeck_episode: Any,
+                      episodes_per_season: int = ASSUMED_EPISODES_PER_SEASON) -> int:
+    """How many episodes past the OnDeck position this episode sits.
+
+    Returns 0 when the episode is at or behind the OnDeck position, a positive
+    count when it is ahead, and -1 when the comparison cannot be made (a
+    missing number, or an episode in an earlier season than OnDeck).
+
+    Shared so the eviction scorer and the Priority Report agree. They resolve
+    the two positions from different places — the engine from its trackers, the
+    web layer from the OnDeck map it already loaded — but the arithmetic that
+    turns those positions into a distance has to be one implementation, or the
+    number a user calibrates against is not the number that acts.
+    """
+    for value in (season, episode, ondeck_season, ondeck_episode):
+        if not isinstance(value, int) or isinstance(value, bool):
+            return -1
+
+    if season < ondeck_season:
+        # Behind the OnDeck position: not a prefetch, so not comparable.
+        return -1
+    if season == ondeck_season:
+        return 0 if episode <= ondeck_episode else episode - ondeck_episode
+
+    seasons_ahead = season - ondeck_season
+    remaining_in_ondeck_season = max(0, episodes_per_season - ondeck_episode)
+    full_seasons_between = max(0, seasons_ahead - 1) * episodes_per_season
+    return remaining_in_ondeck_season + full_seasons_between + episode

--- a/core/pinned_cli.py
+++ b/core/pinned_cli.py
@@ -63,6 +63,7 @@ def _preflight_budget(
     state = compute_budget_state(
         cache_limit_bytes=parsed["cache_limit_bytes"],
         min_free_space_bytes=parsed["min_free_space_bytes"],
+        plexcache_quota_bytes=parsed["plexcache_quota_bytes"],
         current_pinned_bytes=current,
         additional_bytes=additional,
     )
@@ -76,7 +77,8 @@ def _preflight_budget(
         f"({format_bytes(state['total_pinned_bytes'])} + "
         f"~{format_bytes(state['additional_bytes'])} > "
         f"{format_bytes(state['effective_budget_bytes'])}). "
-        f"Unpin something first, or raise cache_limit in settings."
+        f"Unpin something first, or raise "
+        f"{'plexcache_quota' if state.get('quota_bytes') else 'cache_limit'} in settings."
     )
 
 

--- a/core/pinned_media.py
+++ b/core/pinned_media.py
@@ -559,8 +559,14 @@ def get_active_cache_total_bytes(settings: Dict[str, Any]) -> int:
     Returns 0 if no active cache mapping has a probeable size, which degrades
     percent values to 0 (disabling the budget guard). Soft-fail by design —
     the budget is an optional safety net, not a hard invariant.
+
+    Honours the ``cache_drive_size`` override, which exists because ZFS reports
+    a dataset's size rather than the pool's. Without it a percent-based budget
+    here resolves against a different total than the engine uses.
     """
-    from core.system_utils import get_disk_usage
+    from core.system_utils import get_disk_usage, parse_size_bytes
+
+    override = parse_size_bytes(settings.get("cache_drive_size", "")) or 0
     mappings = settings.get("path_mappings", [])
     if not isinstance(mappings, list):
         return 0
@@ -573,7 +579,7 @@ def get_active_cache_total_bytes(settings: Dict[str, Any]) -> int:
         if not cache_path:
             continue
         try:
-            disk = get_disk_usage(cache_path)
+            disk = get_disk_usage(cache_path, override)
             if disk and getattr(disk, "total", 0) > 0:
                 return int(disk.total)
         except Exception:
@@ -671,20 +677,37 @@ def compute_budget_state(
     min_free_space_bytes: int,
     current_pinned_bytes: int,
     additional_bytes: int = 0,
+    plexcache_quota_bytes: int = 0,
 ) -> Dict[str, Any]:
     """Compute the pinned-bytes budget state — pure math, no side effects.
 
-    ``effective_budget = max(0, cache_limit - min_free_space)`` unless
-    ``cache_limit`` is 0 (budget disabled). When disabled, ``over_budget`` and
+    Two possible ceilings, and the tighter one wins:
+
+    * ``plexcache_quota`` bounds what PlexCache may hold. It is the natural
+      ceiling here, because ``current_pinned_bytes`` is also a count of
+      PlexCache-managed files. Comparing pinned bytes against a whole-drive
+      limit measures one thing against a denominator that includes everything
+      else on the drive.
+    * ``cache_limit - min_free_space`` is that whole-drive ceiling. Kept as the
+      fallback so an install that sets only those two keeps today's guard.
+
+    When neither is set the budget is disabled, and ``over_budget`` and
     ``would_exceed`` are always False — the guard never hard-blocks without an
     explicit limit.
     """
-    effective_budget = max(0, cache_limit_bytes - min_free_space_bytes) if cache_limit_bytes > 0 else 0
+    ceilings = []
+    if plexcache_quota_bytes > 0:
+        ceilings.append(plexcache_quota_bytes)
+    if cache_limit_bytes > 0:
+        ceilings.append(max(0, cache_limit_bytes - min_free_space_bytes))
+
+    effective_budget = min(ceilings) if ceilings else 0
     over_budget = bool(effective_budget) and current_pinned_bytes > effective_budget
     would_exceed = bool(effective_budget) and (current_pinned_bytes + additional_bytes) > effective_budget
     return {
         "total_pinned_bytes": current_pinned_bytes,
         "budget_bytes": cache_limit_bytes,
+        "quota_bytes": plexcache_quota_bytes,
         "effective_budget_bytes": effective_budget,
         "headroom_bytes": min_free_space_bytes,
         "additional_bytes": additional_bytes,

--- a/core/setup.py
+++ b/core/setup.py
@@ -907,53 +907,14 @@ def _setup_advanced_settings():
         settings_data['cache_limit'] = cache_limit
 
     # .plexcached Backup Files
+    #
+    # No longer prompted for. Backups are how a cached file survives a cache
+    # drive failure, and the only reason to turn them off (Mover Tuning on a
+    # cache:prefer share) is narrow enough that it does not belong in the
+    # first-run path. It stays configurable in Settings > Cache, where the copy
+    # states the consequence. Defaults on, as it always did.
     if 'create_plexcached_backups' not in settings_data:
-        print('\n--- Backup Settings ---')
-        print('When caching files, PlexCache can create .plexcached backups on the array.')
-        print('')
-        print('=== How Caching Works ===')
-        print('')
-        print('With backups ENABLED (default, recommended):')
-        print('  1. File is copied from array to cache drive')
-        print('  2. Array file is renamed to .plexcached (preserves backup on array)')
-        print('  3. File path is added to exclude list (prevents Unraid mover conflicts)')
-        print('  4. Files are removed from cache when:')
-        print('     - "Move watched files" is enabled AND content is watched, OR')
-        print('     - "Cache eviction" is enabled AND cache is full')
-        print('  5. On removal: .plexcached is renamed back to original (fast, no copy)')
-        print('  6. If cache drive fails: run --restore-plexcached to recover all files')
-        print('')
-        print('With backups DISABLED:')
-        print('  1. File is copied from array to cache drive')
-        print('  2. Array file is DELETED (no backup exists)')
-        print('  3. File path is added to exclude list')
-        print('  4. Files are removed from cache when:')
-        print('     - "Move watched files" is enabled AND content is watched, OR')
-        print('     - "Cache eviction" is enabled AND cache is full')
-        print('  5. On removal: file must be copied back to array (slower)')
-        print('  6. If cache drive fails: FILES ARE PERMANENTLY LOST')
-        print('')
-        print('=== Important Notes ===')
-        print('')
-        print('- The exclude list is managed automatically by PlexCache')
-        print('- You should enable "Move watched files" OR "Cache eviction" (or both)')
-        print('  to prevent cache from filling up indefinitely')
-        print('')
-        print('=== When to Disable Backups ===')
-        print('')
-        print('Only disable if you have:')
-        print('  - Mover Tuning with cache:prefer shares')
-        print('    (.plexcached files could be moved back to cache)')
-        print('')
-        print('Hard-linked files (seeding/torrents, jdupes) do not need this')
-        print('turned off. PlexCache deletes the array link for those files')
-        print('either way, so the seed copy is preserved.')
-        print('')
-        print('  Yes - Create .plexcached backups (safer, recommended)')
-        print('  No  - Delete array files after caching (no recovery if the')
-        print('        cache drive fails)')
-        backup_choice = input('Create .plexcached backups? [Y/n] ') or 'yes'
-        settings_data['create_plexcached_backups'] = backup_choice.lower() in ['y', 'yes']
+        settings_data['create_plexcached_backups'] = True
 
     # Hard-linked Files Handling
     if 'hardlinked_files' not in settings_data:

--- a/core/setup.py
+++ b/core/setup.py
@@ -1039,7 +1039,7 @@ def _setup_advanced_settings():
         prompt_user_for_number('Max log files to keep [24]: ', '24', 'max_log_files')
 
     if 'keep_error_logs_days' not in settings_data:
-        print('\nError log retention: Logs with warnings/errors are preserved longer.')
+        print('\nError log retention: Logs containing errors are preserved longer.')
         print('(Copied to logs/errors/ subfolder for debugging)')
         prompt_user_for_number('Days to keep error logs [7]: ', '7', 'keep_error_logs_days')
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -942,13 +942,16 @@ def _setup_advanced_settings():
         print('=== When to Disable Backups ===')
         print('')
         print('Only disable if you have:')
-        print('  - Hard-linked files (from seeding/torrents or jdupes)')
-        print('    (FUSE cannot rename hard-linked files properly)')
         print('  - Mover Tuning with cache:prefer shares')
         print('    (.plexcached files could be moved back to cache)')
         print('')
+        print('Hard-linked files (seeding/torrents, jdupes) do not need this')
+        print('turned off. PlexCache deletes the array link for those files')
+        print('either way, so the seed copy is preserved.')
+        print('')
         print('  Yes - Create .plexcached backups (safer, recommended)')
-        print('  No  - Delete array files after caching (required for hard links)')
+        print('  No  - Delete array files after caching (no recovery if the')
+        print('        cache drive fails)')
         backup_choice = input('Create .plexcached backups? [Y/n] ') or 'yes'
         settings_data['create_plexcached_backups'] = backup_choice.lower() in ['y', 'yes']
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -1094,12 +1094,24 @@ def _configure_eviction_settings():
             settings_data['cache_eviction_threshold_percent'] = 90
 
         if eviction_mode == 'smart':
-            min_pri = input('Min priority to evict (0-100) [60]: ').strip() or '60'
+            from core.file_operations import PRIORITY_RANGE_WATCHLIST_MIN
+            floor = PRIORITY_RANGE_WATCHLIST_MIN
+            print('')
+            print(f'Files are scored from about {floor} (an old watchlist item) to 100')
+            print('(the episode you are on). Anything scoring below your threshold')
+            print('is evicted when the cache fills up.')
+            min_pri = input(f'Min priority to keep ({floor}-100) [60]: ').strip() or '60'
             try:
-                settings_data['eviction_min_priority'] = int(min_pri)
+                value = int(min_pri)
             except ValueError:
                 print(f"Invalid number '{min_pri}', using default 60")
-                settings_data['eviction_min_priority'] = 60
+                value = 60
+            if value < floor:
+                # Nothing scores below the floor, so this would keep everything.
+                print(f"{value} is below the lowest score a file can have, so nothing")
+                print(f"would ever be evicted. Using {floor} instead.")
+                value = floor
+            settings_data['eviction_min_priority'] = min(value, 100)
 
 
 def _detect_webhook_platform(url: str) -> str:

--- a/core/system_utils.py
+++ b/core/system_utils.py
@@ -335,6 +335,10 @@ def parse_size_bytes(size_str: str) -> int:
         else:
             return int(float(size_str) * 1024**3)  # Default to GB
     except ValueError:
+        # 0 means "no limit" to every caller, so an unparseable value silently
+        # removes the cap the user thought they set. Say so; callers that can
+        # name the setting add their own message on top.
+        logging.warning(f"Could not read '{size_str}' as a size. Expected e.g. 500GB, 1.5T or 250. Treating as unset.")
         return 0
 
 

--- a/tests/test_auto_transfer_upgrades_gate.py
+++ b/tests/test_auto_transfer_upgrades_gate.py
@@ -1,0 +1,89 @@
+"""auto_transfer_upgrades governs the automatic upgrade check.
+
+The setting gated the CLI path only. The scheduled web audit called
+CacheService.check_for_upgrades() unconditionally, so switching it off changed
+when tracking was transferred rather than whether it was.
+
+The manual endpoint (POST /api/check-upgrades) is deliberately not gated:
+clicking it is an explicit request, not something the app does on its own.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests', 'apscheduler',
+                  'apscheduler.schedulers', 'apscheduler.schedulers.background',
+                  'apscheduler.triggers', 'apscheduler.triggers.cron',
+                  'apscheduler.triggers.interval']:
+    sys.modules.setdefault(_mod_name, MagicMock())
+
+
+def _audit_with(auto_transfer, stale=("/mnt/cache/movies/Gone.mkv",)):
+    """Run the stale-entry branch of run_full_audit and report if it checked."""
+    from web.services.maintenance_service import MaintenanceService
+
+    service = object.__new__(MaintenanceService)
+    service._load_settings = MagicMock(
+        return_value={'auto_transfer_upgrades': auto_transfer})
+    service.get_exclude_files = MagicMock(return_value=set(stale))
+    service.get_timestamp_files = MagicMock(return_value=set())
+
+    cache_service = MagicMock()
+    cache_service.check_for_upgrades.return_value = {"upgrades_resolved": 0}
+
+    results = MagicMock()
+    results.stale_exclude_entries = list(stale)
+
+    with patch("web.services.cache_service.get_cache_service", return_value=cache_service):
+        # The guarded block, exercised directly.
+        if results.stale_exclude_entries and service._load_settings().get(
+                'auto_transfer_upgrades', True):
+            cache_service.check_for_upgrades(results.stale_exclude_entries)
+
+    return cache_service.check_for_upgrades.called
+
+
+class TestAuditHonoursTheSetting:
+
+    def test_source_gates_the_audit_call(self):
+        """The real audit reads the setting before checking for upgrades."""
+        import inspect
+        from web.services.maintenance_service import MaintenanceService
+
+        source = inspect.getsource(MaintenanceService.run_full_audit)
+        assert "auto_transfer_upgrades" in source, (
+            "run_full_audit calls check_for_upgrades without consulting the "
+            "setting that claims to control it"
+        )
+
+    def test_enabled_checks_for_upgrades(self):
+        assert _audit_with(True) is True
+
+    def test_disabled_skips_the_check(self):
+        assert _audit_with(False) is False
+
+    def test_missing_key_defaults_to_enabled(self):
+        """Backward compatible: the setting has always defaulted to True."""
+        from web.services.maintenance_service import MaintenanceService
+
+        service = object.__new__(MaintenanceService)
+        service._load_settings = MagicMock(return_value={})
+
+        assert service._load_settings().get('auto_transfer_upgrades', True) is True
+
+
+class TestManualEndpointStaysOpen:
+
+    def test_endpoint_does_not_consult_the_setting(self):
+        """An explicit click is not 'automatic' transfer."""
+        import inspect
+        from web.routers import api
+
+        source = inspect.getsource(api.check_upgrades)
+        assert "auto_transfer_upgrades" not in source, (
+            "the manual endpoint should stay available regardless of the setting"
+        )

--- a/tests/test_eviction_priority_floor.py
+++ b/tests/test_eviction_priority_floor.py
@@ -117,10 +117,25 @@ class TestInputsRejectDeadValues:
         tag = re.search(r'<input[^>]*?name="eviction_min_priority"[^>]*?>', html, re.S)
 
         assert tag, "eviction_min_priority input not found"
-        assert 'min="{{ priority_range.watchlist_min }}"' in tag.group(0), (
+        assert "priority_range.watchlist_min" in tag.group(0), (
             "the input should take its floor from the same constant the hint shows, "
             f"not a literal (currently {PRIORITY_RANGE_WATCHLIST_MIN})"
         )
+
+    def test_web_input_floor_applies_only_to_smart_mode(self):
+        """The form is hx-put, so HTML5 validation blocks the whole tab.
+
+        A leftover low threshold with eviction off harms nothing, and refusing
+        to save every other cache setting until it is corrected would be a
+        worse outcome than the dead value it guards against.
+        """
+        html = (REPO / "web" / "templates" / "settings" / "cache.html").read_text(encoding="utf-8")
+        tag = re.search(r'<input[^>]*?name="eviction_min_priority"[^>]*?>', html, re.S)
+
+        assert "cache_eviction_mode == 'smart'" in tag.group(0), (
+            "the floor should be conditional on smart eviction being active"
+        )
+        assert "else 0" in tag.group(0), "no floor when eviction is not smart"
 
     def test_wizard_clamps_below_floor_values(self):
         """New setups have no stored behaviour to preserve, so clamping is safe."""

--- a/tests/test_eviction_priority_floor.py
+++ b/tests/test_eviction_priority_floor.py
@@ -1,0 +1,132 @@
+"""A priority threshold below the score floor keeps every file.
+
+``CachePriorityManager.calculate_priority()`` cannot return an arbitrary
+number: the base is 50 and the negative factors are bounded, so the lowest a
+real file reaches is around ``PRIORITY_RANGE_WATCHLIST_MIN``.
+``get_eviction_candidates()`` then keeps anything scoring ``>= threshold``, so
+a threshold at or below that floor keeps everything and eviction frees nothing
+while still reporting itself as enabled.
+
+Config load reports this rather than correcting it. Raising a stored threshold
+would start deleting cache copies on the next run, and a config load is not
+the place to make that decision for someone. The web input and the wizard stop
+new values from landing there.
+"""
+
+import logging
+import re
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests']:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+from core.file_operations import PRIORITY_RANGE_WATCHLIST_MIN  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+class TestFloorIsReal:
+
+    def test_no_file_scores_below_the_documented_floor(self):
+        """The constant the UI shows agrees with what the scorer can produce.
+
+        Base 50, watchlist source (+0), one user (+5), stale cache (+0) and the
+        worst watchlist age (-10) is the documented worst case.
+        """
+        assert 50 + 0 + 5 + 0 - 10 == PRIORITY_RANGE_WATCHLIST_MIN
+
+    def test_threshold_at_the_floor_selects_nothing(self, tmp_path):
+        """Sanity-check the comparison that makes low thresholds inert."""
+        from core.file_operations import CachePriorityManager
+
+        manager = object.__new__(CachePriorityManager)
+        manager.eviction_min_priority = 0
+        manager.active_pinned_paths = set()
+
+        # get_eviction_candidates keeps everything scoring >= the threshold.
+        scores = [PRIORITY_RANGE_WATCHLIST_MIN, 60, 100]
+        kept = [s for s in scores if s >= manager.eviction_min_priority]
+
+        assert kept == scores, "a threshold of 0 keeps every file"
+
+
+def _validate(caplog, *, priority, mode="smart", threshold=90):
+    """Run the real validation over a CacheConfig holding these values."""
+    from core.config import CacheConfig, ConfigManager
+
+    manager = object.__new__(ConfigManager)
+    manager.cache = CacheConfig()
+    manager.cache.cache_eviction_mode = mode
+    manager.cache.cache_eviction_threshold_percent = threshold
+    manager.cache.eviction_min_priority = priority
+
+    with caplog.at_level(logging.WARNING):
+        manager._validate_eviction_settings()
+    return manager.cache
+
+
+class TestConfigWarnsAboutADeadThreshold:
+
+    @pytest.mark.parametrize("priority", [0, 1, PRIORITY_RANGE_WATCHLIST_MIN - 1])
+    def test_warns_below_the_floor(self, priority, caplog):
+        cache = _validate(caplog, priority=priority)
+
+        assert "will never select anything" in caplog.text
+        assert cache.eviction_min_priority == priority, (
+            "the value must be left as configured — raising it would start "
+            "deleting cache copies the user never agreed to lose"
+        )
+        assert cache.cache_eviction_mode == "smart", "the mode must not be flipped either"
+
+    @pytest.mark.parametrize("priority", [PRIORITY_RANGE_WATCHLIST_MIN, 60, 100])
+    def test_silent_at_or_above_the_floor(self, priority, caplog):
+        _validate(caplog, priority=priority)
+
+        assert "will never select anything" not in caplog.text
+
+    def test_silent_when_eviction_is_off(self, caplog):
+        """A leftover threshold with eviction disabled is not a problem."""
+        _validate(caplog, priority=0, mode="none")
+
+        assert "will never select anything" not in caplog.text
+
+    def test_silent_for_fifo(self, caplog):
+        """FIFO does not read the priority score at all."""
+        _validate(caplog, priority=0, mode="fifo")
+
+        assert "will never select anything" not in caplog.text
+
+    def test_out_of_range_still_falls_back(self, caplog):
+        """The existing range check keeps working."""
+        cache = _validate(caplog, priority=150)
+
+        assert cache.eviction_min_priority == 60
+        assert "Invalid eviction_min_priority" in caplog.text
+
+
+class TestInputsRejectDeadValues:
+
+    def test_web_input_floor_is_the_score_floor(self):
+        html = (REPO / "web" / "templates" / "settings" / "cache.html").read_text(encoding="utf-8")
+        tag = re.search(r'<input[^>]*?name="eviction_min_priority"[^>]*?>', html, re.S)
+
+        assert tag, "eviction_min_priority input not found"
+        assert 'min="{{ priority_range.watchlist_min }}"' in tag.group(0), (
+            "the input should take its floor from the same constant the hint shows, "
+            f"not a literal (currently {PRIORITY_RANGE_WATCHLIST_MIN})"
+        )
+
+    def test_wizard_clamps_below_floor_values(self):
+        """New setups have no stored behaviour to preserve, so clamping is safe."""
+        source = (REPO / "core" / "setup.py").read_text(encoding="utf-8")
+
+        assert "PRIORITY_RANGE_WATCHLIST_MIN" in source
+        assert "Min priority to evict (0-100)" not in source, (
+            "the wizard should no longer advertise a range starting at 0"
+        )

--- a/tests/test_log_rotation_cleanup.py
+++ b/tests/test_log_rotation_cleanup.py
@@ -85,3 +85,21 @@ class TestRotationBackupCleanup:
 
         remaining = sorted(p.name for p in logs.glob("plexcache_log_*.log"))
         assert len(remaining) == 3, remaining
+
+
+class TestLatestPointerIsNotCounted:
+
+    def test_symlink_does_not_consume_a_retention_slot(self, tmp_path):
+        """"Keep 3" should keep 3 runs, not 2 runs plus the pointer."""
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        for i in range(3):
+            _make(logs, f"plexcache_log_2026010{i}_000000.log", 1_000 + i)
+        _make(logs, "plexcache_log_latest.log", 9_999)
+
+        _manager(logs, max_log_files=3)._clean_old_log_files()
+
+        runs = sorted(p.name for p in logs.glob("plexcache_log_*.log")
+                      if p.name != "plexcache_log_latest.log")
+        assert len(runs) == 3, runs
+        assert (logs / "plexcache_log_latest.log").exists()

--- a/tests/test_log_rotation_cleanup.py
+++ b/tests/test_log_rotation_cleanup.py
@@ -1,0 +1,87 @@
+"""Rotation backups are cleaned up with the log file they belong to.
+
+Each run writes its own timestamped log, so RotatingFileHandler only rolls over
+when a single run exceeds maxBytes (20 MB). The backup it leaves is named
+``plexcache_log_<stamp>.log.1``, which the ``plexcache_log_*.log`` cleanup glob
+cannot match, so nothing removed them.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+if 'fcntl' not in sys.modules:
+    sys.modules['fcntl'] = MagicMock()
+
+
+def _manager(logs_folder, max_log_files=3):
+    from core.logging_config import LoggingManager
+
+    manager = object.__new__(LoggingManager)
+    manager.logs_folder = logs_folder
+    manager.max_log_files = max_log_files
+    manager.log_file_pattern = "plexcache_log_*.log"
+    return manager
+
+
+def _make(folder, name, mtime):
+    import os
+    path = folder / name
+    path.write_text("x", encoding="utf-8")
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+class TestRotationBackupCleanup:
+
+    def test_backup_goes_when_its_log_is_cleaned(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        # Oldest run overflowed 20MB and left two backups.
+        old = _make(logs, "plexcache_log_20260101_000000.log", 1_000)
+        old_b1 = _make(logs, "plexcache_log_20260101_000000.log.1", 1_000)
+        old_b2 = _make(logs, "plexcache_log_20260101_000000.log.2", 1_000)
+        for i, stamp in enumerate(["20260102", "20260103", "20260104"], start=1):
+            _make(logs, f"plexcache_log_{stamp}_000000.log", 2_000 + i)
+
+        _manager(logs, max_log_files=3)._clean_old_log_files()
+
+        assert not old.exists(), "oldest log should be cleaned"
+        assert not old_b1.exists(), "its rotation backup should go with it"
+        assert not old_b2.exists()
+
+    def test_backup_stays_while_its_log_stays(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        current = _make(logs, "plexcache_log_20260104_000000.log", 5_000)
+        backup = _make(logs, "plexcache_log_20260104_000000.log.1", 5_000)
+
+        _manager(logs, max_log_files=3)._clean_old_log_files()
+
+        assert current.exists()
+        assert backup.exists(), "a live run's overflow must be kept"
+
+    def test_leaves_unrelated_files_alone(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        _make(logs, "plexcache_log_20260104_000000.log", 5_000)
+        # Not a numeric rollover suffix.
+        notes = _make(logs, "plexcache_log_20260101_000000.log.bak", 1_000)
+        latest = _make(logs, "plexcache_log_latest.log", 5_001)
+
+        _manager(logs, max_log_files=3)._clean_old_log_files()
+
+        assert notes.exists(), ".bak is not a rollover suffix"
+        assert latest.exists()
+
+    def test_count_limit_still_applies(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        for i in range(6):
+            _make(logs, f"plexcache_log_2026010{i}_000000.log", 1_000 + i)
+
+        _manager(logs, max_log_files=3)._clean_old_log_files()
+
+        remaining = sorted(p.name for p in logs.glob("plexcache_log_*.log"))
+        assert len(remaining) == 3, remaining

--- a/tests/test_per_user_retention_parsing.py
+++ b/tests/test_per_user_retention_parsing.py
@@ -1,0 +1,80 @@
+"""Per-user retention overrides accept the values their inputs offer.
+
+The global Watchlist Retention is a float rendered with ``step="0.5"``, and
+``core/config.py`` casts the per-user value with ``float()``. The save handler
+parsed it with ``int()``, so every half-day the form invites raised ValueError
+and the override was dropped, silently falling back to the global default.
+
+Days to Monitor really is a whole number (``core/config.py`` casts it with
+``int()``), so it stays an int here.
+"""
+
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests', 'apscheduler',
+                  'apscheduler.schedulers', 'apscheduler.schedulers.background',
+                  'apscheduler.triggers', 'apscheduler.triggers.cron',
+                  'apscheduler.triggers.interval']:
+    sys.modules.setdefault(_mod_name, MagicMock())
+
+
+def _save(form: dict, caplog):
+    """Run save_user_settings over one user and return that user's dict.
+
+    The handler mutates the dicts it gets from get_user_settings() in place and
+    hands the same list to save_user_settings(), so inspecting the dict we
+    supplied shows exactly what would be persisted.
+    """
+    from starlette.datastructures import ImmutableMultiDict
+    from web.routers import settings as settings_router
+
+    user = {"title": "alice", "token": "t"}
+
+    settings_service = MagicMock()
+    settings_service.get_user_settings.return_value = {"users": [user]}
+    settings_service.save_user_settings.return_value = True
+
+    with patch.object(settings_router, "get_settings_service", return_value=settings_service), \
+         patch.object(settings_router, "templates", MagicMock()), \
+         caplog.at_level(logging.WARNING):
+        settings_router.save_user_settings(MagicMock(), ImmutableMultiDict(form))
+
+    assert settings_service.save_user_settings.called, "handler did not reach the save"
+    return user, caplog.text
+
+
+class TestPerUserRetentionParsing:
+
+    def test_half_day_watchlist_retention_survives(self, caplog):
+        """step="0.5" is offered by the form, so it has to be accepted."""
+        user, _ = _save({"watchlist_days_alice": "0.5"}, caplog)
+
+        assert user.get("watchlist_retention_days") == 0.5, (
+            "a half-day override was dropped, silently reverting this user "
+            "to the global default"
+        )
+
+    def test_whole_day_watchlist_retention_still_works(self, caplog):
+        user, _ = _save({"watchlist_days_alice": "14"}, caplog)
+
+        assert user.get("watchlist_retention_days") == 14
+
+    def test_days_to_monitor_stays_a_whole_number(self, caplog):
+        user, _ = _save({"ondeck_days_alice": "30"}, caplog)
+
+        assert user.get("days_to_monitor") == 30
+        assert isinstance(user.get("days_to_monitor"), int)
+
+    def test_unparseable_value_is_reported(self, caplog):
+        """Falling back to the global default must not be silent."""
+        user, log_text = _save({"watchlist_days_alice": "soon"}, caplog)
+
+        assert "watchlist_retention_days" not in user
+        assert "Watchlist Retention" in log_text
+        assert "alice" in log_text

--- a/tests/test_pin_budget_quota.py
+++ b/tests/test_pin_budget_quota.py
@@ -1,0 +1,140 @@
+"""The pin budget measures pinned bytes against a comparable ceiling.
+
+``parse_budget_from_settings()`` has always computed ``plexcache_quota_bytes``,
+but ``compute_budget_state()`` was only given ``cache_limit`` and
+``min_free_space``. Two consequences:
+
+* An install configured with only ``plexcache_quota`` got no pin guard at all.
+  ``effective_budget`` was 0, and both flags are hardcoded False when it is 0.
+* Where ``cache_limit`` was set, pinned bytes (a count of PlexCache-managed
+  files) were compared against a whole-drive ceiling whose denominator includes
+  everything else on the drive.
+
+``plexcache_quota`` bounds the same population that ``current_pinned_bytes``
+counts, so it is the comparable ceiling. The whole-drive limit stays as a
+fallback and as a co-constraint.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests']:
+    sys.modules.setdefault(_mod_name, MagicMock())
+
+from core.pinned_media import compute_budget_state  # noqa: E402
+
+GB = 1024 ** 3
+
+
+class TestQuotaAsPinCeiling:
+
+    def test_quota_alone_now_guards(self):
+        """The regression: this configuration previously had no guard."""
+        state = compute_budget_state(
+            cache_limit_bytes=0,
+            min_free_space_bytes=0,
+            plexcache_quota_bytes=100 * GB,
+            current_pinned_bytes=120 * GB,
+        )
+
+        assert state["effective_budget_bytes"] == 100 * GB
+        assert state["over_budget"] is True
+
+    def test_quota_alone_blocks_a_pin_that_would_exceed(self):
+        state = compute_budget_state(
+            cache_limit_bytes=0,
+            min_free_space_bytes=0,
+            plexcache_quota_bytes=100 * GB,
+            current_pinned_bytes=95 * GB,
+            additional_bytes=10 * GB,
+        )
+
+        assert state["would_exceed"] is True
+
+    def test_quota_alone_allows_a_pin_that_fits(self):
+        state = compute_budget_state(
+            cache_limit_bytes=0,
+            min_free_space_bytes=0,
+            plexcache_quota_bytes=100 * GB,
+            current_pinned_bytes=50 * GB,
+            additional_bytes=10 * GB,
+        )
+
+        assert state["would_exceed"] is False
+        assert state["over_budget"] is False
+
+    def test_tighter_ceiling_wins_when_both_are_set(self):
+        # quota 40GB vs drive ceiling 100-10=90GB
+        state = compute_budget_state(
+            cache_limit_bytes=100 * GB,
+            min_free_space_bytes=10 * GB,
+            plexcache_quota_bytes=40 * GB,
+            current_pinned_bytes=50 * GB,
+        )
+
+        assert state["effective_budget_bytes"] == 40 * GB
+        assert state["over_budget"] is True
+
+    def test_drive_ceiling_wins_when_it_is_tighter(self):
+        state = compute_budget_state(
+            cache_limit_bytes=50 * GB,
+            min_free_space_bytes=10 * GB,
+            plexcache_quota_bytes=200 * GB,
+            current_pinned_bytes=45 * GB,
+        )
+
+        assert state["effective_budget_bytes"] == 40 * GB
+        assert state["over_budget"] is True
+
+
+class TestUnchangedBehaviour:
+
+    def test_cache_limit_only_is_untouched(self):
+        """Installs without a quota keep exactly the guard they had."""
+        state = compute_budget_state(
+            cache_limit_bytes=10 * GB,
+            min_free_space_bytes=2 * GB,
+            current_pinned_bytes=5 * GB,
+        )
+
+        assert state["effective_budget_bytes"] == 8 * GB
+        assert state["over_budget"] is False
+
+    def test_nothing_configured_never_blocks(self):
+        """The guard must not hard-block without an explicit limit."""
+        state = compute_budget_state(
+            cache_limit_bytes=0,
+            min_free_space_bytes=0,
+            plexcache_quota_bytes=0,
+            current_pinned_bytes=900 * GB,
+            additional_bytes=900 * GB,
+        )
+
+        assert state["effective_budget_bytes"] == 0
+        assert state["over_budget"] is False
+        assert state["would_exceed"] is False
+
+
+class TestDriveSizeOverride:
+
+    def test_percent_budget_uses_the_configured_drive_total(self):
+        """ZFS reports the dataset, not the pool, hence the override."""
+        from core.pinned_media import get_active_cache_total_bytes
+
+        settings = {
+            "cache_drive_size": "4TB",
+            "path_mappings": [{"enabled": True, "cache_path": "/mnt/cache/media"}],
+        }
+        probed = MagicMock(total=500 * GB)
+
+        with patch("core.system_utils.get_disk_usage", return_value=probed) as probe:
+            total = get_active_cache_total_bytes(settings)
+
+        assert probe.call_args.args[1] == 4 * 1024 * GB, (
+            "the override should be handed to get_disk_usage, as the engine does"
+        )
+        assert total > 0

--- a/tests/test_scorer_parity.py
+++ b/tests/test_scorer_parity.py
@@ -1,0 +1,143 @@
+"""The Priority Report and the eviction engine must produce the same score.
+
+Two implementations exist because they read from different places:
+``CachePriorityManager`` from its tracker objects, ``CacheService`` from the
+raw JSON the web layer already has loaded. That is a reasonable split, but the
+*number* has to match — ``eviction_min_priority`` is calibrated against what
+the report shows, and acted on by what the engine computes.
+
+The episode-position factor is the one that had drifted: the web scorer
+computed a prefetch window and never compared against it, so every episode with
+a number scored +10 where the engine gave it only within half the window.
+``core.media_grouping.episodes_ahead_of()`` is now shared by both.
+"""
+
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests']:
+    sys.modules.setdefault(_mod_name, MagicMock())
+
+from core.media_grouping import episodes_ahead_of  # noqa: E402
+
+def _cache_path(season, episode):
+    return f"/mnt/cache/tv/Show/Show - S{season:02d}E{episode:02d}.mkv"
+
+
+def _plex_path(season, episode):
+    return f"/data/tv/Show/Show - S{season:02d}E{episode:02d}.mkv"
+
+
+def _engine_score(*, source, users, episode_info, ondeck_positions, number_episodes=6):
+    from core.file_operations import CachePriorityManager
+
+    mgr = object.__new__(CachePriorityManager)
+    mgr.active_pinned_paths = set()
+    mgr.active_ondeck_paths = None
+    mgr.number_episodes = number_episodes
+
+    mgr.timestamp_tracker = MagicMock()
+    mgr.timestamp_tracker.get_source.return_value = source
+    mgr.timestamp_tracker.get_episode_info.return_value = episode_info
+
+    mgr.ondeck_tracker = MagicMock()
+    mgr.ondeck_tracker.get_entry.return_value = (
+        {"users": users, "first_seen": None} if source == "ondeck" else None)
+    mgr.ondeck_tracker.get_episode_info.return_value = episode_info
+    mgr.ondeck_tracker.get_earliest_ondeck_position.return_value = (
+        min(ondeck_positions) if ondeck_positions else None)
+
+    mgr.watchlist_tracker = MagicMock()
+    mgr.watchlist_tracker.get_entry.return_value = None
+
+    mgr._get_hours_since_cached = MagicMock(return_value=500)  # old, no bonus
+    target = _cache_path((episode_info or {}).get("season", 1),
+                         (episode_info or {}).get("episode", 1))
+    return mgr.calculate_priority(target)
+
+
+def _web_score(*, source, users, episode_info, ondeck_positions, number_episodes=6):
+    from web.services.cache_service import CacheService
+
+    svc = object.__new__(CacheService)
+
+    tgt_season = (episode_info or {}).get("season", 1)
+    tgt_episode = (episode_info or {}).get("episode", 1)
+    target = _cache_path(tgt_season, tgt_episode)
+
+    timestamps = {target: {"source": source,
+                           "cached_at": (datetime.now() - timedelta(days=30)).isoformat()}}
+
+    ondeck = {}
+    # Whoever is furthest behind sets the reference point. Written first so the
+    # target's own entry wins if it happens to be that same episode.
+    for season, ep in ondeck_positions:
+        ondeck[_plex_path(season, ep)] = {
+            "users": ["u"],
+            "episode_info": {"show": "Show", "season": season, "episode": ep,
+                             "is_current_ondeck": True},
+        }
+    if source == "ondeck":
+        ondeck[_plex_path(tgt_season, tgt_episode)] = {
+            "users": users, "episode_info": episode_info}
+
+    return svc.calculate_priority(
+        target, timestamps, ondeck, {}, {"number_episodes": number_episodes})
+
+
+CASES = [
+    pytest.param(0, id="current-ondeck-episode"),
+    pytest.param(2, id="two-ahead-inside-window"),
+    pytest.param(3, id="at-the-window-edge"),
+    pytest.param(6, id="far-ahead-outside-window"),
+    pytest.param(20, id="very-far-ahead"),
+]
+
+
+@pytest.mark.parametrize("ahead", CASES)
+def test_episode_position_scores_agree(ahead):
+    """The factor that had drifted, across the whole window."""
+    target_ep = 5 + ahead
+    episode_info = {"show": "Show", "season": 1, "episode": target_ep,
+                    "is_current_ondeck": ahead == 0}
+    positions = [(1, 5)]
+
+    engine = _engine_score(source="ondeck", users=["u"],
+                           episode_info=episode_info, ondeck_positions=positions)
+    web = _web_score(source="ondeck", users=["u"],
+                     episode_info=episode_info, ondeck_positions=positions)
+
+    assert engine == web, (
+        f"{ahead} episodes ahead: engine scores {engine}, report shows {web}"
+    )
+
+
+def test_far_ahead_episode_gets_no_bonus_in_either():
+    """The concrete regression: the report used to read 10 points high."""
+    episode_info = {"show": "Show", "season": 1, "episode": 25,
+                    "is_current_ondeck": False}
+    positions = [(1, 5)]
+
+    web = _web_score(source="ondeck", users=["u"],
+                     episode_info=episode_info, ondeck_positions=positions)
+    engine = _engine_score(source="ondeck", users=["u"],
+                           episode_info=episode_info, ondeck_positions=positions)
+
+    assert episodes_ahead_of(1, 25, 1, 5) == 20, "sanity: well outside the window"
+    assert web == engine
+    # base 50 + ondeck 15 + one user 5, and no episode bonus
+    assert web == 70
+
+
+def test_watchlist_item_scores_agree():
+    engine = _engine_score(source="watchlist", users=[],
+                           episode_info=None, ondeck_positions=[])
+    web = _web_score(source="watchlist", users=[],
+                     episode_info=None, ondeck_positions=[])
+
+    assert engine == web

--- a/tests/test_settings_copy_accuracy.py
+++ b/tests/test_settings_copy_accuracy.py
@@ -1,0 +1,143 @@
+"""Settings copy states the mechanism, not a plausible-sounding summary.
+
+Each check below corresponds to a place where the wording described something
+the code does not do:
+
+* OnDeck retention said "auto-expire", which reads as deletion. It stops
+  holding the item; a later run moves it back to the array.
+* Hard-linked files were described by their inode topology. Detection is
+  automatic, so the only choice is what to do with them.
+* Nothing said that retention clocks advance only while PlexCache runs, which
+  bounds how fine any of these values can usefully be.
+* A per-user Days to Monitor override also sets that user's OnDeck retention
+  threshold. One field, two clocks, two epochs, and no surface said so.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+CACHE_HTML = REPO / "web" / "templates" / "settings" / "cache.html"
+USERS_TABLE = REPO / "web" / "templates" / "settings" / "partials" / "users_table.html"
+SEARCH_INDEX = REPO / "web" / "settings_search_index.py"
+
+
+def _hint_for(setting_id: str) -> str:
+    """The form-hint text belonging to one setting's form-group."""
+    html = CACHE_HTML.read_text(encoding="utf-8")
+    start = html.index(f'data-setting-id="{setting_id}"')
+    # Up to the next form-group, so a neighbour's hint cannot satisfy the test.
+    nxt = html.find("data-setting-id=", start + 1)
+    block = html[start:nxt if nxt != -1 else len(html)]
+    hints = re.findall(r'<div class="form-hint">(.*?)</div>', block, re.S)
+    return " ".join(" ".join(h.split()) for h in hints)
+
+
+class TestOnDeckRetentionNamesItsMechanism:
+
+    def test_says_it_does_not_delete(self):
+        hint = _hint_for("ondeck_retention_days")
+        assert "not deleted" in hint, hint
+
+    def test_names_the_epoch(self):
+        hint = _hint_for("ondeck_retention_days")
+        assert "PlexCache first saw it" in hint, hint
+
+    def test_states_the_across_all_users_rule(self):
+        """AND across users, not OR: the last user to finish decides."""
+        hint = _hint_for("ondeck_retention_days")
+        assert "every" in hint.lower(), hint
+
+    def test_no_longer_claims_auto_expire(self):
+        assert "Auto-expire OnDeck" not in CACHE_HTML.read_text(encoding="utf-8")
+
+
+class TestWatchlistRetentionNamesItsEpoch:
+
+    def test_counts_from_the_plex_date(self):
+        hint = _hint_for("watchlist_retention_days")
+        assert "added in Plex" in hint, hint
+        assert "not from when" in hint, hint
+
+
+class TestHardlinkedFilesDescribesTheOutcome:
+
+    def test_hint_is_about_the_choice_not_the_inode(self):
+        hint = _hint_for("hardlinked_files")
+        assert "torrent client" in hint, hint
+        assert "automatically" in hint, hint
+        assert "hardlinks" not in hint.lower(), f"still explaining inodes: {hint}"
+
+    def test_move_option_no_longer_claims_to_break_links(self):
+        """'move' caches the file; the seed survives via the remaining link."""
+        html = CACHE_HTML.read_text(encoding="utf-8")
+        assert "break hardlinks" not in html, (
+            "the 'move' option said it breaks hardlinks, which is the opposite "
+            "of what _move_to_cache does for those files"
+        )
+
+
+class TestRetentionClocksAreQualified:
+
+    def test_section_says_clocks_need_runs(self):
+        html = CACHE_HTML.read_text(encoding="utf-8")
+        retention = html[html.index(">\n                Retention"):]
+        assert "only advance while PlexCache is running" in " ".join(retention.split())
+
+
+class TestPerUserCouplingIsDocumented:
+
+    def test_global_hint_mentions_the_per_user_coupling(self):
+        hint = _hint_for("days_to_monitor")
+        assert "retention" in hint.lower(), hint
+
+    def test_per_user_tooltip_mentions_both_clocks(self):
+        html = USERS_TABLE.read_text(encoding="utf-8")
+        tag = re.search(r'<input[^>]*?name="ondeck_days_[^>]*?>', html, re.S).group(0)
+        assert "retention threshold" in tag, tag
+
+    def test_per_user_watchlist_input_accepts_half_days(self):
+        """The handler parses float; the input has to offer it."""
+        html = USERS_TABLE.read_text(encoding="utf-8")
+        tag = re.search(r'<input[^>]*?name="watchlist_days_[^>]*?>', html, re.S).group(0)
+        assert 'step="0.5"' in tag, (
+            f"input rejects the half-days the backend accepts: {tag}"
+        )
+
+
+class TestSearchIndexMatchesTheTemplates:
+
+    @pytest.mark.parametrize("setting_id,phrase", [
+        ("ondeck_retention_days", "does not delete"),
+        ("hardlinked_files", "torrent client"),
+        ("days_to_monitor", "retention threshold"),
+    ])
+    def test_index_hint_reflects_the_new_copy(self, setting_id, phrase):
+        source = SEARCH_INDEX.read_text(encoding="utf-8")
+        start = source.index(f'"setting_id": "{setting_id}"')
+        entry = source[start:source.index("}", start)]
+        assert phrase in entry, f"{setting_id} index hint is stale: {entry}"
+
+
+class TestBackupsAreNoLongerAFirstRunQuestion:
+
+    def test_wizard_does_not_prompt(self):
+        """40 lines of interrogation for a setting almost nobody should change."""
+        source = (REPO / "core" / "setup.py").read_text(encoding="utf-8")
+        assert "Create .plexcached backups?" not in source
+
+    def test_wizard_still_defaults_it_on(self):
+        source = (REPO / "core" / "setup.py").read_text(encoding="utf-8")
+        assert "settings_data['create_plexcached_backups'] = True" in source
+
+    def test_web_toggle_now_carries_the_consequence(self):
+        """Removing the prompt leaves this as the only surface that warns."""
+        hint = _hint_for("create_plexcached_backups")
+        assert "cannot be" in hint and "recovered" in hint, hint
+        assert "deleted, not renamed" in hint, hint
+
+    def test_web_toggle_does_not_repeat_the_obsolete_hardlink_advice(self):
+        hint = _hint_for("create_plexcached_backups")
+        assert "do not need it off" in hint, hint

--- a/tests/test_settings_default_parity.py
+++ b/tests/test_settings_default_parity.py
@@ -1,0 +1,98 @@
+"""Web-layer defaults must agree with the engine's.
+
+``core.config.CacheConfig`` is what actually runs. When the web layer repeats a
+default as a literal, the two can drift, and the drift is invisible: the UI
+shows one number, the run uses another. Two concrete cases this guards:
+
+* ``cache_limit`` defaulted to ``"250GB"`` in the web getter against core's
+  ``""``. Saving any unrelated field on the Cache tab wrote that cap to disk,
+  and since ``cache_limit`` gates both eviction entry points
+  (``core/app.py`` ``_filter_low_priority_files`` and ``_run_smart_eviction``),
+  it also armed eviction for someone who never asked for it.
+* ``cache_eviction_threshold_percent`` defaulted to 95 across seven web sites
+  against core's 90, so the cache page drew the eviction line in the wrong
+  place.
+
+Settings deliberately absent here are ones the web layer has no business
+defaulting at all.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests']:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+from core.config import CacheConfig  # noqa: E402
+
+SHARED = [
+    "cache_limit",
+    "cache_eviction_mode",
+    "cache_eviction_threshold_percent",
+    "eviction_min_priority",
+    "cache_retention_hours",
+    "watchlist_retention_days",
+    "ondeck_retention_days",
+]
+
+
+@pytest.mark.parametrize("setting", SHARED)
+def test_web_getter_matches_core(setting, tmp_path, monkeypatch):
+    """get_cache_settings() on an empty settings file returns core's default."""
+    from web.services.settings_service import SettingsService
+
+    service = object.__new__(SettingsService)
+    monkeypatch.setattr(SettingsService, "_load_raw", lambda self: {})
+
+    values = SettingsService.get_cache_settings(service)
+    if setting not in values:
+        pytest.skip(f"{setting} is not surfaced by get_cache_settings()")
+
+    assert values[setting] == getattr(CacheConfig, setting), (
+        f"web default for {setting} is {values[setting]!r}, "
+        f"core default is {getattr(CacheConfig, setting)!r}"
+    )
+
+
+@pytest.mark.parametrize("setting", SHARED)
+def test_pydantic_model_matches_core(setting):
+    """The declared model agrees too, so reading it does not mislead."""
+    from web.models.settings import CacheSettingsModel
+
+    fields = CacheSettingsModel.model_fields
+    if setting not in fields:
+        pytest.skip(f"{setting} is not on CacheSettingsModel")
+
+    assert fields[setting].default == getattr(CacheConfig, setting), (
+        f"CacheSettingsModel.{setting} defaults to {fields[setting].default!r}, "
+        f"core defaults to {getattr(CacheConfig, setting)!r}"
+    )
+
+
+def test_no_hardcoded_cache_limit_literal():
+    """The 250GB fallback is gone from every web source."""
+    import pathlib
+    import re
+    web = pathlib.Path(__file__).resolve().parent.parent / "web"
+
+    # Only a *default* counts: an assignment, a .get() fallback keyed by name,
+    # or a Jinja default(). "250GB" as an example inside a placeholder or a
+    # validation message is legitimate and must not trip this.
+    as_default = re.compile(
+        r"""=\s*["']250GB["']"""                             # x = "250GB"
+        r"""|\.get\(\s*["'][^"']+["']\s*,\s*["']250GB["']"""  # .get("k", "250GB")
+        r"""|default\(\s*["']250GB["']\s*\)"""                # | default('250GB')
+    )
+
+    offenders = [
+        f"{p.relative_to(web)}:{i}"
+        for p in list(web.rglob("*.py")) + list(web.rglob("*.html"))
+        for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), 1)
+        if as_default.search(line)
+    ]
+
+    assert not offenders, f"hardcoded 250GB default still present: {offenders}"

--- a/tests/test_silent_misconfiguration_warnings.py
+++ b/tests/test_silent_misconfiguration_warnings.py
@@ -1,0 +1,136 @@
+"""Configurations that quietly do nothing should say so.
+
+Two cases where a fully configured feature was inert and the log looked
+identical to a healthy run:
+
+* Both eviction entry points size themselves against ``cache_limit``. With no
+  limit set they returned immediately, so "smart" eviction plus a
+  ``plexcache_quota`` evicted nothing, forever, silently.
+* Caching renames the original to ``.plexcached``. Off Unraid, without a
+  merged view of the two paths, Plex stops finding the file unless
+  ``use_symlinks`` is on, and that setting defaults to False.
+"""
+
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests']:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+GB = 1024 ** 3
+
+
+def _app(eviction_mode="smart", cache_limit_bytes=0):
+    from core.app import PlexCacheApp
+
+    app = object.__new__(PlexCacheApp)
+    app.config_manager = MagicMock()
+    app.config_manager.cache.cache_eviction_mode = eviction_mode
+    app.config_manager.cache.cache_eviction_threshold_percent = 90
+    app.config_manager.cache.eviction_min_priority = 60
+    app.config_manager.cache.cache_drive_size_bytes = 0
+    app.config_manager.paths.cache_dir = "/mnt/cache/media"
+    app.config_manager.paths.path_mappings = []
+    app._warned_eviction_needs_limit = False
+    app._get_effective_cache_limit = MagicMock(return_value=(cache_limit_bytes, ""))
+    return app
+
+
+class TestEvictionWithoutCacheLimit:
+
+    def test_filter_path_warns(self, caplog):
+        app = _app()
+        with caplog.at_level(logging.WARNING):
+            result = app._filter_low_priority_files(["/mnt/cache/a.mkv"], {})
+
+        assert result == ["/mnt/cache/a.mkv"], "files still pass through"
+        assert "no Cache Limit is configured" in caplog.text
+        assert "smart" in caplog.text
+
+    def test_eviction_path_warns(self, caplog):
+        app = _app()
+        with caplog.at_level(logging.WARNING):
+            evicted, freed = app._run_smart_eviction()
+
+        assert (evicted, freed) == (0, 0)
+        assert "no Cache Limit is configured" in caplog.text
+
+    def test_warns_once_per_run(self, caplog):
+        """Both entry points run every cycle; one warning is enough."""
+        app = _app()
+        with caplog.at_level(logging.WARNING):
+            app._filter_low_priority_files([], {})
+            app._run_smart_eviction()
+            app._filter_low_priority_files([], {})
+
+        assert caplog.text.count("no Cache Limit is configured") == 1
+
+    def test_silent_when_eviction_is_off(self, caplog):
+        """Not a misconfiguration, so nothing to say."""
+        app = _app(eviction_mode="none")
+        with caplog.at_level(logging.WARNING):
+            app._filter_low_priority_files([], {})
+            app._run_smart_eviction()
+
+        assert "Cache Limit" not in caplog.text
+
+    def test_silent_when_a_limit_is_set(self, caplog):
+        app = _app(cache_limit_bytes=500 * GB)
+        with caplog.at_level(logging.WARNING), \
+             patch("core.app.get_disk_usage", side_effect=OSError("no disk")):
+            app._filter_low_priority_files([], {})
+
+        assert "no Cache Limit is configured" not in caplog.text
+
+
+def _symlink_app(is_unraid, use_symlinks, with_mapping=True):
+    from core.app import PlexCacheApp
+
+    app = object.__new__(PlexCacheApp)
+    app.system_detector = MagicMock()
+    app.system_detector.is_unraid = is_unraid
+    app.config_manager = MagicMock()
+    app.config_manager.cache.use_symlinks = use_symlinks
+
+    if with_mapping:
+        mapping = MagicMock(enabled=True, cacheable=True, cache_path="/mnt/cache/media")
+        app.config_manager.paths.path_mappings = [mapping]
+    else:
+        app.config_manager.paths.path_mappings = []
+        app.config_manager.paths.cache_dir = ""
+    return app
+
+
+class TestSymlinkAdvisory:
+
+    def test_warns_off_unraid_with_symlinks_off(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _symlink_app(is_unraid=False, use_symlinks=False)._advise_on_symlinks()
+
+        assert "Create symlinks" in caplog.text
+
+    def test_silent_on_unraid(self, caplog):
+        """The FUSE union keeps the original path resolving."""
+        with caplog.at_level(logging.WARNING):
+            _symlink_app(is_unraid=True, use_symlinks=False)._advise_on_symlinks()
+
+        assert caplog.text == ""
+
+    def test_silent_when_symlinks_are_on(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _symlink_app(is_unraid=False, use_symlinks=True)._advise_on_symlinks()
+
+        assert caplog.text == ""
+
+    def test_silent_with_nothing_cacheable(self, caplog):
+        """No cacheable path means nothing gets renamed."""
+        with caplog.at_level(logging.WARNING):
+            _symlink_app(is_unraid=False, use_symlinks=False,
+                         with_mapping=False)._advise_on_symlinks()
+
+        assert caplog.text == ""

--- a/tests/test_size_parsing_and_expiry.py
+++ b/tests/test_size_parsing_and_expiry.py
@@ -1,0 +1,149 @@
+"""Size settings accept what the app advertises, and expiry is reported.
+
+``_parse_cache_limit`` rejected two formats the rest of the app accepts, and
+because 0 means "no limit" to every consumer, a rejected value silently removed
+the cap the user believed they had set:
+
+* ``7.5%`` — the percent branch used ``int()``
+* ``3.7T`` — there was no short-suffix branch, unlike ``parse_size_bytes()``
+
+The same function parses cache_limit, min_free_space and plexcache_quota, so
+its warnings named cache_limit no matter which one was mistyped.
+"""
+
+import logging
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault('fcntl', MagicMock())
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests']:
+    sys.modules.setdefault(_mod_name, MagicMock())
+
+GB = 1024 ** 3
+TB = 1024 ** 4
+
+
+def _parse(value, key="cache_limit"):
+    from core.config import ConfigManager
+    return ConfigManager._parse_cache_limit(object.__new__(ConfigManager), value, key)
+
+
+class TestFormatsTheAppAdvertises:
+
+    @pytest.mark.parametrize("value,expected", [
+        ("3.7T", int(3.7 * TB)),
+        ("1.5G", int(1.5 * GB)),
+        ("500M", 500 * 1024 ** 2),
+        ("250GB", 250 * GB),
+        ("500MB", 500 * 1024 ** 2),
+        ("2", 2 * GB),
+    ])
+    def test_byte_quantities(self, value, expected):
+        assert _parse(value) == expected
+
+    @pytest.mark.parametrize("value,expected", [
+        ("7.5%", -7.5),
+        ("50%", -50.0),
+        ("1%", -1.0),
+        ("100%", -100.0),
+    ])
+    def test_percentages_may_be_fractional(self, value, expected):
+        assert _parse(value) == expected
+
+    def test_fractional_percent_resolves_against_the_drive(self):
+        """The negative sentinel has to survive _get_effective_limit()."""
+        from core.app import PlexCacheApp
+
+        app = object.__new__(PlexCacheApp)
+        app.config_manager = MagicMock()
+        app.config_manager.cache.cache_drive_size_bytes = 0
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("core.app.get_disk_usage",
+                       lambda *a, **k: MagicMock(total=1000 * GB))
+            resolved, readable = app._get_effective_limit(_parse("7.5%"), "/mnt/cache", "cache_limit")
+
+        assert resolved == 75 * GB
+        assert "7.5%" in readable
+
+
+class TestRejectionIsLoudAndNamed:
+
+    @pytest.mark.parametrize("value", ["nonsense", "12PB", "GB"])
+    def test_unparseable_is_zero_and_warns(self, value, caplog):
+        with caplog.at_level(logging.WARNING):
+            assert _parse(value) == 0
+        assert "Using no limit" in caplog.text
+
+    @pytest.mark.parametrize("value", ["0%", "101%", "-5%"])
+    def test_out_of_range_percent_is_rejected(self, value, caplog):
+        with caplog.at_level(logging.WARNING):
+            assert _parse(value) == 0
+
+    @pytest.mark.parametrize("key", ["cache_limit", "min_free_space", "plexcache_quota"])
+    def test_warning_names_the_setting_that_was_mistyped(self, key, caplog):
+        with caplog.at_level(logging.WARNING):
+            _parse("wrong", key)
+        assert key in caplog.text
+
+    def test_parse_size_bytes_no_longer_fails_silently(self, caplog):
+        from core.system_utils import parse_size_bytes
+
+        with caplog.at_level(logging.WARNING):
+            assert parse_size_bytes("lots") == 0
+        assert "Could not read" in caplog.text
+
+    @pytest.mark.parametrize("value", ["", "0", None])
+    def test_empty_and_zero_stay_quiet(self, value, caplog):
+        """Disabled is not a mistake, so it must not warn."""
+        from core.system_utils import parse_size_bytes
+
+        with caplog.at_level(logging.WARNING):
+            assert parse_size_bytes(value) == 0
+        assert caplog.text == ""
+
+
+class TestWatchlistExpiryVisibility:
+
+    def test_expiry_summary_logs_at_info(self):
+        """DEBUG hid it; the OnDeck twin has always logged at INFO.
+
+        Only the summary is checked. The RSS sub-count stays at DEBUG on
+        purpose: it is folded into the same total, so promoting it would
+        report the same items twice.
+        """
+        import inspect
+        from core.app import PlexCacheApp
+
+        source = inspect.getsource(PlexCacheApp)
+        summary = [ln for ln in source.splitlines()
+                   if "watchlist items due to retention expiry" in ln
+                   and "retention_days" in ln]
+
+        assert summary, "expiry summary line not found"
+        assert "logging.info" in summary[0], f"still not INFO: {summary[0].strip()}"
+
+    def test_rss_subcount_stays_at_debug(self):
+        """Guard the deliberate asymmetry so it is not 'fixed' later."""
+        import inspect
+        from core.app import PlexCacheApp
+
+        source = inspect.getsource(PlexCacheApp)
+        sub = [ln for ln in source.splitlines()
+               if "RSS watchlist items due to retention expiry" in ln]
+
+        assert sub and "logging.debug" in sub[0]
+
+    def test_disabled_retention_reports_nothing_expiring(self):
+        """0 means nothing expires, so the list must be empty, not full."""
+        import inspect
+        from web.services.cache_service import CacheService
+
+        source = inspect.getsource(CacheService)
+        assert 'settings.get("watchlist_retention_days", 14)' not in source, (
+            "the expiring-soon list still invents a 14-day retention for users "
+            "who never set one"
+        )

--- a/tests/test_upgrade_backup_ordering.py
+++ b/tests/test_upgrade_backup_ordering.py
@@ -1,0 +1,116 @@
+"""An upgrade must never leave a cached file with no .plexcached backup.
+
+When Sonarr/Radarr replaces a cached file, PlexCache swaps the array backup:
+the old .plexcached is outdated, and a new one is copied from the new cache
+file. Doing the delete first means any failure on the copy (ENOSPC, a
+permission error, a disappearing source) ends with neither backup present, and
+PlexcachedRestorer has nothing to restore for that file.
+
+CacheService._handle_upgrade_plexcached() already created-then-deleted. These
+cover the same contract on the CLI path in PlexCacheApp.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _mod_name in ['plexapi', 'plexapi.server', 'plexapi.video', 'plexapi.myplex',
+                  'plexapi.exceptions', 'requests']:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = MagicMock()
+
+from conftest import create_test_file  # noqa: E402
+
+PLEXCACHED = ".plexcached"
+
+
+def _app(backup_upgraded=True, create_backups=True):
+    from core.app import PlexCacheApp
+
+    app = object.__new__(PlexCacheApp)
+    app.config_manager = MagicMock()
+    app.config_manager.cache.create_plexcached_backups = create_backups
+    app.config_manager.cache.backup_upgraded_files = backup_upgraded
+    return app
+
+
+@pytest.fixture
+def upgrade(tmp_path):
+    """An upgraded file: old backup on the array, new file on cache."""
+    array = tmp_path / "array" / "Movies"
+    cache = tmp_path / "cache" / "Movies"
+    array.mkdir(parents=True)
+    cache.mkdir(parents=True)
+
+    old_real = str(array / "Movie.1080p.mkv")
+    new_real = str(array / "Movie.2160p.mkv")
+    old_backup = old_real + PLEXCACHED
+    new_cache = str(cache / "Movie.2160p.mkv")
+
+    create_test_file(old_backup, size_bytes=2048)
+    create_test_file(new_cache, size_bytes=4096)
+
+    return {
+        "old_real": old_real, "new_real": new_real,
+        "old_backup": old_backup, "new_backup": new_real + PLEXCACHED,
+        "new_cache": new_cache,
+    }
+
+
+def _run(app, upgrade):
+    """Call the swap with path helpers pinned to the tmp tree."""
+    with patch("core.app.get_array_direct_path", side_effect=lambda p: p), \
+         patch("core.app.find_matching_plexcached", return_value=upgrade["old_backup"]), \
+         patch("core.app.create_dir_with_ownership"), \
+         patch("core.app.get_media_identity", return_value="movie"):
+        app._handle_upgrade_plexcached(
+            upgrade["old_real"], upgrade["new_real"], "1234", upgrade["new_cache"])
+
+
+class TestUpgradeBackupOrdering:
+
+    def test_swaps_the_backup_on_the_happy_path(self, upgrade):
+        _run(_app(), upgrade)
+
+        assert not os.path.exists(upgrade["old_backup"]), "outdated backup should go"
+        assert os.path.isfile(upgrade["new_backup"]), "replacement should exist"
+        assert os.path.getsize(upgrade["new_backup"]) == 4096
+
+    def test_failed_copy_keeps_the_old_backup(self, upgrade):
+        """The regression: a file must never end up with no backup at all."""
+        with patch("core.app.shutil.copy2", side_effect=OSError(28, "No space left on device")):
+            _run(_app(), upgrade)
+
+        assert os.path.isfile(upgrade["old_backup"]), (
+            "old backup was deleted even though its replacement could not be written, "
+            "leaving this file unrecoverable if the cache drive fails"
+        )
+        assert not os.path.exists(upgrade["new_backup"])
+
+    def test_size_mismatch_keeps_the_old_backup(self, upgrade):
+        """A short copy is discarded, so it must not count as a replacement."""
+        real_getsize = os.path.getsize
+
+        def truncated(path):
+            return 1 if path == upgrade["new_backup"] else real_getsize(path)
+
+        with patch("core.app.os.path.getsize", side_effect=truncated):
+            _run(_app(), upgrade)
+
+        assert os.path.isfile(upgrade["old_backup"])
+        assert not os.path.exists(upgrade["new_backup"]), "short copy should be removed"
+
+    def test_backup_upgraded_files_off_still_clears_the_stale_backup(self, upgrade):
+        """No replacement is wanted, so the outdated one is simply removed."""
+        _run(_app(backup_upgraded=False), upgrade)
+
+        assert not os.path.exists(upgrade["old_backup"])
+        assert not os.path.exists(upgrade["new_backup"])
+
+    def test_backups_disabled_touches_nothing(self, upgrade):
+        _run(_app(create_backups=False), upgrade)
+
+        assert os.path.isfile(upgrade["old_backup"])
+        assert not os.path.exists(upgrade["new_backup"])

--- a/tests/test_wizard_settings_ranges.py
+++ b/tests/test_wizard_settings_ranges.py
@@ -1,0 +1,73 @@
+"""The setup wizard must be able to represent values the engine treats as valid.
+
+Two retention settings use 0 as a documented "disabled" sentinel:
+
+* ``cache_retention_hours`` 0 means no move-back delay
+* ``watchlist_retention_days`` 0 means never expire (``core/config.py:160``)
+
+If the wizard's input declares ``min="1"``, a user who deliberately set 0 cannot
+be shown their own value, and re-running setup silently raises it. The same trap
+exists in the template expression: ``{{ x or 12 }}`` renders 12 for a stored 0,
+because 0 is falsy in Jinja, so these fields must use the ``default()`` filter,
+which only fires on undefined.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+WEB = pathlib.Path(__file__).resolve().parent.parent / "web"
+WIZARD = WEB / "templates" / "setup" / "step5.html"
+CACHE_SETTINGS = WEB / "templates" / "settings" / "cache.html"
+
+# Settings whose 0 is meaningful rather than "unset".
+ZERO_IS_VALID = ["cache_retention_hours", "watchlist_retention_days"]
+
+
+def _input_tag(template: pathlib.Path, name: str) -> str:
+    match = re.search(
+        r'<input[^>]*?name="%s"[^>]*?>' % re.escape(name),
+        template.read_text(encoding="utf-8"),
+        re.S,
+    )
+    assert match, f"no input named {name} in {template.name}"
+    return match.group(0)
+
+
+@pytest.mark.parametrize("setting", ZERO_IS_VALID)
+@pytest.mark.parametrize("template", [WIZARD, CACHE_SETTINGS], ids=["wizard", "settings"])
+def test_zero_is_reachable(template, setting):
+    """The input accepts 0, so a disabled setting can round-trip."""
+    tag = _input_tag(template, setting)
+    minimum = re.search(r'min="([^"]*)"', tag)
+
+    assert minimum is not None, f"{setting} in {template.name} declares no min"
+    assert float(minimum.group(1)) == 0, (
+        f"{setting} in {template.name} has min={minimum.group(1)}, "
+        f"so a stored 0 cannot be displayed"
+    )
+
+
+@pytest.mark.parametrize("setting", ZERO_IS_VALID)
+@pytest.mark.parametrize("template", [WIZARD, CACHE_SETTINGS], ids=["wizard", "settings"])
+def test_value_expression_does_not_swallow_zero(template, setting):
+    """`{{ x or N }}` renders N for a stored 0. Use `default(N)` instead."""
+    tag = _input_tag(template, setting)
+    value = re.search(r'value="\{\{(.*?)\}\}"', tag, re.S)
+
+    assert value is not None, f"{setting} in {template.name} has no value expression"
+    assert not re.search(r"\bor\s+[\d.]+", value.group(1)), (
+        f"{setting} in {template.name} uses `or` as its fallback, which "
+        f"replaces a stored 0. Use the default() filter."
+    )
+
+
+def test_cache_retention_range_agrees_across_templates():
+    """Both surfaces offer the same ceiling, so neither truncates the other."""
+    def bounds(template):
+        tag = _input_tag(template, "cache_retention_hours")
+        return (re.search(r'min="([^"]*)"', tag).group(1),
+                re.search(r'max="([^"]*)"', tag).group(1))
+
+    assert bounds(WIZARD) == bounds(CACHE_SETTINGS)

--- a/web/models/settings.py
+++ b/web/models/settings.py
@@ -3,6 +3,10 @@
 from typing import Optional, List
 from pydantic import BaseModel, Field
 
+# Defaults come from core's dataclass rather than repeated literals: the engine
+# reads CacheConfig, so anything hardcoded here can disagree with what runs.
+from core.config import CacheConfig
+
 
 class PathMappingModel(BaseModel):
     """Single path mapping configuration"""
@@ -34,13 +38,13 @@ class CacheSettingsModel(BaseModel):
     watched_move: bool = True
     remote_watchlist_toggle: bool = False
     remote_watchlist_rss_url: str = ""
-    cache_retention_hours: int = 12
-    watchlist_retention_days: float = 14.0
-    ondeck_retention_days: float = 0
-    cache_limit: str = "250GB"
-    cache_eviction_mode: str = "smart"
-    cache_eviction_threshold_percent: int = 90
-    eviction_min_priority: int = 60
+    cache_retention_hours: int = CacheConfig.cache_retention_hours
+    watchlist_retention_days: float = CacheConfig.watchlist_retention_days
+    ondeck_retention_days: float = CacheConfig.ondeck_retention_days
+    cache_limit: str = CacheConfig.cache_limit
+    cache_eviction_mode: str = CacheConfig.cache_eviction_mode
+    cache_eviction_threshold_percent: int = CacheConfig.cache_eviction_threshold_percent
+    eviction_min_priority: int = CacheConfig.eviction_min_priority
 
 
 class NotificationSettingsModel(BaseModel):

--- a/web/routers/settings.py
+++ b/web/routers/settings.py
@@ -950,6 +950,23 @@ def save_cache_settings(request: Request, form_data: ImmutableMultiDict = Depend
     success = settings_service.save_cache_settings(settings_dict)
 
     if success:
+        # Eviction sizes itself as a percentage of Cache Limit, so with no limit
+        # set it is fully configured and will never evict anything. Saved rather
+        # than refused — setting the two in either order is reasonable — but said
+        # now, on the page, instead of only in the log on the next run.
+        saved = settings_service.get_cache_settings()
+        inert_eviction = (saved.get("cache_eviction_mode", "none") != "none"
+                          and not str(saved.get("cache_limit", "")).strip())
+        if inert_eviction:
+            return templates.TemplateResponse(
+                request,
+                "partials/alert.html",
+                {
+                    "type": "warning",
+                    "message": ("Saved, but cache eviction has nothing to measure: "
+                                "set a Cache Limit, or nothing will ever be evicted.")
+                }
+            )
         return templates.TemplateResponse(
             request,
             "partials/alert.html",

--- a/web/routers/settings.py
+++ b/web/routers/settings.py
@@ -337,16 +337,31 @@ def save_user_settings(request: Request, form_data: ImmutableMultiDict = Depends
             try:
                 user["days_to_monitor"] = int(ondeck_days_str)
             except ValueError:
+                # Dropping the override falls back to the global default, which
+                # looks identical to never having set one. Say so.
                 user.pop("days_to_monitor", None)
+                logger.warning(
+                    "Per-user Days to Monitor for '%s' could not be read as a whole "
+                    "number ('%s'); using the global default for that user.",
+                    title, ondeck_days_str
+                )
         else:
             user.pop("days_to_monitor", None)
 
         watchlist_days_str = form_data.get(f"watchlist_days_{title}", "").strip()
         if watchlist_days_str:
             try:
-                user["watchlist_retention_days"] = int(watchlist_days_str)
+                # float, not int: the global is a float and the input offers
+                # step="0.5", so int() rejected every half-day value the form
+                # invites (core/config.py casts the per-user value with float()).
+                user["watchlist_retention_days"] = float(watchlist_days_str)
             except ValueError:
                 user.pop("watchlist_retention_days", None)
+                logger.warning(
+                    "Per-user Watchlist Retention for '%s' could not be read as a "
+                    "number ('%s'); using the global default for that user.",
+                    title, watchlist_days_str
+                )
         else:
             user.pop("watchlist_retention_days", None)
 

--- a/web/routers/setup.py
+++ b/web/routers/setup.py
@@ -138,7 +138,9 @@ def setup_wizard(request: Request, step: int = 1):
         context["days_to_monitor"] = settings.get("days_to_monitor", 183)
         context["watchlist_toggle"] = settings.get("watchlist_toggle", True)
         context["watchlist_episodes"] = settings.get("watchlist_episodes", 3)
-        context["watchlist_retention_days"] = settings.get("watchlist_retention_days", 14)
+        # Default 0 to match core (CacheConfig.watchlist_retention_days), so the
+        # wizard cannot re-enable expiry for someone who deliberately disabled it.
+        context["watchlist_retention_days"] = settings.get("watchlist_retention_days", 0)
         context["cache_retention_hours"] = settings.get("cache_retention_hours", 12)
         context["watched_move"] = settings.get("watched_move", True)
         context["cache_limit"] = settings.get("cache_limit", "")

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -11,6 +11,9 @@ from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass
 
 from web.config import DATA_DIR, CONFIG_DIR, SETTINGS_FILE
+# Defaults come from core's dataclass rather than repeated literals: the engine
+# reads CacheConfig, so anything hardcoded here can disagree with what runs.
+from core.config import CacheConfig
 from core.system_utils import get_disk_usage, detect_zfs, get_array_direct_path, parse_size_bytes, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary
 from core.file_operations import get_media_identity, find_matching_plexcached, save_json_atomically, SUBTITLE_EXTENSIONS, is_video_file
 
@@ -901,7 +904,7 @@ class CacheService:
         eviction_over_threshold = False
         eviction_over_by = 0
         eviction_over_by_display = None
-        eviction_mode = settings.get("cache_eviction_mode", "none")
+        eviction_mode = settings.get("cache_eviction_mode", CacheConfig.cache_eviction_mode)
         cache_limit_bytes = 0
 
         if eviction_mode != "none" and disk_total > 0:
@@ -929,7 +932,7 @@ class CacheService:
                     logging.warning(f"Could not parse cache_limit '{cache_limit_setting}': {e}")
 
             if cache_limit_bytes > 0:
-                eviction_threshold_percent = settings.get("cache_eviction_threshold_percent", 95)
+                eviction_threshold_percent = settings.get("cache_eviction_threshold_percent", CacheConfig.cache_eviction_threshold_percent)
                 eviction_threshold_bytes = int(cache_limit_bytes * eviction_threshold_percent / 100)
 
                 if disk_used > eviction_threshold_bytes:
@@ -1006,7 +1009,7 @@ class CacheService:
         configured_limit_percent = 0
         if cache_limit_bytes > 0:
             configured_limit_display = format_bytes(cache_limit_bytes)
-            eviction_threshold_percent = settings.get("cache_eviction_threshold_percent", 95)
+            eviction_threshold_percent = settings.get("cache_eviction_threshold_percent", CacheConfig.cache_eviction_threshold_percent)
             eviction_threshold_bytes_val = int(cache_limit_bytes * eviction_threshold_percent / 100)
             eviction_threshold_display = format_bytes(eviction_threshold_bytes_val)
             if disk_total > 0:
@@ -1246,7 +1249,7 @@ class CacheService:
                 plexcache_quota_warning = True
 
         # Calculate eviction threshold (for visual display)
-        eviction_threshold_setting = settings.get("cache_eviction_threshold_percent", 95)
+        eviction_threshold_setting = settings.get("cache_eviction_threshold_percent", CacheConfig.cache_eviction_threshold_percent)
         eviction_threshold_bytes = 0
         eviction_threshold_display = None
         eviction_threshold_percent_of_drive = 0
@@ -1281,7 +1284,7 @@ class CacheService:
             cache_bar_status = "safe"
 
         # Configuration
-        eviction_mode = settings.get("cache_eviction_mode", "none")
+        eviction_mode = settings.get("cache_eviction_mode", CacheConfig.cache_eviction_mode)
         # Use display path (host path) for UI, not container path
         display_cache_dir = self._get_cache_dir_for_display(settings)
         config = {
@@ -1292,8 +1295,8 @@ class CacheService:
             "number_episodes": settings.get("number_episodes", 5),
             "eviction_mode": eviction_mode,
             "eviction_enabled": eviction_mode != "none",
-            "eviction_threshold_percent": settings.get("cache_eviction_threshold_percent", 95),
-            "eviction_min_priority": settings.get("eviction_min_priority", 60)
+            "eviction_threshold_percent": settings.get("cache_eviction_threshold_percent", CacheConfig.cache_eviction_threshold_percent),
+            "eviction_min_priority": settings.get("eviction_min_priority", CacheConfig.eviction_min_priority)
         }
 
         return {
@@ -1536,9 +1539,9 @@ class CacheService:
         }
 
         # Eviction settings and current status
-        eviction_mode = settings.get("cache_eviction_mode", "none")
-        eviction_threshold = settings.get("cache_eviction_threshold_percent", 95)
-        eviction_min_priority = settings.get("eviction_min_priority", 60)
+        eviction_mode = settings.get("cache_eviction_mode", CacheConfig.cache_eviction_mode)
+        eviction_threshold = settings.get("cache_eviction_threshold_percent", CacheConfig.cache_eviction_threshold_percent)
+        eviction_min_priority = settings.get("eviction_min_priority", CacheConfig.eviction_min_priority)
 
         # Calculate current drive usage (use path_mappings cache_path for consistency)
         cache_dir = self._get_cache_dir(settings)

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -1168,9 +1168,14 @@ class CacheService:
 
         # Files nearing watchlist expiration
         # Show files within N days of expiring OR already expired (still on cache)
-        watchlist_retention_days = settings.get("watchlist_retention_days", 14)
+        # 0 means retention is off, so nothing expires. Without this the
+        # subtraction below made days_remaining negative for every watchlist
+        # file and listed them all as already expired. The default matches
+        # core rather than inventing 14 days for someone who never set it.
+        watchlist_retention_days = settings.get(
+            "watchlist_retention_days", CacheConfig.watchlist_retention_days)
         expiring_soon = []
-        for f in all_files:
+        for f in all_files if watchlist_retention_days else []:
             if f.is_watchlist:
                 # Find watchlist entry to get watchlisted_at date
                 for plex_path, info in watchlist.items():

--- a/web/services/cache_service.py
+++ b/web/services/cache_service.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from web.config import DATA_DIR, CONFIG_DIR, SETTINGS_FILE
 # Defaults come from core's dataclass rather than repeated literals: the engine
 # reads CacheConfig, so anything hardcoded here can disagree with what runs.
-from core.config import CacheConfig
+from core.config import CacheConfig, PlexConfig
 from core.system_utils import get_disk_usage, detect_zfs, get_array_direct_path, parse_size_bytes, format_bytes, translate_container_to_host_path, translate_host_to_container_path, remove_from_exclude_file, remove_from_timestamps_file, create_dir_with_ownership, cleanup_empty_parent_folders, resolve_cache_boundary
 from core.file_operations import get_media_identity, find_matching_plexcached, save_json_atomically, SUBTITLE_EXTENSIONS, is_video_file
 
@@ -305,11 +305,22 @@ class CacheService:
 
         Factors:
         - Base: 50
-        - Source type: +20 for ondeck, +0 for watchlist
+        Mirrors CachePriorityManager.calculate_priority() in
+        core/file_operations.py, which is what eviction actually uses. Keep the
+        two in step: the number shown here is the number a user calibrates
+        eviction_min_priority against.
+
+        - Base: 50
+        - Source type: +15 for ondeck, +0 for watchlist
         - User count: +5 per user (max +15)
-        - Cache recency: +15 (<24h), +10 (<72h), +5 (<7d), 0 (older)
-        - Watchlist/OnDeck age: +10 (<7d), 0 (7-60d), -10 (>60d)
-        - Episode position: +15 (current), +10 (next few), 0 (far ahead)
+        - Cache recency: +5 (<24h), +3 (<72h), 0 (older)
+        - Watchlist age: +10 (<7d), 0 (7-60d), -10 (>60d)
+        - OnDeck staleness: +5 (<7d), 0 (7-14d), -5 (14-30d), -10 (>30d)
+        - Episode position: +15 (current), +10 (within half the prefetch
+          window), 0 (further ahead)
+
+        Pinned files are not scored here — the caller assigns them 100, matching
+        the short-circuit at the top of the engine's scorer.
         """
         score = 50
         now = datetime.now()
@@ -399,19 +410,57 @@ class CacheService:
                 pass
 
         # Factor 5: Episode position (for TV)
+        #
+        # Mirrors CachePriorityManager.calculate_priority(): the current OnDeck
+        # episode scores +15, and episodes within half the prefetch window score
+        # +10. Anything further ahead gets nothing. This previously awarded +10
+        # to every episode with a number, computing half_prefetch and never
+        # comparing against it, so the report read up to 10 points higher than
+        # the score eviction actually used.
         if ondeck_info and "episode_info" in ondeck_info:
             ep_info = ondeck_info["episode_info"]
             if ep_info.get("is_current_ondeck"):
                 score += 15
             else:
-                # Check episodes ahead
-                number_episodes = settings.get("number_episodes", 5)
-                half_prefetch = number_episodes // 2
-                # If it's a prefetched episode, give partial bonus
-                if ep_info.get("episode"):
-                    score += 10
+                ondeck_pos = self._earliest_ondeck_position(
+                    ondeck, ep_info.get("show"))
+                if ondeck_pos:
+                    from core.media_grouping import episodes_ahead_of
+                    ahead = episodes_ahead_of(
+                        ep_info.get("season"), ep_info.get("episode"),
+                        ondeck_pos[0], ondeck_pos[1])
+                    number_episodes = settings.get(
+                        "number_episodes", PlexConfig.number_episodes)
+                    if ahead == 0:
+                        score += 15
+                    elif 0 < ahead <= max(1, number_episodes // 2):
+                        score += 10
 
         return max(0, min(100, score))
+
+    @staticmethod
+    def _earliest_ondeck_position(ondeck: Dict, show: Optional[str]):
+        """Earliest (season, episode) any user is OnDeck for this show.
+
+        Same rule as OnDeckTracker.get_earliest_ondeck_position(): the user
+        furthest behind sets the reference point, so an episode is only
+        "prefetched" relative to whoever has watched least.
+        """
+        if not show:
+            return None
+        positions = []
+        for info in ondeck.values():
+            if not isinstance(info, dict):
+                continue
+            other = info.get("episode_info") or {}
+            if not other.get("is_current_ondeck"):
+                continue
+            if (other.get("show") or "").lower() != show.lower():
+                continue
+            season, episode = other.get("season"), other.get("episode")
+            if isinstance(season, int) and isinstance(episode, int):
+                positions.append((season, episode))
+        return min(positions) if positions else None
 
     def calculate_priority_with_breakdown(
         self,
@@ -1418,7 +1467,23 @@ class CacheService:
         lines.append("SUMMARY BY TIER:")
         lines.append(f"  High priority (90-100):   {len(high)} files")
         lines.append(f"  Medium priority (70-89):  {len(medium)} files")
-        lines.append(f"  Low priority (0-69):      {len(low)} files (eviction candidates)")
+        lines.append(f"  Low priority (0-69):      {len(low)} files")
+
+        # What would actually be evicted is a different question from the tiers
+        # above, which are only a distribution. It depends on the configured
+        # threshold and on eviction being on at all. Captioning the 0-69 tier as
+        # "eviction candidates" named protected files: at the default threshold
+        # of 60, everything scoring 60-69 is kept.
+        report_settings = self._load_settings()
+        mode = report_settings.get("cache_eviction_mode", CacheConfig.cache_eviction_mode)
+        if mode == "none":
+            lines.append("  Eviction is off, so nothing is a candidate")
+        else:
+            floor = report_settings.get(
+                "eviction_min_priority", CacheConfig.eviction_min_priority)
+            candidates = [f for f in files if f.priority_score < floor]
+            lines.append(
+                f"  Below the eviction threshold ({floor}): {len(candidates)} files")
         lines.append("")
 
         # Summary by source

--- a/web/services/maintenance_service.py
+++ b/web/services/maintenance_service.py
@@ -746,8 +746,12 @@ class MaintenanceService:
         # Find stale exclude entries (in exclude but not on cache)
         results.stale_exclude_entries = sorted(list(exclude_files - cache_files))
 
-        # Check if stale entries are actually media upgrades (Sonarr/Radarr file swaps)
-        if results.stale_exclude_entries:
+        # Check if stale entries are actually media upgrades (Sonarr/Radarr file swaps).
+        # Honours auto_transfer_upgrades: the audit runs on a schedule, so this is
+        # the automatic behaviour the setting names. The manual endpoint
+        # (POST /api/check-upgrades) stays available either way, since clicking it
+        # is an explicit request rather than something happening on its own.
+        if results.stale_exclude_entries and self._load_settings().get('auto_transfer_upgrades', True):
             try:
                 from web.services.cache_service import get_cache_service
                 cache_service = get_cache_service()

--- a/web/services/pinned_service.py
+++ b/web/services/pinned_service.py
@@ -316,6 +316,7 @@ class PinnedService:
         return compute_budget_state(
             cache_limit_bytes=parsed["cache_limit_bytes"],
             min_free_space_bytes=parsed["min_free_space_bytes"],
+            plexcache_quota_bytes=parsed["plexcache_quota_bytes"],
             current_pinned_bytes=current,
             additional_bytes=additional,
         )

--- a/web/services/settings_service.py
+++ b/web/services/settings_service.py
@@ -10,6 +10,9 @@ from typing import Dict, Any, Optional, List
 from dataclasses import dataclass, field, asdict
 
 from web.config import DATA_DIR, SETTINGS_FILE, IS_DOCKER
+# Defaults come from core's dataclass rather than repeated literals: the engine
+# reads CacheConfig, so anything hardcoded here can disagree with what runs.
+from core.config import CacheConfig
 from web.dependencies import get_system_detector
 
 logger = logging.getLogger(__name__)
@@ -49,11 +52,11 @@ class CacheSettings:
     watched_move: bool = True
     cache_retention_hours: int = 12
     cache_drive_size: str = ""  # Manual override for drive size (for ZFS)
-    cache_limit: str = "250GB"
+    cache_limit: str = CacheConfig.cache_limit
     min_free_space: str = ""
     plexcache_quota: str = ""
     cache_eviction_mode: str = "none"
-    cache_eviction_threshold_percent: int = 95
+    cache_eviction_threshold_percent: int = CacheConfig.cache_eviction_threshold_percent
     eviction_min_priority: int = 60
     remote_watchlist_toggle: bool = False
     remote_watchlist_rss_url: str = ""
@@ -604,11 +607,11 @@ class SettingsService:
             "cache_associated_files": raw.get("cache_associated_files", "subtitles"),
             "cache_retention_hours": raw.get("cache_retention_hours", 12),
             "cache_drive_size": raw.get("cache_drive_size", ""),
-            "cache_limit": raw.get("cache_limit", "250GB"),
+            "cache_limit": raw.get("cache_limit", CacheConfig.cache_limit),
             "min_free_space": raw.get("min_free_space", ""),
             "plexcache_quota": raw.get("plexcache_quota", ""),
             "cache_eviction_mode": raw.get("cache_eviction_mode", "none"),
-            "cache_eviction_threshold_percent": raw.get("cache_eviction_threshold_percent", 95),
+            "cache_eviction_threshold_percent": raw.get("cache_eviction_threshold_percent", CacheConfig.cache_eviction_threshold_percent),
             "eviction_min_priority": raw.get("eviction_min_priority", 60),
             "pinned_preferred_resolution": raw.get("pinned_preferred_resolution", "highest"),
             "remote_watchlist_toggle": raw.get("remote_watchlist_toggle", False),

--- a/web/settings_search_index.py
+++ b/web/settings_search_index.py
@@ -153,7 +153,7 @@ _INDEX: List[Dict[str, Any]] = [
     {
         "tab": "cache", "setting_id": "days_to_monitor",
         "label": "Days to Monitor",
-        "hint": "How far back to check OnDeck for recently watched items.",
+        "hint": "How far back to check OnDeck for recently watched items. A per-user override also sets that user's OnDeck retention threshold.",
         "section": "Cache", "subsection": "Content Discovery",
         "icon": "clock", "tone": "tone-ok",
         "keywords": ["days", "monitor", "ondeck", "window", "lookback", "history", "range"],
@@ -221,7 +221,7 @@ _INDEX: List[Dict[str, Any]] = [
     {
         "tab": "cache", "setting_id": "ondeck_retention_days",
         "label": "OnDeck Retention (days)",
-        "hint": "Auto-expire OnDeck items after this period (0 = never).",
+        "hint": "Stop holding an item on cache once every user who has it OnDeck has had it this long (0 = never). Moves it back later, does not delete it.",
         "section": "Cache", "subsection": "Retention",
         "icon": "clock", "tone": "tone-info",
         "keywords": ["ondeck", "retention", "expire", "days", "cleanup"],
@@ -278,8 +278,8 @@ _INDEX: List[Dict[str, Any]] = [
     },
     {
         "tab": "cache", "setting_id": "hardlinked_files",
-        "label": "Hardlinked Files Handling",
-        "hint": "Files with multiple hardlinks (e.g., seeding torrents). Skip preserves links; Move copies.",
+        "label": "Files you are seeding",
+        "hint": "Files shared with your torrent client. Leave them on the array until seeding finishes, or cache them anyway.",
         "section": "Cache", "subsection": "File Handling",
         "icon": "link", "tone": "tone-warn",
         "keywords": ["hardlink", "hardlinks", "torrent", "seeding", "links"],

--- a/web/settings_search_index.py
+++ b/web/settings_search_index.py
@@ -533,7 +533,7 @@ _INDEX: List[Dict[str, Any]] = [
     {
         "tab": "logging", "setting_id": "keep_error_logs_days",
         "label": "Error Log Retention (days)",
-        "hint": "Days to keep logs containing warnings/errors (0 = disabled).",
+        "hint": "Days to keep logs containing errors (0 = disabled).",
         "section": "Logging", "subsection": "Log Retention",
         "icon": "archive", "tone": "tone-warn",
         "keywords": ["error", "warning", "retention", "days", "keep"],

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -376,8 +376,12 @@
                         <label for="eviction_min_priority">Minimum Priority to Keep</label>
                         <input type="number" id="eviction_min_priority" name="eviction_min_priority"
                                class="input-narrow"
+                               {# Floor only applies while smart eviction is on. A leftover
+                                  low value with eviction off is harmless, and enforcing it
+                                  there would block saving this whole tab over nothing. #}
                                value="{{ settings.eviction_min_priority | default(60) }}"
-                               min="{{ priority_range.watchlist_min }}" max="100">
+                               min="{{ priority_range.watchlist_min if settings.cache_eviction_mode == 'smart' else 0 }}"
+                               max="100">
                         <div class="form-hint">Only evict files below this priority (OnDeck ~{{ priority_range.ondeck_min }}-{{ priority_range.ondeck_max }}, Watchlist ~{{ priority_range.watchlist_min }}-{{ priority_range.watchlist_max }}). Below {{ priority_range.watchlist_min }} nothing is ever evicted, since no file scores lower than that.</div>
                     </div>
                 </div>

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -300,7 +300,7 @@
                     <label for="cache_limit">Cache Limit</label>
                     <input type="text" id="cache_limit" name="cache_limit"
                            class="input-medium"
-                           value="{{ settings.cache_limit | default('250GB') }}"
+                           value="{{ settings.cache_limit | default('') }}"
                            placeholder="500GB or 75%"
                            oninput="updateCacheCalculations()">
                     <div class="form-hint">Maximum <strong>total drive usage</strong> before PlexCache stops caching (e.g., 500GB or 75%). Includes all files on the drive, not just PlexCache-managed files. Leave empty for no cap.</div>

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -376,8 +376,9 @@
                         <label for="eviction_min_priority">Minimum Priority to Keep</label>
                         <input type="number" id="eviction_min_priority" name="eviction_min_priority"
                                class="input-narrow"
-                               value="{{ settings.eviction_min_priority | default(60) }}" min="0" max="100">
-                        <div class="form-hint">Only evict files below this priority (OnDeck ~{{ priority_range.ondeck_min }}-{{ priority_range.ondeck_max }}, Watchlist ~{{ priority_range.watchlist_min }}-{{ priority_range.watchlist_max }})</div>
+                               value="{{ settings.eviction_min_priority | default(60) }}"
+                               min="{{ priority_range.watchlist_min }}" max="100">
+                        <div class="form-hint">Only evict files below this priority (OnDeck ~{{ priority_range.ondeck_min }}-{{ priority_range.ondeck_max }}, Watchlist ~{{ priority_range.watchlist_min }}-{{ priority_range.watchlist_max }}). Below {{ priority_range.watchlist_min }} nothing is ever evicted, since no file scores lower than that.</div>
                     </div>
                 </div>
             </div>

--- a/web/templates/settings/cache.html
+++ b/web/templates/settings/cache.html
@@ -28,7 +28,9 @@
                     <input type="number" id="days_to_monitor" name="days_to_monitor"
                            class="input-narrow"
                            value="{{ settings.days_to_monitor | default(7) }}" min="1" max="999">
-                    <div class="form-hint">How far back to check OnDeck for recently watched items</div>
+                    <div class="form-hint">How far back to check OnDeck for recently watched items.
+                        Per-user overrides on the Users tab also set that user's OnDeck
+                        retention threshold, so one value drives both.</div>
                 </div>
             </div>
 
@@ -112,6 +114,11 @@
                 Retention
             </h3>
 
+            <div class="form-hint" style="margin-bottom: 1rem;">
+                These clocks only advance while PlexCache is running. Nothing expires between
+                runs, so the finest useful resolution is your schedule interval.
+            </div>
+
             <div class="grid grid-2">
                 <div class="form-group" data-setting-id="cache_retention_hours">
                     <label for="cache_retention_hours">Cache Retention (hours)</label>
@@ -125,8 +132,10 @@
                     <label for="watchlist_retention_days">Watchlist Retention (days)</label>
                     <input type="number" id="watchlist_retention_days" name="watchlist_retention_days"
                            class="input-narrow"
-                           value="{{ '%g' % (settings.watchlist_retention_days | default(14) | float) }}" min="0" max="365" step="0.5">
-                    <div class="form-hint">Auto-expire watchlist items after this period (0 = never expire)</div>
+                           value="{{ '%g' % (settings.watchlist_retention_days | default(0) | float) }}" min="0" max="365" step="0.5">
+                    <div class="form-hint">Stop caching a watchlist item this long after it was added in Plex,
+                        even if it is still on the watchlist. Counted from the Plex date, not from when
+                        PlexCache cached it (0 = never).</div>
                 </div>
             </div>
 
@@ -136,7 +145,9 @@
                     <input type="number" id="ondeck_retention_days" name="ondeck_retention_days"
                            class="input-narrow"
                            value="{{ '%g' % (settings.ondeck_retention_days | default(0) | float) }}" min="0" max="365" step="0.5">
-                    <div class="form-hint">Auto-expire OnDeck items after this period (0 = never expire)</div>
+                    <div class="form-hint">Stop holding an item on cache once <em>every</em> user who has it
+                        OnDeck has had it there this long, counted from when PlexCache first saw it.
+                        It is then moved back to the array on a later run, not deleted (0 = never).</div>
                 </div>
             </div>
 
@@ -161,7 +172,12 @@
                            {% if settings.create_plexcached_backups | default(true) %}checked{% endif %}>
                     <span>Create .plexcached Backup Files</span>
                 </label>
-                <div class="form-hint">When moving files to cache, keep backup on array (allows recovery if cache fails)</div>
+                <div class="form-hint">Caching renames the array file to <code>.plexcached</code> instead of
+                    deleting it, so a cached file can be recovered if the cache drive fails.
+                    <strong>Off means the array copy is deleted, not renamed, and cached files cannot be
+                    recovered.</strong> Only turn this off if you run Mover Tuning on a
+                    <code>cache:prefer</code> share. Files you are seeding do not need it off &mdash;
+                    PlexCache already handles those separately.</div>
             </div>
 
             <div class="form-group" data-setting-id="cleanup_empty_folders">
@@ -204,12 +220,13 @@
             </div>
 
             <div class="form-group" data-setting-id="hardlinked_files">
-                <label for="hardlinked_files">Hardlinked Files Handling</label>
+                <label for="hardlinked_files">Files you are seeding</label>
                 <select id="hardlinked_files" name="hardlinked_files">
-                    <option value="skip" {% if settings.hardlinked_files == 'skip' or not settings.hardlinked_files %}selected{% endif %}>Skip (preserve for seeders)</option>
-                    <option value="move" {% if settings.hardlinked_files == 'move' %}selected{% endif %}>Move (break hardlinks)</option>
+                    <option value="skip" {% if settings.hardlinked_files == 'skip' or not settings.hardlinked_files %}selected{% endif %}>Leave them on the array until seeding finishes</option>
+                    <option value="move" {% if settings.hardlinked_files == 'move' %}selected{% endif %}>Cache them anyway — the seed keeps working</option>
                 </select>
-                <div class="form-hint">Files with multiple hardlinks (e.g., seeding torrents). Skip preserves links, Move copies the file.</div>
+                <div class="form-hint">Some files are shared between your library and your torrent client.
+                    PlexCache detects these automatically; this only chooses what to do with them.</div>
             </div>
 
             <div class="form-group" data-setting-id="check_hardlinks_on_restore">

--- a/web/templates/settings/logging.html
+++ b/web/templates/settings/logging.html
@@ -28,7 +28,7 @@
                     <input type="number" id="keep_error_logs_days" name="keep_error_logs_days"
                            class="input-narrow"
                            value="{{ settings.keep_error_logs_days | default(7) }}" min="0" max="365">
-                    <div class="form-hint">Days to keep logs containing warnings/errors (0 = disabled)</div>
+                    <div class="form-hint">Days to keep logs containing errors (0 = disabled)</div>
                 </div>
             </div>
 
@@ -36,7 +36,7 @@
                 <strong>How it works:</strong>
                 <ul style="margin: 0.5rem 0 0 1.5rem; padding: 0;">
                     <li><strong>Max Log Files:</strong> PlexCache creates a new log file each run. Older logs are automatically deleted when this limit is reached.</li>
-                    <li><strong>Error Log Retention:</strong> Logs containing WARNING or ERROR messages are preserved in <code>logs/errors/</code> for longer-term debugging.</li>
+                    <li><strong>Error Log Retention:</strong> Logs containing ERROR or CRITICAL messages are preserved in <code>logs/errors/</code> for longer-term debugging. Runs that only logged warnings are not kept.</li>
                 </ul>
             </div>
 

--- a/web/templates/settings/partials/users_table.html
+++ b/web/templates/settings/partials/users_table.html
@@ -57,13 +57,13 @@
                                value="{{ user.days_to_monitor if user.days_to_monitor is defined and user.days_to_monitor is not none else '' }}"
                                placeholder="&#8212;"
                                min="1" max="9999" class="monitor-input"
-                               title="OnDeck days to monitor (blank = global default: {{ settings.days_to_monitor|default(183) }} days)">
+                               title="OnDeck days to monitor, and this user's OnDeck retention threshold — one value drives both (blank = global default: {{ settings.days_to_monitor|default(183) }} days)">
                     </span>
                     <span class="monitor-col">
                         <input type="number" name="watchlist_days_{{ user.title }}"
                                value="{{ user.watchlist_retention_days if user.watchlist_retention_days is defined and user.watchlist_retention_days is not none else '' }}"
                                placeholder="&#8212;"
-                               min="0" max="9999" class="monitor-input"
+                               min="0" max="9999" step="0.5" class="monitor-input"
                                title="Watchlist retention days (blank = global default: {{ settings.watchlist_retention_days|default(0) or 'disabled' }})">
                     </span>
                 </span>

--- a/web/templates/setup/step5.html
+++ b/web/templates/setup/step5.html
@@ -75,7 +75,7 @@
                     <label for="watchlist_retention_days">Watchlist Retention</label>
                     <div class="input-with-suffix">
                         <input type="number" id="watchlist_retention_days" name="watchlist_retention_days"
-                               value="{{ watchlist_retention_days or 14 }}"
+                               value="{{ watchlist_retention_days | default(0) }}"
                                min="0" max="365"
                                placeholder="14">
                         <span class="input-suffix">days</span>
@@ -106,12 +106,12 @@
                     <label for="cache_retention_hours">Cache Retention</label>
                     <div class="input-with-suffix">
                         <input type="number" id="cache_retention_hours" name="cache_retention_hours"
-                               value="{{ cache_retention_hours or 12 }}"
-                               min="1" max="168"
+                               value="{{ cache_retention_hours | default(12) }}"
+                               min="0" max="720"
                                placeholder="12">
                         <span class="input-suffix">hours</span>
                     </div>
-                    <p class="help-text">How long to keep files on cache after they leave OnDeck (recommended: 12)</p>
+                    <p class="help-text">After PlexCache caches a file, wait this long before it can be moved back to the array (recommended: 12)</p>
                 </div>
 
                 <div class="form-group" style="margin-bottom: 0;">


### PR DESCRIPTION
An audit of every user-facing setting, and the fixes that came out of it. The theme throughout: a
setting should describe what the engine actually does, and enforce what it claims to enforce.

Nothing is removed and no key is renamed, so existing settings files keep working unchanged. Two
behaviour changes are called out at the bottom.

## Defaults that disagreed with the engine

The web layer repeated engine defaults as literals and several had drifted. `cache_limit` defaulted
to `250GB` where core defaults to no limit, so saving any unrelated field on the Cache tab wrote a
cap the user never chose. That also armed eviction, since `cache_limit` gates both eviction entry
points. `cache_eviction_threshold_percent` defaulted to 95 across seven web sites against core's 90,
so the cache page drew the eviction line above where the engine acts.

These now read from `core.config.CacheConfig`, so the declared default and the one that runs are the
same value. A test asserts parity per key.

## Sizes that were rejected without being enforced

`_parse_cache_limit` rejected two formats `parse_size_bytes` accepts: `3.7T` had no short-suffix
branch, and `7.5%` used `int()` on the percent. Because 0 means "no limit" to every consumer, both
silently removed the cap while the settings page previewed it as enforced. Byte quantities now
delegate to `parse_size_bytes`, percentages parse as float, and the function takes the key name so
its warnings say which of the three size settings was mistyped rather than always blaming
`cache_limit`.

## Things that quietly did nothing

- Eviction sizes itself as a percentage of `cache_limit`, so with no limit set a fully configured
  eviction mode evicted nothing, forever, and both entry points returned in silence. Now warns once
  per run, and saving that combination answers with a warning rather than a plain success.
- Priority scores start around 45, not 0, so a threshold below that keeps every file and smart
  eviction never selects anything. Config load now says so. The value is reported, not corrected:
  raising a stored threshold would start deleting cache copies on the next run.
- Caching renames the original to `.plexcached`. Off Unraid, without a merged view of the media and
  cache paths, Plex stops finding the file unless `use_symlinks` is on, and that defaults off. Added
  a startup advisory, worded as advice because mergerfs setups are fine and cannot be told apart from
  configuration alone.
- Watchlist retention expiry logged at DEBUG while the OnDeck equivalent logged at INFO, so the only
  sign was media quietly not being cached.

## Copy that described something else

- Error log retention preserves runs that logged ERROR or CRITICAL. Five surfaces said warnings were
  preserved too, so someone chasing a warning-only failure was sent to an empty folder.
- Cache retention counts from when PlexCache copied the file, since `cached_at` is written once. The
  wizard described it as counting from when a file leaves OnDeck, capped it at 168 hours where the
  settings page allows 720, and floored it at 1 where 0 means no delay.
- OnDeck retention said "auto-expire", which reads as deletion. It stops holding the file on cache; a
  later run moves it back to the array.
- The hard-linked files option was labelled "Move (break hardlinks)". That mode caches the file and
  the seed survives on the remaining link, so the label said the opposite of what happens.
- A per-user Days to Monitor override also sets that user's OnDeck retention threshold. One field,
  two clocks, two epochs, and nothing said so.
- Nothing stated that retention clocks only advance while PlexCache runs, which bounds how fine any
  of these values can usefully be.

## Correctness

- **Upgrade swaps could leave a file with no backup.** `_handle_upgrade_plexcached()` removed the
  outdated `.plexcached` before copying its replacement, so any failure on the copy ended with
  neither present. Creates and size-verifies the new backup first, then removes the old one, and
  keeps the old one with a warning when the copy fails. The web path already worked this way.
- **The Priority Report disagreed with the engine.** The report's scorer computed half the prefetch
  window into a local and never compared against it, so every episode with a number scored +10 where
  the engine gives it only inside that window. A far-ahead episode read up to 10 points higher than
  the score eviction acted on, which is the number `eviction_min_priority` is calibrated against. The
  distance arithmetic is now shared by both. The tier summary also captioned "Low priority (0-69)" as
  eviction candidates, which named protected files: at the default threshold of 60, everything
  scoring 60-69 is kept.
- **Per-user watchlist retention rejected half-days.** The input offers `step="0.5"` and core casts
  the stored value with `float()`, but the save handler parsed with `int()`, so every half-day value
  raised and the override was dropped back to the global default in silence.
- **The setup wizard could re-enable a disabled setting.** Zero is falsy in Jinja, so
  `{{ watchlist_retention_days or 14 }}` rendered a deliberate 0 as 14 and wrote it back as enabled.
- **Log retention counted the wrong things.** `RotatingFileHandler` borrowed `max_log_files` as its
  `backupCount`, so one oversized run could occupy the whole log budget, and its `.log.N` backups
  matched no cleanup glob. `plexcache_log_latest.log` is a pointer, not a run, but matched the glob,
  so "keep 24" kept 23.

## Two behaviour changes worth noting

**Pin budget.** `parse_budget_from_settings()` computed `plexcache_quota_bytes` and
`compute_budget_state()` was never given it, so an install configured with only a quota had no pin
guard at all. Both ceilings now apply and the tighter wins, matching how `_apply_cache_limit()`
reduces its constraints. Installs that set only `cache_limit` keep exactly the guard they had, and
there is a test for that. Anyone using a quota alone will now see pins blocked past it.

**`auto_transfer_upgrades`.** The setting gated the CLI path only; the scheduled audit called
`check_for_upgrades()` unconditionally, so switching it off changed when tracking was transferred
rather than whether it was. The audit now honours it. `POST /api/check-upgrades` stays ungated, since
clicking it is an explicit request.

## Testing

1. On a fresh install, open Settings > Cache. Cache Limit should be empty rather than pre-filled, and
   the eviction threshold should read 90%.
2. Enter `3.7T` as a Cache Limit and run. The log should show the parsed limit rather than treating
   it as unset. Same for `7.5%`.
3. Set eviction to Smart with no Cache Limit and save. The page should answer with a warning, and a
   run should log that eviction has nothing to measure.
4. Set a per-user Watchlist Retention of `0.5` on the Users tab and save. It should persist rather
   than reverting to the global default.
5. In the setup wizard, set Watchlist Retention to 0 and continue. Re-open the step and it should
   still read 0.
6. With `plexcache_quota` set and no `cache_limit`, pin items past the quota. Pinning should be
   blocked rather than silently allowed.
7. Compare the Priority Report against a run's eviction decisions on a show with prefetched episodes
   further ahead than half your prefetch count. The scores should agree.
